### PR TITLE
Object: Put class into namespace OpenOrienteering

### DIFF
--- a/packaging/translations.cpp
+++ b/packaging/translations.cpp
@@ -11,4 +11,4 @@ QT_TRANSLATE_NOOP("OpenOrienteering", "Orienteering map");
 QT_TRANSLATE_NOOP("OpenOrienteering", "Software for drawing orienteering maps");
 
 //: For the moment, we use this existing translation instead of the previous one.
-QT_TRANSLATE_NOOP("AboutDialog", "A free software for drawing orienteering maps");
+QT_TRANSLATE_NOOP("OpenOrienteering::AboutDialog", "A free software for drawing orienteering maps");

--- a/src/core/autosave.cpp
+++ b/src/core/autosave.cpp
@@ -28,6 +28,9 @@
 
 #include "settings.h"
 
+
+namespace OpenOrienteering {
+
 AutosavePrivate::AutosavePrivate(Autosave& document)
 : document(document)
 , autosave_needed(false)
@@ -135,3 +138,6 @@ bool Autosave::autosaveNeeded() const
 {
 	return autosave_controller->autosaveNeeded();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/autosave.h
+++ b/src/core/autosave.h
@@ -24,6 +24,8 @@
 
 class QString;
 
+namespace OpenOrienteering {
+
 class AutosavePrivate;
 
 
@@ -83,5 +85,8 @@ private:
 	
 	QScopedPointer<AutosavePrivate> autosave_controller;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/autosave_p.h
+++ b/src/core/autosave_p.h
@@ -25,6 +25,9 @@
 
 #include "autosave.h"
 
+namespace OpenOrienteering {
+
+
 /**
  * @brief AutosavePrivate is a helper class of Autosave.
  * 
@@ -59,5 +62,8 @@ private:
 	bool autosave_needed;
 	int  autosave_interval;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/crs_template.cpp
+++ b/src/core/crs_template.cpp
@@ -28,6 +28,8 @@
 #include <QLatin1Char>
 
 
+namespace OpenOrienteering {
+
 // From crs_template_implementation.h/.cpp
 namespace CRSTemplates
 {
@@ -133,3 +135,6 @@ void CRSTemplateRegistry::add(std::unique_ptr<const CRSTemplate> temp)
 {
 	templates->push_back(std::move(temp));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/crs_template.h
+++ b/src/core/crs_template.h
@@ -29,6 +29,8 @@
 
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Georeferencing;
 
 
@@ -316,5 +318,8 @@ const CRSTemplateRegistry::TemplateList& CRSTemplateRegistry::list() const
 {
 	return *templates;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/crs_template_implementation.cpp
+++ b/src/core/crs_template_implementation.cpp
@@ -40,8 +40,9 @@
 #include "gui/widgets/crs_param_widgets.h"
 
 
-namespace CRSTemplates
-{
+namespace OpenOrienteering {
+
+namespace CRSTemplates {
 
 CRSTemplateRegistry::TemplateList defaultList()
 {
@@ -51,22 +52,22 @@ CRSTemplateRegistry::TemplateList defaultList()
 	// UTM
 	auto temp = std::make_unique<CRSTemplate>(
 	  QString::fromLatin1("UTM"),
-	  Georeferencing::tr("UTM", "UTM coordinate reference system"),
-	  Georeferencing::tr("UTM coordinates"),
+	  ::OpenOrienteering::Georeferencing::tr("UTM", "UTM coordinate reference system"),
+	  ::OpenOrienteering::Georeferencing::tr("UTM coordinates"),
 	  QString::fromLatin1("+proj=utm +datum=WGS84 +zone=%1"),
 	  CRSTemplate::ParameterList {
-	    new UTMZoneParameter(QString::fromLatin1("zone"), Georeferencing::tr("UTM Zone (number north/south)"))
+	    new UTMZoneParameter(QString::fromLatin1("zone"), ::OpenOrienteering::Georeferencing::tr("UTM Zone (number north/south)"))
 	  } );
 	templates.push_back(std::move(temp));
 	
 	// Gauss-Krueger
 	temp = std::make_unique<CRSTemplate>(
 	  QString::fromLatin1("Gauss-Krueger, datum: Potsdam"),
-	  Georeferencing::tr("Gauss-Krueger, datum: Potsdam", "Gauss-Krueger coordinate reference system"),
-	  Georeferencing::tr("Gauss-Krueger coordinates"),
+	  ::OpenOrienteering::Georeferencing::tr("Gauss-Krueger, datum: Potsdam", "Gauss-Krueger coordinate reference system"),
+	  ::OpenOrienteering::Georeferencing::tr("Gauss-Krueger coordinates"),
 	  QString::fromLatin1("+proj=tmerc +lat_0=0 +lon_0=%1 +k=1.000000 +x_0=%2 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs"),
 	  CRSTemplate::ParameterList {
-	    new IntRangeParameter(QString::fromLatin1("zone"), Georeferencing::tr("Zone number (1 to 119)", "Zone number for Gauss-Krueger coordinates"),
+	    new IntRangeParameter(QString::fromLatin1("zone"), ::OpenOrienteering::Georeferencing::tr("Zone number (1 to 119)", "Zone number for Gauss-Krueger coordinates"),
 	                          1, 119, { {3, 0}, {1000000, 500000} })
 	  } );
 	templates.push_back(std::move(temp));
@@ -74,23 +75,23 @@ CRSTemplateRegistry::TemplateList defaultList()
 	// EPSG
 	temp = std::make_unique<CRSTemplate>(
 	  QString::fromLatin1("EPSG"),
-	  Georeferencing::tr("by EPSG code", "as in: The CRS is specified by EPSG code"),
+	  ::OpenOrienteering::Georeferencing::tr("by EPSG code", "as in: The CRS is specified by EPSG code"),
 	  //: Don't translate @code@. It is placeholder.
-	  Georeferencing::tr("EPSG @code@ coordinates"),
+	  ::OpenOrienteering::Georeferencing::tr("EPSG @code@ coordinates"),
 	  QString::fromLatin1("+init=epsg:%1"),
 	  CRSTemplate::ParameterList {
-	    new IntRangeParameter(QString::fromLatin1("code"), Georeferencing::tr("EPSG code"), 1000, 99999)
+	    new IntRangeParameter(QString::fromLatin1("code"), ::OpenOrienteering::Georeferencing::tr("EPSG code"), 1000, 99999)
 	  } );
 	templates.push_back(std::move(temp));
 	
 	// Custom
 	temp = std::make_unique<CRSTemplate>(
 	  QString::fromLatin1("PROJ.4"), // Don't change this ID.
-	  Georeferencing::tr("Custom PROJ.4", "PROJ.4 specification"),
-	  Georeferencing::tr("Local coordinates"),
+	  ::OpenOrienteering::Georeferencing::tr("Custom PROJ.4", "PROJ.4 specification"),
+	  ::OpenOrienteering::Georeferencing::tr("Local coordinates"),
 	  QString::fromLatin1("%1"),
 	  CRSTemplate::ParameterList {
-	    new FullSpecParameter(QString::fromLatin1("spec"), Georeferencing::tr("Specification", "PROJ.4 specification"))
+	    new FullSpecParameter(QString::fromLatin1("spec"), ::OpenOrienteering::Georeferencing::tr("Specification", "PROJ.4 specification"))
 	  } );
 	templates.push_back(std::move(temp));
 	
@@ -288,5 +289,6 @@ void IntRangeParameter::setValue(QWidget* edit_widget, const QString& value)
 }
 
 
+}  // namespace CRSTemplates
 
-} // namespace CRSTemplates
+}  // namespace OpenOrienteering

--- a/src/core/crs_template_implementation.h
+++ b/src/core/crs_template_implementation.h
@@ -33,14 +33,15 @@
 
 class QWidget;
 
+namespace OpenOrienteering {
+
 class LatLon;
 
 
 /**
  * This namespace collects CRS template implementations
  */
-namespace CRSTemplates
-{
+namespace CRSTemplates {
 
 /**
  * Creates and returns a list of known CRS Templates.
@@ -126,6 +127,9 @@ private:
 	const OutputList outputs;
 };
 
-} // namespace CRSTemplates
+
+}  // namespace CRSTemplates
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -78,6 +78,8 @@ namespace literal
 	static const QLatin1String geographic_coordinates("Geographic coordinates");
 }
 
+
+
 namespace
 {
 	/** Helper for PROJ.4 initialization.
@@ -136,8 +138,13 @@ namespace
 	                         " +no_defs"
 	    },
 	};
-}
+	
+	
+}  // namespace
 
+
+
+namespace OpenOrienteering {
 
 //### Georeferencing ###
 
@@ -851,6 +858,11 @@ QDebug operator<<(QDebug dbg, const Georeferencing &georef)
 	return dbg.space();
 }
 
+
+}  // namespace OpenOrienteering
+
+
+
 #if defined(Q_OS_ANDROID)
 
 QScopedPointer<QTemporaryDir> temp_dir;  // removed upon destruction
@@ -903,4 +915,4 @@ extern "C"
 	}
 }
 
-#endif
+#endif  // defined(Q_OS_ANDROID)

--- a/src/core/georeferencing.h
+++ b/src/core/georeferencing.h
@@ -39,6 +39,7 @@ class QXmlStreamWriter;
 
 typedef void* projPJ;
 
+namespace OpenOrienteering {
 
 
 #if defined(Q_OS_ANDROID)
@@ -687,5 +688,8 @@ LatLon Georeferencing::getGeographicRefPoint() const
 {
 	return geographic_ref_point;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/image_transparency_fixup.h
+++ b/src/core/image_transparency_fixup.h
@@ -22,6 +22,9 @@
 
 #include <QImage>
 
+namespace OpenOrienteering {
+
+
 /**
  * ImageTransparencyFixup repairs a particular issue with composing
  * transparent pixels.
@@ -85,5 +88,8 @@ protected:
 	QRgb* dest;
 	QRgb* dest_end;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/latlon.cpp
+++ b/src/core/latlon.cpp
@@ -22,6 +22,8 @@
 #include <QDebug>
 
 
+namespace OpenOrienteering {
+
 QDebug operator<<(QDebug dbg, const LatLon& lat_lon)
 {
 	dbg.space() 
@@ -29,3 +31,6 @@ QDebug operator<<(QDebug dbg, const LatLon& lat_lon)
 	  << lat_lon.latitude() << lat_lon.longitude();
 	return dbg.space();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/latlon.h
+++ b/src/core/latlon.h
@@ -25,6 +25,7 @@
 
 class QDebug;
 
+namespace OpenOrienteering {
 
 /**
  * @brief Specifies geographic location by latitude and longitude.
@@ -130,5 +131,8 @@ constexpr bool LatLon::operator!=(const LatLon& rhs) const
 {
 	return !(*this == rhs);
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -78,13 +78,15 @@
 // IWYU pragma: no_forward_declare QRectF
 
 
+namespace OpenOrienteering {
+
 QPointer<QTranslator> map_symbol_translator{};
 
 
-// ### Misc ###
 
-namespace
-{
+namespace {
+
+// ### Misc ###
 
 /** A record of information about the mapping of a color in a source MapColorSet
  *  to a color in a destination MapColorSet.
@@ -136,7 +138,8 @@ void showMessageBox(QWidget* parent, const QString& title, const QString& headli
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
-} // namespace
+
+}  // namespace
 
 
 
@@ -2669,3 +2672,6 @@ void Map::undoCleanChanged(bool is_clean)
 		setHasUnsavedChanges(true);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -51,6 +51,8 @@ class QTranslator;
 class QWidget;
 // IWYU pragma: no_forward_declare QRectF
 
+namespace OpenOrienteering {
+
 class CombinedSymbol;
 class FileFormat;
 class Georeferencing;
@@ -89,7 +91,6 @@ Q_OBJECT
 friend class MapTest;
 friend class MapRenderables;
 friend class OCAD8FileImport;
-friend class XMLFileImport;
 friend class NativeFileImport;
 friend class NativeFileExport;
 friend class XMLFileImporter;
@@ -1560,12 +1561,9 @@ private:
 	static CombinedSymbol* covering_combined_line;
 };
 
-Q_DECLARE_METATYPE(const Map*)
 
 
 // ### Map inline code ###
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(Map::ImportMode)
 
 inline
 int Map::getNumColors() const
@@ -1885,5 +1883,14 @@ TextSymbol* Map::getUndefinedText()
 {
 	return undefined_text;
 }
+
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_METATYPE(const OpenOrienteering::Map*)
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::Map::ImportMode)
+
 
 #endif

--- a/src/core/map_color.cpp
+++ b/src/core/map_color.cpp
@@ -30,8 +30,10 @@
 #include <QLatin1String>
 
 
+namespace OpenOrienteering {
+
 MapColor::MapColor()
-: name(QCoreApplication::translate("Map", "New color")),
+: name(QCoreApplication::translate("OpenOrienteering::Map", "New color")),
   priority(Undefined),
   opacity(1.0f),
   q_color(Qt::black),
@@ -45,7 +47,7 @@ MapColor::MapColor()
 }
 
 MapColor::MapColor(int priority)
-: name(QCoreApplication::translate("Map", "New color")),
+: name(QCoreApplication::translate("OpenOrienteering::Map", "New color")),
   priority(priority),
   opacity(1.0f),
   q_color(Qt::black),
@@ -74,7 +76,7 @@ MapColor::MapColor(int priority)
 			break;
 		case Registration:
 			Q_ASSERT(isBlack());
-			name = QCoreApplication::translate("MapColor", "Registration black (all printed colors)");
+			name = QCoreApplication::translate("OpenOrienteering::MapColor", "Registration black (all printed colors)");
 			break;
 		default:
 			; // no change
@@ -359,3 +361,6 @@ MapColorRgb MapColor::rgbFromSpotColors() const
 	}
 	return rgb;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/map_color.h
+++ b/src/core/map_color.h
@@ -31,6 +31,8 @@
 #include <QRgb>
 #include <QString>
 
+namespace OpenOrienteering {
+
 class MapColor;
 
 /**
@@ -439,9 +441,6 @@ protected:
 	SpotColorComponents components;
 };
 
-// Allow explicit use of MapColor pointers in QVariant
-Q_DECLARE_METATYPE(const MapColor*)
-
 /** Returns true if both MapColor are equal in all components. */
 bool operator==(const MapColor& lhs, const MapColor& rhs);
 
@@ -835,6 +834,13 @@ QColor colorWithOpacity(const MapColor& c)
 {
 	return colorWithOpacity(static_cast<const QColor&>(c), c.getOpacity());
 }
+
+
+}  // namespace OpenOrienteering
+
+
+// Allow explicit use of MapColor pointers in QVariant
+Q_DECLARE_METATYPE(const OpenOrienteering::MapColor*)
 
 
 #endif

--- a/src/core/map_coord.cpp
+++ b/src/core/map_coord.cpp
@@ -34,6 +34,8 @@
 #include "util/xml_stream_util.h"
 
 
+namespace OpenOrienteering {
+
 static_assert(sizeof(qint32) <= sizeof(int), 
               "MapCoord::setX/Y uses qRound() returning int, xp/yp is of type qint32");
 
@@ -177,11 +179,11 @@ void ensureBoundsForQint32(qint64 x64, qint64 y64)
 		 || y64 < std::numeric_limits<qint32>::min()
 		 || y64 > std::numeric_limits<qint32>::max() )
 	{
-		throw std::range_error(QT_TRANSLATE_NOOP("MapCoord", "Coordinates are out-of-bounds."));
+		throw std::range_error(QT_TRANSLATE_NOOP("OpenOrienteering::MapCoord", "Coordinates are out-of-bounds."));
 	}
 }
 
-} // namespace
+}  // namespace
 
 
 
@@ -456,3 +458,6 @@ MapCoord::MapCoord(QStringRef& text)
 	++i;
 	text = text.mid(i, len-i);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/map_coord.h
+++ b/src/core/map_coord.h
@@ -35,6 +35,7 @@
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
 
 #ifndef NO_NATIVE_FILE_FORMAT
 	
@@ -83,7 +84,7 @@ struct LegacyMapCoord
  */
 class MapCoord
 {
-	Q_DECLARE_TR_FUNCTIONS(MapCoord)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::MapCoord)
 	
 public:
 	/**
@@ -662,9 +663,6 @@ typedef std::vector<MapCoordF> MapCoordVectorF;
 
 // ### MapCoord inline code ###
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(MapCoord::Flags)
-
-
 constexpr bool MapCoord::BoundsOffset::isZero() const
 {
 	return x==0 && y==0;
@@ -1184,6 +1182,11 @@ constexpr const MapCoordF operator/(const MapCoordF& lhs, qreal divisor)
 	return static_cast<const MapCoordF>(static_cast<const QPointF&>(lhs) / divisor);
 }
 
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::MapCoord::Flags)
 
 
 #endif

--- a/src/core/map_grid.cpp
+++ b/src/core/map_grid.cpp
@@ -31,6 +31,11 @@
 #include "util/util.h"
 #include "util/xml_stream_util.h"
 
+
+namespace OpenOrienteering {
+
+namespace {
+
 struct ProcessLine
 {
 	QPainter* painter;
@@ -41,6 +46,10 @@ void ProcessLine::processLine(QPointF a, QPointF b)
 {
 	painter->drawLine(a, b);
 }
+
+
+}  // namespace
+
 
 // ### MapGrid ###
 
@@ -215,3 +224,6 @@ bool operator!=(const MapGrid& lhs, const MapGrid& rhs)
 {
 	return !(lhs == rhs);
 }
+
+
+}  // namespace

--- a/src/core/map_grid.h
+++ b/src/core/map_grid.h
@@ -30,6 +30,8 @@ class QRectF;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapCoordF;
 
@@ -161,5 +163,7 @@ bool operator==(const MapGrid& lhs, const MapGrid& rhs);
  */
 bool operator!=(const MapGrid& lhs, const MapGrid& rhs);
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/map_part.cpp
+++ b/src/core/map_part.cpp
@@ -51,6 +51,9 @@ namespace literal
 }
 
 
+
+namespace OpenOrienteering {
+
 MapPart::MapPart(const QString& name, Map* map)
 : name(name)
 , map(map)
@@ -367,3 +370,6 @@ void MapPart::applyOnAllObjects(const std::function<void (Object*, MapPart*, int
 		operation(objects[i], this, int(i));
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -37,6 +37,8 @@ class QXmlStreamReader;
 class QXmlStreamWriter;
 // IWYU pragma: no_forward_declare QRectF
 
+namespace OpenOrienteering {
+
 class Map;
 class MapCoordF;
 class Object;
@@ -275,5 +277,7 @@ const Object* MapPart::getObject(int i) const
 	return objects[std::size_t(i)];
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -90,6 +90,8 @@ namespace literal
 
 
 
+namespace OpenOrienteering {
+
 // #### MapPrinterPageFormat ###
 
 MapPrinterPageFormat::MapPrinterPageFormat(QSizeF page_rect_size, qreal margin, qreal overlap) 
@@ -341,6 +343,7 @@ void MapPrinterConfig::save(QXmlStreamWriter& xml, const QLatin1String& element_
 #ifdef QT_PRINTSUPPORT_LIB
 
 // ### MapPrinter ###
+
 const QPrinterInfo* MapPrinter::pdfTarget()
 {
 	static QPrinterInfo pdf_target; // TODO: set name and features?
@@ -484,7 +487,7 @@ std::unique_ptr<QPrinter> MapPrinter::makePrinter() const
 		PlatformPrinterProperties::restore(printer.get(), native_data);
 	}
 	
-	printer->setDocName(tr("- Map -"));
+	printer->setDocName(::OpenOrienteering::MapPrinter::tr("- Map -"));
 	printer->setFullPage(true);
 	if (page_format.paper_size == QPrinter::Custom)
 	{
@@ -1235,8 +1238,8 @@ bool MapPrinter::printMap(QPrinter* printer)
 	int step = 0;
 	auto num_steps = v_page_pos.size() * h_page_pos.size();
 	const QString message_template( (options.mode == MapPrinterOptions::Separations) ?
-	  tr("Processing separations of page %1...") :
-	  tr("Processing page %1...") );
+	  ::OpenOrienteering::MapPrinter::tr("Processing separations of page %1...") :
+	  ::OpenOrienteering::MapPrinter::tr("Processing page %1...") );
 	auto message = message_template.arg(1);
 	emit printProgress(0, message);
 	
@@ -1286,16 +1289,16 @@ bool MapPrinter::printMap(QPrinter* printer)
 	
 	if (cancel_print_map)
 	{
-		emit printProgress(100, tr("Canceled"));
+		emit printProgress(100, ::OpenOrienteering::MapPrinter::tr("Canceled"));
 	}
 	else if (!painter.isActive())
 	{
-		emit printProgress(100, tr("Error"));
+		emit printProgress(100, ::OpenOrienteering::MapPrinter::tr("Error"));
 		return false;
 	}
 	else
 	{
-		emit printProgress(100, tr("Finished"));
+		emit printProgress(100, ::OpenOrienteering::MapPrinter::tr("Finished"));
 	}
 	return true;
 }
@@ -1304,5 +1307,8 @@ void MapPrinter::cancelPrintMap()
 {
 	cancel_print_map = true;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif // QT_PRINTSUPPORT_LIB

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -47,8 +47,11 @@ class QPrinter;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapView;
+
 
 /** The MapPrinterPageFormat is a complete description of page properties. */
 class MapPrinterPageFormat
@@ -546,5 +549,8 @@ bool MapPrinter::separationsModeSelected() const
 }
 
 #endif
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -60,6 +60,10 @@ namespace literal
 	static const QLatin1String template_string("template");
 }
 
+
+
+namespace OpenOrienteering {
+
 const double MapView::zoom_in_limit = 512;
 const double MapView::zoom_out_limit = 1 / 16.0;
 
@@ -537,3 +541,6 @@ void MapView::setTemplateLoadingBlocked(bool blocked)
 {
 	template_loading_blocked = blocked;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/map_view.h
+++ b/src/core/map_view.h
@@ -40,6 +40,8 @@ class QRectF;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class Template;
 
@@ -443,8 +445,6 @@ bool operator!=(TemplateVisibility lhs, TemplateVisibility rhs)
 
 // ### MapView inline code ###
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(MapView::ChangeFlags)
-
 inline
 MapCoord MapView::viewToMap(QPointF point) const
 {
@@ -529,6 +529,11 @@ bool MapView::isOverprintingSimulationEnabled() const
 	return overprinting_simulation_enabled;
 }
 
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::MapView::ChangeFlags)
 
 
 #endif

--- a/src/core/objects/boolean_tool.cpp
+++ b/src/core/objects/boolean_tool.cpp
@@ -51,8 +51,7 @@
  * This is a C++ language issue, not a Qt issue.
  * Cf. https://bugreports.qt-project.org/browse/QTBUG-34912
  */
-namespace ClipperLib
-{
+namespace ClipperLib {
 
 /**
  * Implements qHash for ClipperLib::IntPoint.
@@ -65,7 +64,12 @@ uint qHash(const IntPoint& point, uint seed)
 	return ::qHash(tmp, seed); // must use :: namespace to prevent endless recursion
 }
 
-} // namespace ClipperLib
+
+}  // namespace ClipperLib
+
+
+
+namespace OpenOrienteering {
 
 /**
  * Removes flags from the coordinate to be able to use it in the reconstruction.
@@ -1077,3 +1081,5 @@ bool BooleanTool::checkSegmentMatch(
 	return found;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/core/objects/boolean_tool.h
+++ b/src/core/objects/boolean_tool.h
@@ -29,6 +29,8 @@
 
 #include <clipper.hpp>
 
+namespace OpenOrienteering {
+
 class CombinedUndoStep;
 class Map;
 class PathCoord;
@@ -264,5 +266,8 @@ private:
 	const Operation op;
 	Map* const map;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -64,6 +64,8 @@ namespace literal
 
 
 
+namespace OpenOrienteering {
+
 // ### Object implementation ###
 
 Object::Object(Object::Type type, const Symbol* symbol)
@@ -404,7 +406,7 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 	Object::Type object_type = object_element.attribute<Object::Type>(literal::type);
 	Object* object = Object::getObjectForType(object_type);
 	if (!object)
-		throw FileFormatException(ImportExport::tr("Error while loading an object of type %1.").arg(object_type));
+		throw FileFormatException(::OpenOrienteering::ImportExport::tr("Error while loading an object of type %1.").arg(object_type));
 	
 	object->map = map;
 	
@@ -436,7 +438,7 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 				break;
 			default:
 				throw FileFormatException(
-				  ImportExport::tr("Unable to find symbol for object at %1:%2.").
+				  ::OpenOrienteering::ImportExport::tr("Unable to find symbol for object at %1:%2.").
 				  arg(xml.lineNumber()).arg(xml.columnNumber()) );
 		}
 	}
@@ -448,7 +450,7 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 		if (point_symbol && point_symbol->isRotatable())
 			point->setRotation(object_element.attribute<float>(literal::rotation));
 		else if (!point_symbol)
-			throw FileFormatException(ImportExport::tr("Point object with undefined or wrong symbol at %1:%2.").arg(xml.lineNumber()).arg(xml.columnNumber()));
+			throw FileFormatException(::OpenOrienteering::ImportExport::tr("Point object with undefined or wrong symbol at %1:%2.").arg(xml.lineNumber()).arg(xml.columnNumber()));
 	}
 	else if (object_type == Text)
 	{
@@ -468,7 +470,7 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 			}
 			catch (FileFormatException& e)
 			{
-				throw FileFormatException(ImportExport::tr("Error while loading an object of type %1 at %2:%3: %4").
+				throw FileFormatException(::OpenOrienteering::ImportExport::tr("Error while loading an object of type %1 at %2:%3: %4").
 				  arg(object_type).arg(xml.lineNumber()).arg(xml.columnNumber()).arg(e.message()));
 			}
 		}
@@ -488,7 +490,7 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 					}
 					catch (std::range_error& e)
 					{
-						throw FileFormatException(MapCoord::tr(e.what()));
+						throw FileFormatException(::OpenOrienteering::MapCoord::tr(e.what()));
 					}
 				}
 				else
@@ -842,6 +844,7 @@ void Object::includeControlPointsRect(QRectF& rect) const
 			rectInclude(rect, text_handle);
 	}
 }
+
 
 
 // ### PathPart ###
@@ -3256,3 +3259,6 @@ bool PointObject::intersectsBox(const QRectF& box) const
 {
 	return box.contains(QPointF(coords.front()));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -44,6 +44,8 @@ class QXmlStreamReader;
 class QXmlStreamWriter;
 // IWYU pragma: no_forward_declare QRectF
 
+namespace OpenOrienteering {
+
 class Map;
 class PointObject;
 class PathObject;
@@ -1283,6 +1285,7 @@ constexpr ObjectPathCoord::operator bool() const
 	return bool { object };
 }
 
+}  // namespace OpenOrienteering
 
 
 #endif

--- a/src/core/objects/object_mover.cpp
+++ b/src/core/objects/object_mover.cpp
@@ -30,6 +30,8 @@
 #include "core/symbols/text_symbol.h"
 
 
+namespace OpenOrienteering {
+
 ObjectMover::ObjectMover(Map* map, const MapCoordF& start_pos)
  : start_position(start_pos), prev_drag_x(0), prev_drag_y(0), constraints_calculated(true)
 {
@@ -296,3 +298,4 @@ void ObjectMover::calculateConstraints()
 }
 
 
+}  // namespace OpenOrienteering

--- a/src/core/objects/object_mover.h
+++ b/src/core/objects/object_mover.h
@@ -30,10 +30,13 @@
 
 #include "core/map_coord.h"
 
+namespace OpenOrienteering {
+
 class Map;
 class Object;
 class PathObject;
 class TextObject;
+
 using SelectionInfoVector = std::vector<std::pair<int, Object*>>;
 
 
@@ -107,5 +110,7 @@ private:
 	bool constraints_calculated;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/objects/object_operations.h
+++ b/src/core/objects/object_operations.h
@@ -26,6 +26,8 @@
 #include "core/objects/object.h"
 #include "core/symbols/symbol.h"
 
+namespace OpenOrienteering {
+
 /**
  * Object conditions and processors,
  * see methods Map::applyOnAllObjects() and MapPart::applyOnAllObjects()
@@ -122,5 +124,8 @@ namespace ObjectOp
 		}
 	};
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -101,6 +101,8 @@ QString keyToString(const QString &key)
 
 
 
+namespace OpenOrienteering {
+
 // ### ObjectQuery::LogicalOperands ###
 
 ObjectQuery::LogicalOperands::LogicalOperands(const ObjectQuery::LogicalOperands& proto)
@@ -773,3 +775,6 @@ QString ObjectQueryParser::tokenAsString() const
 		string = fromEscaped(string);
 	return string;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -28,6 +28,8 @@
 #include <QString>
 #include <QStringRef>
 
+namespace OpenOrienteering {
+
 class Object;
 class Symbol;
 
@@ -46,7 +48,7 @@ class Symbol;
  */
 class ObjectQuery
 {
-	Q_DECLARE_TR_FUNCTIONS(ObjectQuery)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::ObjectQuery)
 	
 public:
 	enum Operator {
@@ -204,8 +206,6 @@ private:
 	
 };
 
-Q_DECLARE_METATYPE(ObjectQuery::Operator)
-
 bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs);
 
 bool operator!=(const ObjectQuery& lhs, const ObjectQuery& rhs);
@@ -275,5 +275,11 @@ bool operator!=(const ObjectQuery::StringOperands& lhs, const ObjectQuery::Strin
 {
 	return !(lhs==rhs);
 }
+
+
+}  // namespace OpenOrienteering
+
+Q_DECLARE_METATYPE(OpenOrienteering::ObjectQuery::Operator)
+
 
 #endif

--- a/src/core/objects/symbol_rule_set.cpp
+++ b/src/core/objects/symbol_rule_set.cpp
@@ -42,6 +42,8 @@
 #include "undo/undo_manager.h"
 
 
+namespace OpenOrienteering {
+
 // The SymbolRule member "query" may throw on copying.
 Q_STATIC_ASSERT(std::is_nothrow_constructible<SymbolRule>::value);
 Q_STATIC_ASSERT(std::is_nothrow_default_constructible<SymbolRule>::value);
@@ -411,3 +413,6 @@ void SymbolRuleSet::apply(Map& object_map, const Map& symbol_set, Options option
 	object_map.setSymbolsDirty();
 	object_map.undoManager().clear();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/objects/symbol_rule_set.h
+++ b/src/core/objects/symbol_rule_set.h
@@ -29,6 +29,8 @@
 
 class QTextStream;
 
+namespace OpenOrienteering {
+
 class Map;
 class Object;
 class Symbol;
@@ -190,7 +192,11 @@ public:
 	
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(SymbolRuleSet::Options)
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::SymbolRuleSet::Options)
 
 
 #endif // OPENORIENTEERING_SYMBOL_RULE_SET_H

--- a/src/core/objects/text_object.cpp
+++ b/src/core/objects/text_object.cpp
@@ -33,6 +33,9 @@
 
 // IWYU pragma: no_forward_declare QPointF
 
+
+namespace OpenOrienteering {
+
 // ### TextObjectPartInfo ###
 
 int TextObjectPartInfo::getIndex(double pos_x) const
@@ -510,3 +513,6 @@ void TextObject::prepareLineInfos() const
 		}
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/objects/text_object.h
+++ b/src/core/objects/text_object.h
@@ -39,6 +39,8 @@
 // IWYU pragma: no_forward_declare QRectF
 // IWYU pragma: no_forward_declare QTransform
 
+namespace OpenOrienteering {
+
 class Symbol;
 
 
@@ -381,5 +383,6 @@ const TextObjectLineInfo*TextObject::getLineInfo(int i) const
 }
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/path_coord.cpp
+++ b/src/core/path_coord.cpp
@@ -32,6 +32,8 @@
 #include "core/virtual_path.h"
 
 
+namespace OpenOrienteering {
+
 static_assert(std::is_nothrow_default_constructible<PathCoord>::value,
               "PathCoord must be nothrow default constructible.");
 static_assert(std::is_nothrow_copy_constructible<PathCoord>::value,
@@ -521,3 +523,6 @@ bool PathCoord::valueLessThanIndex(size_type value, const PathCoord& coord)
 {
 	return value < coord.index;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/path_coord.h
+++ b/src/core/path_coord.h
@@ -28,6 +28,8 @@
 
 #include "map_coord.h"
 
+namespace OpenOrienteering {
+
 class PathCoordVector;
 
 
@@ -285,5 +287,8 @@ SplitPathCoord SplitPathCoord::at(const PathCoordVector& path_coords, SplitPathC
 {
 	return at(length, begin(path_coords));
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/renderables/renderable.cpp
+++ b/src/core/renderables/renderable.cpp
@@ -45,6 +45,9 @@
 static_assert(false, "This file needs to be modified for correct printing on Android");
 #endif
 
+
+namespace OpenOrienteering {
+
 /* 
  * The macro MAPPER_OVERPRINTING_CORRECTION allows to select different
  * implementations of spot color overprinting simulation correction towards
@@ -730,3 +733,6 @@ bool PainterConfig::activate(QPainter* painter, const QPainterPath*& current_cli
 	
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/renderables/renderable.h
+++ b/src/core/renderables/renderable.h
@@ -37,9 +37,12 @@ class QPainter;
 class QPainterPath;
 // IWYU pragma: no_forward_declare QRectF
 
+namespace OpenOrienteering {
+
 class Map;
 class Object;
 class PainterConfig;
+
 
 /**
  * This class contains rendering configuration values.
@@ -373,8 +376,6 @@ private:
 
 // ### RenderConfig ###
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(RenderConfig::Options)
-
 inline
 bool RenderConfig::testFlag(const RenderConfig::Option flag) const
 {
@@ -475,6 +476,11 @@ bool MapRenderables::empty() const
 	return std::map<int, ObjectRenderablesMap>::empty();
 }
 
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::RenderConfig::Options)
 
 
 #endif

--- a/src/core/renderables/renderable_implementation.cpp
+++ b/src/core/renderables/renderable_implementation.cpp
@@ -85,7 +85,11 @@ inline void fixPenForPdf(QPen& pen, const QPainter& painter)
 #endif
 }
 
-}
+}  // namespace
+
+
+
+namespace OpenOrienteering {
 
 // ### DotRenderable ###
 
@@ -787,3 +791,6 @@ void TextFramingRenderable::render(QPainter& painter, const RenderConfig& config
 	TextRenderable::renderCommon(painter, config);
 	painter.restore();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/renderables/renderable_implementation.h
+++ b/src/core/renderables/renderable_implementation.h
@@ -33,6 +33,8 @@
 class QPainter;
 class QPointF;
 
+namespace OpenOrienteering {
+
 class AreaSymbol;
 class LineSymbol;
 class MapColor;
@@ -143,5 +145,6 @@ const QPainterPath* AreaRenderable::painterPath() const
 }
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/storage_location.cpp
+++ b/src/core/storage_location.cpp
@@ -39,6 +39,8 @@
 #include <QVector>
 
 
+namespace OpenOrienteering {
+
 namespace Android {
 
 /**
@@ -234,11 +236,15 @@ std::shared_ptr<const std::vector<StorageLocation>> buildLocationCache()
 	return locations;
 }
 
-} // namespace
+
+}  // namespace Android
+
+}  // namespace OpenOrienteering
 
 #endif
 
 
+namespace OpenOrienteering {
 
 // static
 std::shared_ptr<const std::vector<StorageLocation>> StorageLocation::knownLocations()
@@ -294,3 +300,5 @@ QString StorageLocation::fileHintTextTemplate(Hint hint)
 	Q_UNREACHABLE();
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/core/storage_location.h
+++ b/src/core/storage_location.h
@@ -29,6 +29,7 @@
 #include <QCoreApplication>
 #include <QString>
 
+namespace OpenOrienteering {
 
 // noexcept since Qt 5.5
 constexpr bool qstring_is_nothrow_copy_constructible = std::is_nothrow_copy_constructible<QString>::value;
@@ -40,7 +41,7 @@ constexpr bool qstring_is_nothrow_move_constructible = std::is_nothrow_move_cons
  */
 class StorageLocation
 {
-	Q_DECLARE_TR_FUNCTIONS(StorageLocation)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::StorageLocation)
 	
 public:
 	/** Various hints about locations. */
@@ -118,5 +119,8 @@ QString StorageLocation::hintText() const
 {
 	return fileHintTextTemplate(hint()).arg(path());
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_STORAGE_LOCATION_H

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -48,6 +48,8 @@ class QXmlStreamWriter;
 // IWYU pragma: no_forward_declare QXmlStreamReader
 
 
+namespace OpenOrienteering {
+
 // ### FillPattern ###
 
 AreaSymbol::FillPattern::FillPattern() noexcept
@@ -880,3 +882,6 @@ bool AreaSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensit
 		return lhs.equals(rhs, case_sensitivity);
 	});
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -38,6 +38,8 @@ class QRectF;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class AreaRenderable;
 class LineSymbol;
 class Map;
@@ -302,8 +304,6 @@ protected:
 
 
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(AreaSymbol::FillPattern::Options)
-
 inline
 bool AreaSymbol::FillPattern::rotatable() const
 {
@@ -315,6 +315,12 @@ AreaSymbol::FillPattern::Options AreaSymbol::FillPattern::clipping() const
 {
 	return flags & Option::AlternativeToClipping;
 }
+
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::AreaSymbol::FillPattern::Options)
 
 
 #endif

--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -41,6 +41,8 @@
 #include "core/symbols/symbol.h"
 
 
+namespace OpenOrienteering {
+
 CombinedSymbol::CombinedSymbol()
 : Symbol{Symbol::Combined}
 , private_parts{ false, false }
@@ -386,3 +388,6 @@ void CombinedSymbol::setPart(int i, const Symbol* symbol, bool is_private)
 	parts[index] = symbol;
 	private_parts[index] = symbol ? is_private : false;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/combined_symbol.h
+++ b/src/core/symbols/combined_symbol.h
@@ -33,6 +33,8 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapColor;
 class MapColorMap;
@@ -115,5 +117,8 @@ protected:
 	std::vector<const Symbol*> parts;
 	std::vector<int> temp_part_indices;	// temporary vector of the indices of the 'parts' symbols, used just for loading
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/symbols/line_symbol.cpp
+++ b/src/core/symbols/line_symbol.cpp
@@ -54,6 +54,8 @@
 #include "core/virtual_path.h"
 
 
+namespace OpenOrienteering {
+
 // ### LineSymbolBorder ###
 
 void LineSymbolBorder::reset() noexcept
@@ -1702,19 +1704,19 @@ qreal LineSymbol::calculateLargestLineExtent() const
 
 void LineSymbol::setStartSymbol(PointSymbol* symbol)
 {
-	replaceSymbol(start_symbol, symbol, QCoreApplication::translate("LineSymbolSettings", "Start symbol"));
+	replaceSymbol(start_symbol, symbol, QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Start symbol"));
 }
 void LineSymbol::setMidSymbol(PointSymbol* symbol)
 {
-	replaceSymbol(mid_symbol, symbol, QCoreApplication::translate("LineSymbolSettings", "Mid symbol"));
+	replaceSymbol(mid_symbol, symbol, QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Mid symbol"));
 }
 void LineSymbol::setEndSymbol(PointSymbol* symbol)
 {
-	replaceSymbol(end_symbol, symbol, QCoreApplication::translate("LineSymbolSettings", "End symbol"));
+	replaceSymbol(end_symbol, symbol, QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "End symbol"));
 }
 void LineSymbol::setDashSymbol(PointSymbol* symbol)
 {
-	replaceSymbol(dash_symbol, symbol, QCoreApplication::translate("LineSymbolSettings", "Dash symbol"));
+	replaceSymbol(dash_symbol, symbol, QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Dash symbol"));
 }
 void LineSymbol::replaceSymbol(PointSymbol*& old_symbol, PointSymbol* replace_with, const QString& name)
 {
@@ -2069,3 +2071,6 @@ bool LineSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensit
 	
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/line_symbol.h
+++ b/src/core/symbols/line_symbol.h
@@ -35,6 +35,9 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
+class LineSymbol;
 class Map;
 class MapColor;
 class MapColorMap;
@@ -52,8 +55,6 @@ class VirtualPath;
 using MapCoordVector = std::vector<MapCoord>;
 using MapCoordVectorF = std::vector<MapCoordF>;
 
-
-class LineSymbol;
 
 /** Settings for a line symbol's border. */
 struct LineSymbolBorder
@@ -374,5 +375,8 @@ protected:
 	LineSymbolBorder border;
 	LineSymbolBorder right_border;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/symbols/point_symbol.cpp
+++ b/src/core/symbols/point_symbol.cpp
@@ -53,6 +53,8 @@
 // IWYU pragma: no_forward_declare QXmlStreamWriter
 
 
+namespace OpenOrienteering {
+
 PointSymbol::PointSymbol() noexcept
 : Symbol{Symbol::Point}
 , rotatable{false}
@@ -718,3 +720,6 @@ bool PointSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensi
 	
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/point_symbol.h
+++ b/src/core/symbols/point_symbol.h
@@ -34,6 +34,8 @@ class QPainterPath;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapColor;
 class MapColorMap;
@@ -151,5 +153,8 @@ protected:
 	int outer_width;		// in 1/1000 mm
 	const MapColor* outer_color;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -56,6 +56,8 @@
 // IWYU pragma: no_include <QObject>
 
 
+namespace OpenOrienteering {
+
 Symbol::Symbol(Type type) noexcept
  : type { type }
  , number { -1, -1, -1 }
@@ -242,7 +244,7 @@ Symbol* Symbol::load(QXmlStreamReader& xml, const Map& map, SymbolDictionary& sy
 	int symbol_type = xml.attributes().value(QLatin1String("type")).toInt();
 	Symbol* symbol = Symbol::getSymbolForType(static_cast<Symbol::Type>(symbol_type));
 	if (!symbol)
-		throw FileFormatException(ImportExport::tr("Error while loading a symbol of type %1 at line %2 column %3.").arg(symbol_type).arg(xml.lineNumber()).arg(xml.columnNumber()));
+		throw FileFormatException(::OpenOrienteering::ImportExport::tr("Error while loading a symbol of type %1 at line %2 column %3.").arg(symbol_type).arg(xml.lineNumber()).arg(xml.columnNumber()));
 	
 	QXmlStreamAttributes attributes = xml.attributes();
 	QString code = attributes.value(QLatin1String("code")).toString();
@@ -250,7 +252,7 @@ Symbol* Symbol::load(QXmlStreamReader& xml, const Map& map, SymbolDictionary& sy
 	{
 		QString id = attributes.value(QLatin1String("id")).toString();
 		if (symbol_dict.contains(id)) 
-			throw FileFormatException(ImportExport::tr("Symbol ID '%1' not unique at line %2 column %3.").arg(id).arg(xml.lineNumber()).arg(xml.columnNumber()));
+			throw FileFormatException(::OpenOrienteering::ImportExport::tr("Symbol ID '%1' not unique at line %2 column %3.").arg(id).arg(xml.lineNumber()).arg(xml.columnNumber()));
 		
 		symbol_dict[id] = symbol;
 		
@@ -298,7 +300,7 @@ Symbol* Symbol::load(QXmlStreamReader& xml, const Map& map, SymbolDictionary& sy
 	{
 		delete symbol;
 		throw FileFormatException(
-		            ImportExport::tr("Error while loading a symbol of type %1 at line %2 column %3: %4")
+		            ::OpenOrienteering::ImportExport::tr("Error while loading a symbol of type %1 at line %2 column %3: %4")
 		            .arg(symbol_type)
 		            .arg(xml.lineNumber())
 		            .arg(xml.columnNumber())
@@ -831,3 +833,6 @@ bool Symbol::compareByColor::operator() (const Symbol* s1, const Symbol* s2)
 	
 	return false; // s1 == s2
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -35,6 +35,8 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class AreaSymbol;
 class CombinedSymbol;
 class LineSymbol;
@@ -54,11 +56,14 @@ class VirtualCoordVector;
 
 typedef QHash<QString, Symbol*> SymbolDictionary;
 
+
 // From gui/util_gui.h, but avoiding extra dependencies
-namespace Util
-{
-	QString plainText(QString maybe_markup);
-}
+namespace Util {
+
+QString plainText(QString maybe_markup);
+
+
+}  // namespace Util
 
 
 /**
@@ -461,8 +466,13 @@ private:
 	bool is_protected;
 };
 
-Q_DECLARE_METATYPE(const Symbol*)
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(Symbol::RenderableOptions)
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_METATYPE(const OpenOrienteering::Symbol*)
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::Symbol::RenderableOptions)
+
 
 #endif

--- a/src/core/symbols/text_symbol.cpp
+++ b/src/core/symbols/text_symbol.cpp
@@ -54,6 +54,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 TextSymbol::TextSymbol()
 : Symbol(Symbol::Text)
 , metrics(QFont())
@@ -550,7 +552,7 @@ bool TextSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensit
 QString TextSymbol::getIconText() const
 {
 	if (icon_text.isEmpty())
-		return QCoreApplication::translate("TextSymbolSettings", "A", "First capital letter of the local alphabet");
+		return QCoreApplication::translate("OpenOrienteering::TextSymbolSettings", "A", "First capital letter of the local alphabet");
 	return icon_text;
 }
 
@@ -578,3 +580,6 @@ double TextSymbol::getNextTab(double pos) const
 	Q_ASSERT(next_tab > pos);
  	return next_tab;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/text_symbol.h
+++ b/src/core/symbols/text_symbol.h
@@ -36,6 +36,8 @@ class QXmlStreamReader;
 class QXmlStreamWriter;
 // IWYU pragma: no_forward_declare QFontMetricsF
 
+namespace OpenOrienteering {
+
 class Map;
 class MapColor;
 class MapColorMap;
@@ -184,5 +186,8 @@ protected:
 	
 	double tab_interval;		/// default tab interval length in text coordinates
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/virtual_coord_vector.cpp
+++ b/src/core/virtual_coord_vector.cpp
@@ -22,6 +22,8 @@
 #include "core/map_coord.h"
 
 
+namespace OpenOrienteering {
+
 //### VirtualCoordVector ###
 
 MapCoordF VirtualCoordVector::fromMapCoordF(size_type index) const
@@ -35,3 +37,4 @@ MapCoordF VirtualCoordVector::fromMapCoord(size_type index) const
 }
 
 
+}  // namespace OpenOrienteering

--- a/src/core/virtual_coord_vector.h
+++ b/src/core/virtual_coord_vector.h
@@ -25,6 +25,7 @@
 
 #include "map_coord.h"
 
+namespace OpenOrienteering {
 
 /**
  * @brief The VirtualFlagsVector class provides read-only access to a MapCoordVector.
@@ -238,5 +239,6 @@ MapCoordF VirtualCoordVector::back() const
 }
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/core/virtual_path.cpp
+++ b/src/core/virtual_path.cpp
@@ -24,9 +24,11 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
 
 namespace
 {
+
 	/**
 	 * Global position error threshold for approximating
 	 * bezier curves with straight segments.
@@ -43,7 +45,9 @@ namespace
 	 * This is counteracted by generating many segments.
 	 */
 	const PathCoord::length_type bezier_segment_maxlen_squared = 1.0;
-}
+	
+	
+}  // namespace
 
 
 
@@ -836,3 +840,6 @@ void VirtualPath::copyLengths(
 	
 	out_lengths.push_back(last.clen);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/core/virtual_path.h
+++ b/src/core/virtual_path.h
@@ -34,6 +34,7 @@
 
 // IWYU pragma: no_forward_declare QRectF
 
+namespace OpenOrienteering {
 
 class PathCoordVector : public std::vector<PathCoord>
 {
@@ -419,5 +420,6 @@ bool VirtualPath::isPointInside(MapCoordF coord) const
 }
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/fileformats/file_format.cpp
+++ b/src/fileformats/file_format.cpp
@@ -22,6 +22,8 @@
 #include <QCoreApplication>
 
 
+namespace OpenOrienteering {
+
 // ### FileFormatException ###
 
 // virtual
@@ -71,7 +73,7 @@ Importer *FileFormat::createImporter(QIODevice* stream, Map *map, MapView *view)
 	Q_UNUSED(stream);
 	Q_UNUSED(map);
 	Q_UNUSED(view);
-	throw FileFormatException(QCoreApplication::translate("Importer", "Format (%1) does not support import").arg(description()));
+	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Importer", "Format (%1) does not support import").arg(description()));
 }
 
 Exporter *FileFormat::createExporter(QIODevice* stream, Map *map, MapView *view) const
@@ -79,5 +81,8 @@ Exporter *FileFormat::createExporter(QIODevice* stream, Map *map, MapView *view)
 	Q_UNUSED(stream);
 	Q_UNUSED(map);
 	Q_UNUSED(view);
-	throw FileFormatException(QCoreApplication::translate("Exporter", "Format (%1) does not support export").arg(description()));
+	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Exporter", "Format (%1) does not support export").arg(description()));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/file_format.h
+++ b/src/fileformats/file_format.h
@@ -32,6 +32,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Exporter;
 class Importer;
 class Map;
@@ -85,7 +87,7 @@ private:
  *  \code
  *  class MyCustomFileFormat : public FileFormat {
  *  public:
- *      MyCustomFileFormat : FileFormat("custom", ImportExport::tr("Custom file"), "custom", true, true) {
+ *      MyCustomFileFormat : FileFormat("custom", ::OpenOrienteering::ImportExport::tr("Custom file"), "custom", true, true) {
  *      }
  *
  *      Importer *createImporter(QIODevice* stream, Map *map, MapView *view) const {
@@ -270,10 +272,6 @@ const QString& FileFormatException::message() const noexcept
 
 // ### FileFormat inline and header code ###
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(FileFormat::FileTypes)
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(FileFormat::FormatFeatures)
-
 inline
 FileFormat::FileType FileFormat::fileType() const
 {
@@ -328,6 +326,14 @@ bool FileFormat::isExportLossy() const
 {
 	return format_features.testFlag(FileFormat::ExportLossy);
 }
+
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::FileFormat::FileTypes)
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::FileFormat::FormatFeatures)
 
 
 #endif // OPENORIENTEERING_FILE_FORMAT_H

--- a/src/fileformats/file_format_registry.cpp
+++ b/src/fileformats/file_format_registry.cpp
@@ -25,6 +25,8 @@
 #include "fileformats/file_format.h"
 
 
+namespace OpenOrienteering {
+
 FileFormatRegistry FileFormats;
 
 
@@ -95,3 +97,6 @@ const FileFormat *FileFormatRegistry::findFormatForFilename(const QString& filen
 	}
 	return nullptr;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/file_format_registry.h
+++ b/src/fileformats/file_format_registry.h
@@ -26,7 +26,10 @@
 
 #include <QString>
 
+namespace OpenOrienteering {
+
 class FileFormat;
+
 
 /** Provides a registry for file formats, and takes ownership of the supported format objects.
  */
@@ -94,5 +97,7 @@ private:
  */
 extern FileFormatRegistry FileFormats;
 
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_FILE_FORMAT_REGISTRY_H

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -34,6 +34,8 @@
 #include "templates/template.h"
 
 
+namespace OpenOrienteering {
+
 // ### ImportExport ###
 
 ImportExport::~ImportExport() = default;
@@ -42,7 +44,7 @@ ImportExport::~ImportExport() = default;
 QVariant ImportExport::option(const QString& name) const
 {
 	if (!options.contains(name))
-		throw FileFormatException(ImportExport::tr("No such option: %1", "No such import / export option").arg(name));
+		throw FileFormatException(::OpenOrienteering::ImportExport::tr("No such option: %1", "No such import / export option").arg(name));
 	return options[name];
 }
 
@@ -72,7 +74,7 @@ void Importer::doImport(bool load_symbols_only, const QString& map_path)
 			Object* object = part->getObject(o);
 			if (object->getSymbol() == nullptr)
 			{
-				addWarning(Importer::tr("Found an object without symbol."));
+				addWarning(::OpenOrienteering::Importer::tr("Found an object without symbol."));
 				if (object->getType() == Object::Point)
 					object->setSymbol(map->getUndefinedPoint(), true);
 				else if (object->getType() == Object::Path)
@@ -107,7 +109,7 @@ void Importer::doImport(bool load_symbols_only, const QString& map_path)
 	for (int i = 0; i < map->getNumSymbols(); ++i)
 	{
 		if (!map->getSymbol(i)->loadFinished(map))
-			throw FileFormatException(Importer::tr("Error during symbol post-processing."));
+			throw FileFormatException(::OpenOrienteering::Importer::tr("Error during symbol post-processing."));
 	}
 	
 	// Template loading: try to find all template files
@@ -135,7 +137,7 @@ void Importer::doImport(bool load_symbols_only, const QString& map_path)
 				if (found_in_map_dir)
 				{
 					error_string.prepend(
-					            Importer::tr(
+					            ::OpenOrienteering::Importer::tr(
 					               "Template \"%1\" has been loaded from the map's directory instead of"
 					               " the relative location to the map file where it was previously."
 					               ).arg(temp->getTemplateFilename()) + QLatin1Char('\n') );
@@ -171,3 +173,6 @@ void Importer::finishImport()
 // ### Exporter ###
 
 Exporter::~Exporter() = default;
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -29,6 +29,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapView;
 
@@ -42,7 +44,7 @@ class MapView;
  */
 class ImportExport
 {
-	Q_DECLARE_TR_FUNCTIONS(ImportExport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::ImportExport)
 	
 public:
 	/** Creates a new importer or exporter with the given input stream, map, and view.
@@ -121,7 +123,7 @@ class ImportAction
  */
 class Importer : public ImportExport
 {
-	Q_DECLARE_TR_FUNCTIONS(Importer)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::Importer)
 	
 public:
 	/** Creates a new Importer with the given output stream, map, and view.
@@ -177,7 +179,7 @@ private:
  */
 class Exporter : public ImportExport
 {
-	Q_DECLARE_TR_FUNCTIONS(Exporter)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::Exporter)
 	
 public:
 	/** Creates a new Importer with the given i/o stream, map, and view.
@@ -258,5 +260,7 @@ Exporter::Exporter(QIODevice* stream, Map* map, MapView* view)
 	// Nothing
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_IMPORT_EXPORT_H

--- a/src/fileformats/native_file_format.cpp
+++ b/src/fileformats/native_file_format.cpp
@@ -39,6 +39,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 // ### NativeFileImport declaration ###
 
 /** An Importer for the native file format. This class delegates to the load() and loadImpl() methods of the
@@ -90,7 +92,7 @@ const int NativeFileFormat::current_file_format_version = 30;
 const char NativeFileFormat::magic_bytes[4] = {0x4F, 0x4D, 0x41, 0x50};	// "OMAP"
 
 NativeFileFormat::NativeFileFormat()
- : FileFormat(FileFormat::MapFile, "native (deprecated)", ImportExport::tr("OpenOrienteering Mapper").append(QLatin1String(" pre-0.5")), QString::fromLatin1("omap"),
+ : FileFormat(FileFormat::MapFile, "native (deprecated)", ::OpenOrienteering::ImportExport::tr("OpenOrienteering Mapper").append(QLatin1String(" pre-0.5")), QString::fromLatin1("omap"),
               FileFormat::ImportSupported)
 {
 	// Nothing
@@ -121,7 +123,7 @@ NativeFileImport::~NativeFileImport()
 
 void NativeFileImport::import(bool load_symbols_only)
 {
-    addWarning(Importer::tr("This file uses an obsolete format. "
+    addWarning(::OpenOrienteering::Importer::tr("This file uses an obsolete format. "
                             "Support for this format is to be removed from this program soon. "
                             "To be able to open the file in the future, save it again."));
 
@@ -134,15 +136,15 @@ void NativeFileImport::import(bool load_symbols_only)
     stream->read((char*)&version, sizeof(int));
     if (version < 0)
     {
-        addWarning(Importer::tr("Invalid file format version."));
+        addWarning(::OpenOrienteering::Importer::tr("Invalid file format version."));
     }
     else if (version < NativeFileFormat::least_supported_file_format_version)
     {
-        throw FileFormatException(Importer::tr("Unsupported old file format version. Please use an older program version to load and update the file."));
+        throw FileFormatException(::OpenOrienteering::Importer::tr("Unsupported old file format version. Please use an older program version to load and update the file."));
     }
     else if (version > NativeFileFormat::current_file_format_version)
     {
-        throw FileFormatException(Importer::tr("Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating."));
+        throw FileFormatException(::OpenOrienteering::Importer::tr("Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating."));
     }
 
     if (version <= 16)
@@ -198,7 +200,7 @@ void NativeFileImport::import(bool load_symbols_only)
 		if (geographic_crs_spec != Georeferencing::geographic_crs_spec)
 		{
 			addWarning(
-			  Importer::tr("The geographic coordinate reference system of the map was \"%1\". This CRS is not supported. Using \"%2\".").
+			  ::OpenOrienteering::Importer::tr("The geographic coordinate reference system of the map was \"%1\". This CRS is not supported. Using \"%2\".").
 			  arg(geographic_crs_spec, Georeferencing::geographic_crs_spec)
 			);
 		}
@@ -316,12 +318,12 @@ void NativeFileImport::import(bool load_symbols_only)
         Symbol* symbol = Symbol::getSymbolForType(static_cast<Symbol::Type>(symbol_type));
         if (!symbol)
         {
-            throw FileFormatException(Importer::tr("Error while loading a symbol with type %2.").arg(symbol_type));
+            throw FileFormatException(::OpenOrienteering::Importer::tr("Error while loading a symbol with type %2.").arg(symbol_type));
         }
 
         if (!symbol->load(stream, version, map))
         {
-            throw FileFormatException(Importer::tr("Error while loading a symbol."));
+            throw FileFormatException(::OpenOrienteering::Importer::tr("Error while loading a symbol."));
         }
         map->symbols[i] = symbol;
     }
@@ -393,7 +395,7 @@ void NativeFileImport::import(bool load_symbols_only)
 		{
 			if (!map->undoManager().load(stream, version))
 			{
-				throw FileFormatException(Importer::tr("Error while loading undo steps."));
+				throw FileFormatException(::OpenOrienteering::Importer::tr("Error while loading undo steps."));
 			}
 		}
 
@@ -403,7 +405,7 @@ void NativeFileImport::import(bool load_symbols_only)
 		int num_parts;
 		if (stream->read((char*)&num_parts, sizeof(int)) < (int)sizeof(int))
 		{
-			throw FileFormatException(Importer::tr("Error while reading map part count."));
+			throw FileFormatException(::OpenOrienteering::Importer::tr("Error while reading map part count."));
 		}
 		delete map->parts[0];
 		map->parts.resize(num_parts);
@@ -414,7 +416,7 @@ void NativeFileImport::import(bool load_symbols_only)
 			if (!part->load(stream, version, map))
 			{
 				delete part;
-				throw FileFormatException(Importer::tr("Error while loading map part %2.").arg(i+1));
+				throw FileFormatException(::OpenOrienteering::Importer::tr("Error while loading map part %2.").arg(i+1));
 			}
 			map->parts[i] = part;
 		}
@@ -423,5 +425,8 @@ void NativeFileImport::import(bool load_symbols_only)
 	emit map->currentMapPartIndexChanged(map->current_part_index);
 	emit map->currentMapPartChanged(map->getPart(map->current_part_index));
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/fileformats/native_file_format.h
+++ b/src/fileformats/native_file_format.h
@@ -26,10 +26,14 @@
 
 #include "fileformats/file_format.h"
 
+class QIODevice;
+
 class Importer;
+
+namespace OpenOrienteering {
+
 class Map;
 class MapView;
-class QIODevice;
 
 
 /** Provides a description of the old native file format. 
@@ -73,5 +77,8 @@ public:
 };
 
 #endif // NO_NATIVE_FILE_FORMAT
+
+
+}  // namespace OpenOrienteering
 
 #endif // NATIVE_FILE_FORMAT_H

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -54,10 +54,12 @@
 #include "util/encoding.h"
 
 
+namespace OpenOrienteering {
+
 // ### OCAD8FileFormat ###
 
 OCAD8FileFormat::OCAD8FileFormat()
- : FileFormat(MapFile, "OCAD78", ImportExport::tr("OCAD Versions 7, 8"), QString::fromLatin1("ocd"),
+ : FileFormat(MapFile, "OCAD78", ::OpenOrienteering::ImportExport::tr("OCAD Versions 7, 8"), QString::fromLatin1("ocd"),
               ImportSupported | ExportSupported | ExportLossy)
 {
 	// Nothing
@@ -115,12 +117,12 @@ void OCAD8FileImport::import(bool load_symbols_only)
 	if (!buffer)
 		throw FileFormatException(tr("Could not allocate buffer."));
 	if (stream->read((char*)buffer, size) != size)
-		throw FileFormatException(Importer::tr("Could not read file: %1").arg(stream->errorString()));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(stream->errorString()));
 	int err = ocad_file_open_memory(&file, buffer, size);
-    if (err != 0) throw FileFormatException(Importer::tr("Could not read file: %1").arg(tr("libocad returned %1").arg(err)));
+    if (err != 0) throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(tr("libocad returned %1").arg(err)));
 	
 	if (file->header->major <= 5 || file->header->major >= 9)
-		throw FileFormatException(Importer::tr("Could not read file: %1").arg(tr("OCAD files of version %1 are not supported!").arg(file->header->major)));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(tr("OCAD files of version %1 are not supported!").arg(file->header->major)));
 
     //qDebug() << "file version is" << file->header->major << ", type is"
     //         << ((file->header->ftype == 2) ? "normal" : "other");
@@ -590,13 +592,13 @@ Symbol *OCAD8FileImport::importLineSymbol(const OCADLineSymbol *ocad_symbol)
     if( ocad_symbol->scnpts > 0 )
     {
 		symbol_line->dash_symbol = importPattern( ocad_symbol->scnpts, symbolptr);
-        symbol_line->dash_symbol->setName(QCoreApplication::translate("LineSymbolSettings", "Dash symbol"));
+        symbol_line->dash_symbol->setName(QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Dash symbol"));
         symbolptr += ocad_symbol->scnpts; 
     }
     if( ocad_symbol->sbnpts > 0 )
     {
 		symbol_line->start_symbol = importPattern( ocad_symbol->sbnpts, symbolptr);
-        symbol_line->start_symbol->setName(QCoreApplication::translate("LineSymbolSettings", "Start symbol"));
+        symbol_line->start_symbol->setName(QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Start symbol"));
         symbolptr += ocad_symbol->sbnpts;
     }
     if( ocad_symbol->senpts > 0 )
@@ -1558,7 +1560,7 @@ void OCAD8FileExport::doExport()
 	
 	// Create struct in memory
 	int err = ocad_file_new(&file);
-	if (err != 0) throw FileFormatException(Exporter::tr("Could not create new file: %1").arg(tr("libocad returned %1").arg(err)));
+	if (err != 0) throw FileFormatException(::OpenOrienteering::Exporter::tr("Could not create new file: %1").arg(tr("libocad returned %1").arg(err)));
 	
 	// Check for a neccessary offset (and add related warnings early).
 	auto area_offset = calculateAreaOffset();
@@ -2848,3 +2850,6 @@ void OCAD8FileExport::addStringTruncationWarning(const QString& text, int trunca
 	temp.insert(truncation_pos, QLatin1String("|||"));
 	addWarning(tr("String truncated (truncation marked with three '|'): %1").arg(temp));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/ocad8_file_format.h
+++ b/src/fileformats/ocad8_file_format.h
@@ -26,6 +26,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Exporter;
 class Importer;
 class Map;
@@ -43,5 +45,8 @@ public:
 	Importer* createImporter(QIODevice* stream, Map *map, MapView *view) const override;
 	Exporter* createExporter(QIODevice* stream, Map* map, MapView* view) const override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OCAD8_FILE_IMPORT_H

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -30,6 +30,7 @@
 #include "fileformats/file_import_export.h"
 #include "libocad/libocad.h"
 
+namespace OpenOrienteering {
 
 class Map;
 class MapColor;
@@ -45,12 +46,13 @@ class PointSymbol;
 class Template;
 class TextSymbol;
 
+
 /** Importer for OCD version 8 files. */
 class OCAD8FileImport : public Importer
 {
 	friend class OcdFileImport;
 	
-	Q_DECLARE_TR_FUNCTIONS(OCAD8FileImport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OCAD8FileImport)
 	
 private:
 	/// Information about an OCAD rectangle symbol
@@ -148,7 +150,7 @@ private:
 /** Exporter for OCD version 8 files. */
 class OCAD8FileExport : public Exporter
 {
-	Q_DECLARE_TR_FUNCTIONS(OCAD8FileExport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OCAD8FileExport)
 	
 public:
 	OCAD8FileExport(QIODevice* stream, Map *map, MapView *view);
@@ -232,5 +234,8 @@ private:
 	
 	void addStringTruncationWarning(const QString& text, int truncation_pos);
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -25,6 +25,8 @@
 #include "fileformats/ocad8_file_format_p.h"
 
 
+namespace OpenOrienteering {
+
 OcdFileExport::OcdFileExport(QIODevice* stream, Map* map, MapView* view)
 : Exporter { stream, map, view }
 {
@@ -44,3 +46,6 @@ void OcdFileExport::doExport()
 		addWarning(w);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -27,9 +27,12 @@
 
 #include "fileformats/file_import_export.h"
 
+class QIODevice;
+
+namespace OpenOrienteering {
+
 class Map;
 class MapView;
-class QIODevice;
 
 
 /**
@@ -37,7 +40,7 @@ class QIODevice;
  */
 class OcdFileExport : public Exporter
 {
-	Q_DECLARE_TR_FUNCTIONS(OcdFileExport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OcdFileExport)
 	
 public:
 	OcdFileExport(QIODevice* stream, Map *map, MapView *view);
@@ -52,5 +55,8 @@ public:
 	void doExport() override;
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/fileformats/ocd_file_format.cpp
+++ b/src/fileformats/ocd_file_format.cpp
@@ -32,10 +32,12 @@
 #include "fileformats/ocd_file_import.h"
 
 
+namespace OpenOrienteering {
+
 // ### OcdFileFormat ###
 
 OcdFileFormat::OcdFileFormat()
-: FileFormat { MapFile, "OCD", ImportExport::tr("OCAD"), QString::fromLatin1("ocd"),
+: FileFormat { MapFile, "OCD", ::OpenOrienteering::ImportExport::tr("OCAD"), QString::fromLatin1("ocd"),
                ImportSupported | ExportSupported | ExportLossy }
 {
 	// Nothing
@@ -59,3 +61,5 @@ Exporter* OcdFileFormat::createExporter(QIODevice* stream, Map* map, MapView* vi
 	return new OcdFileExport(stream, map, view);
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/ocd_file_format.h
+++ b/src/fileformats/ocd_file_format.h
@@ -26,6 +26,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Exporter;
 class Importer;
 class Map;
@@ -57,5 +59,8 @@ public:
 	/// \copydoc FileFormat::createExporter()
 	Exporter* createExporter(QIODevice* stream, Map* map, MapView* view) const override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_OCD_FILE_FORMAT

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -74,6 +74,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 namespace {
 
 static QTextCodec* codecFromSettings()
@@ -83,7 +85,9 @@ static QTextCodec* codecFromSettings()
 	return Util::codecForName(name);
 }	
 
-} // namespace
+
+}  // namespace
+
 
 
 OcdFileImport::OcdImportedPathObject::~OcdImportedPathObject()
@@ -1216,21 +1220,21 @@ void OcdFileImport::setupLineSymbolPointSymbol(OcdFileImport::OcdImportedLineSym
 	{
 		line_symbol->dash_symbol = new OcdImportedPointSymbol();
 		setupPointSymbolPattern(line_symbol->dash_symbol, attributes.corner_data_size, reinterpret_cast<const Ocd::PointSymbolElementV8*>(coords), ocd_version);
-		line_symbol->dash_symbol->setName(QCoreApplication::translate("LineSymbolSettings", "Dash symbol"));
+		line_symbol->dash_symbol->setName(QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Dash symbol"));
 		coords += attributes.corner_data_size;
 	}
 	if (attributes.start_data_size > 0)
 	{
 		line_symbol->start_symbol = new OcdImportedPointSymbol();
 		setupPointSymbolPattern(line_symbol->start_symbol, attributes.start_data_size, reinterpret_cast<const Ocd::PointSymbolElementV8*>(coords), ocd_version);
-		line_symbol->start_symbol->setName(QCoreApplication::translate("LineSymbolSettings", "Start symbol"));
+		line_symbol->start_symbol->setName(QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "Start symbol"));
 		coords += attributes.start_data_size;
 	}
 	if (attributes.end_data_size > 0)
 	{
 		line_symbol->end_symbol = new OcdImportedPointSymbol();
 		setupPointSymbolPattern(line_symbol->end_symbol, attributes.end_data_size, reinterpret_cast<const Ocd::PointSymbolElementV8*>(coords), ocd_version);
-		line_symbol->end_symbol->setName(QCoreApplication::translate("LineSymbolSettings", "End symbol"));
+		line_symbol->end_symbol->setName(QCoreApplication::translate("OpenOrienteering::LineSymbolSettings", "End symbol"));
 	}
 	
 	// FIXME: not really sure how this translates... need test cases
@@ -2059,14 +2063,14 @@ void OcdFileImport::import(bool load_symbols_only)
 	buffer.clear();
 	buffer.append(stream->readAll());
 	if (buffer.isEmpty())
-		throw FileFormatException(Importer::tr("Could not read file: %1").arg(stream->errorString()));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(stream->errorString()));
 	
 	if (size_t(buffer.size()) < sizeof(Ocd::FormatGeneric::FileHeader))
-		throw FileFormatException(Importer::tr("Could not read file: %1").arg(tr("Invalid data.")));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(tr("Invalid data.")));
 	
 	const OcdFile<Ocd::FormatGeneric> generic_file(buffer);
 	if (generic_file.header()->vendor_mark != 0x0cad) // This also tests correct endianess...
-		throw FileFormatException(Importer::tr("Could not read file: %1").arg(tr("Invalid data.")));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(tr("Invalid data.")));
 	
 	int version = generic_file.header()->version;
 	switch (version)
@@ -2096,7 +2100,7 @@ void OcdFileImport::import(bool load_symbols_only)
 		break;
 	default:
 		throw FileFormatException(
-		            Importer::tr("Could not read file: %1").
+		            ::OpenOrienteering::Importer::tr("Could not read file: %1").
 		            arg(tr("OCD files of version %1 are not supported!").arg(version))
 		            );
 	}
@@ -2132,3 +2136,6 @@ void OcdFileImport::handleStrings(const OcdFile<F>& file, std::initializer_list<
 		}
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -51,6 +51,8 @@
 class QChar;
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class CombinedSymbol;
 class Georeferencing;
 class Map;
@@ -66,7 +68,7 @@ class Symbol;
  */
 class OcdFileImport : public Importer
 {
-	Q_DECLARE_TR_FUNCTIONS(OcdFileImport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OcdFileImport)
 	
 protected:
 	/// Information about an OC*D rectangle symbol
@@ -457,5 +459,7 @@ MapColor *OcdFileImport::convertColor(int ocd_color)
 	return color_index[ocd_color];
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_OCD_FILE_IMPORT

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -62,6 +62,8 @@
 #include "util/xml_stream_util.h"
 
 
+namespace OpenOrienteering {
+
 // ### XMLFileFormat definition ###
 
 constexpr int XMLFileFormat::minimum_version = 2;
@@ -85,7 +87,7 @@ QString mapperNamespace()
 
 
 XMLFileFormat::XMLFileFormat()
- : FileFormat(MapFile, "XML", ImportExport::tr("OpenOrienteering Mapper"), QString::fromLatin1("omap"),
+ : FileFormat(MapFile, "XML", ::OpenOrienteering::ImportExport::tr("OpenOrienteering Mapper"), QString::fromLatin1("omap"),
               ImportSupported | ExportSupported) 
 {
 	addExtension(QString::fromLatin1("xmap"));
@@ -498,17 +500,17 @@ void XMLFileImporter::import(bool load_symbols_only)
 {
 	if (!xml.readNextStartElement() || xml.name() != literal::map)
 	{
-		xml.raiseError(Importer::tr("Unsupported file format."));
+		xml.raiseError(::OpenOrienteering::Importer::tr("Unsupported file format."));
 	}
 	
 	XmlElementReader map_element(xml);
 	const int version = map_element.attribute<int>(literal::version);
 	if (version < 1)
-		xml.raiseError(Importer::tr("Invalid file format version."));
+		xml.raiseError(::OpenOrienteering::Importer::tr("Invalid file format version."));
 	else if (version < XMLFileFormat::minimum_version)
-		xml.raiseError(Importer::tr("Unsupported old file format version. Please use an older program version to load and update the file."));
+		xml.raiseError(::OpenOrienteering::Importer::tr("Unsupported old file format version. Please use an older program version to load and update the file."));
 	else if (version > XMLFileFormat::current_version)
-		addWarning(Importer::tr("Unsupported new file format version. Some map features will not be loaded or saved by this version of the program."));
+		addWarning(::OpenOrienteering::Importer::tr("Unsupported new file format version. Some map features will not be loaded or saved by this version of the program."));
 	
 	QScopedValueRollback<MapCoord::BoundsOffset> rollback { MapCoord::boundsOffset() };
 	MapCoord::boundsOffset().reset(true);
@@ -976,7 +978,7 @@ void XMLFileImporter::importPrint()
 	}
 	catch (FileFormatException& e)
 	{
-		addWarning(ImportExport::tr("Error while loading the printing configuration at %1:%2: %3")
+		addWarning(::OpenOrienteering::ImportExport::tr("Error while loading the printing configuration at %1:%2: %3")
 		           .arg(xml.lineNumber()).arg(xml.columnNumber()).arg(e.message()));
 	}
 }
@@ -995,7 +997,7 @@ void XMLFileImporter::importUndo()
 	}
 	catch (FileFormatException& e)
 	{
-		addWarning(ImportExport::tr("Error while loading the undo/redo steps at %1:%2: %3")
+		addWarning(::OpenOrienteering::ImportExport::tr("Error while loading the undo/redo steps at %1:%2: %3")
 		           .arg(xml.lineNumber()).arg(xml.columnNumber()).arg(e.message()));
 		map->undoManager().clear();
 	}
@@ -1015,8 +1017,11 @@ void XMLFileImporter::importRedo()
 	}
 	catch (FileFormatException& e)
 	{
-		addWarning(ImportExport::tr("Error while loading the undo/redo steps at %1:%2: %3")
+		addWarning(::OpenOrienteering::ImportExport::tr("Error while loading the undo/redo steps at %1:%2: %3")
 		           .arg(xml.lineNumber()).arg(xml.columnNumber()).arg(e.message()));
 		map->undoManager().clear();
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -26,6 +26,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Exporter;
 class Importer;
 class Map;
@@ -70,5 +72,8 @@ public:
 	static int active_version;
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_FILE_FORMAT_XML_H

--- a/src/fileformats/xml_file_format_p.h
+++ b/src/fileformats/xml_file_format_p.h
@@ -28,11 +28,12 @@
 #include "core/symbols/symbol.h"
 #include "fileformats/file_import_export.h"
 
+namespace OpenOrienteering {
 
 /** Map exporter for the xml based map format. */
 class XMLFileExporter : public Exporter
 {
-	Q_DECLARE_TR_FUNCTIONS(XMLFileExporter)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::XMLFileExporter)
 	
 public:
 	XMLFileExporter(QIODevice* stream, Map *map, MapView *view);
@@ -59,7 +60,7 @@ private:
 /** Map importer for the xml based map format. */
 class XMLFileImporter : public Importer
 {
-	Q_DECLARE_TR_FUNCTIONS(XMLFileImporter)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::XMLFileImporter)
 	
 public:
 	XMLFileImporter(QIODevice* stream, Map *map, MapView *view);
@@ -86,5 +87,8 @@ protected:
 	SymbolDictionary symbol_dict;
 	bool georef_offset_adjusted;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gdal/gdal_manager.cpp
+++ b/src/gdal/gdal_manager.cpp
@@ -36,6 +36,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 class GdalManager::GdalManagerPrivate
 {
 public:
@@ -347,3 +349,6 @@ void GdalManager::unsetParameter(const QString& key)
 {
 	p->unsetParameter(key);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_manager.h
+++ b/src/gdal/gdal_manager.h
@@ -28,6 +28,8 @@ class QString;
 class QStringList;
 
 
+namespace OpenOrienteering {
+
 /**
  * A utility class which takes care of GDAL settings and options.
  * 
@@ -105,5 +107,8 @@ public:
 	 */
 	void unsetParameter(const QString& key);
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_GDAL_MANAGER_H

--- a/src/gdal/gdal_settings_page.cpp
+++ b/src/gdal/gdal_settings_page.cpp
@@ -40,6 +40,7 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
 
 GdalSettingsPage::GdalSettingsPage(QWidget* parent)
 : SettingsPage(parent)
@@ -227,3 +228,6 @@ int GdalSettingsPage::findDuplicateKey(const QString& key, int row) const
 	}
 	return row;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_settings_page.h
+++ b/src/gdal/gdal_settings_page.h
@@ -29,6 +29,8 @@ class QCheckBox;
 class QTableWidget;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 class GdalSettingsPage : public SettingsPage
 {
@@ -58,5 +60,7 @@ private:
 	QTableWidget* parameters;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -69,8 +69,10 @@
 // IWYU pragma: no_forward_declare QFile
 
 
-namespace ogr
-{
+namespace OpenOrienteering {
+
+namespace ogr {
+	
 	class OGRDataSourceHDeleter
 	{
 	public:
@@ -109,10 +111,12 @@ namespace ogr
 	/** A convenience class for OGR C API geometry handles, similar to std::unique_ptr. */
 	using unique_geometry = std::unique_ptr<typename std::remove_pointer<OGRGeometryH>::type, OGRGeometryHDeleter>;
 	
-}
+}  // namespace ogr
 
-namespace
-{
+
+
+namespace {
+	
 	void applyPenWidth(OGRStyleToolH tool, LineSymbol* line_symbol)
 	{
 		int is_null;
@@ -281,14 +285,14 @@ namespace
 		return srs_wkt;
 	}
 	
-}
+}  // namespace
 
 
 
 // ### OgrFileFormat ###
 
 OgrFileFormat::OgrFileFormat()
- : FileFormat(OgrFile, "OGR", ImportExport::tr("Geospatial vector data"), QString{}, ImportSupported)
+ : FileFormat(OgrFile, "OGR", ::OpenOrienteering::ImportExport::tr("Geospatial vector data"), QString{}, ImportSupported)
 {
 	for (const auto& extension : GdalManager().supportedVectorExtensions())
 		addExtension(QString::fromLatin1(extension));
@@ -409,7 +413,7 @@ void OgrFileImport::import(bool load_symbols_only)
 	auto data_source = ogr::unique_datasource(OGROpen(filename.toUtf8().constData(), 0, nullptr));
 	if (!data_source)
 	{
-		throw FileFormatException(Importer::tr("Could not read '%1': %2")
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read '%1': %2")
 		                          .arg(filename, QString::fromLatin1(CPLGetLastErrorMsg())));
 	}
 	
@@ -1278,7 +1282,7 @@ bool OgrFileImport::checkGeoreferencing(QFile& file, const Georeferencing& geore
 	auto data_source = ogr::unique_datasource(OGROpen(filename.toUtf8().constData(), 0, nullptr));
 	if (!data_source)
 	{
-		throw FileFormatException(Importer::tr("Could not read '%1': %2")
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read '%1': %2")
 		                          .arg(filename, QString::fromLatin1(CPLGetLastErrorMsg())));
 	}
 	
@@ -1331,7 +1335,7 @@ LatLon OgrFileImport::calcAverageLatLon(QFile& file)
 	auto data_source = ogr::unique_datasource(OGROpen(filename.toUtf8().constData(), 0, nullptr));
 	if (!data_source)
 	{
-		throw FileFormatException(Importer::tr("Could not read '%1': %2")
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read '%1': %2")
 		                          .arg(filename, QString::fromLatin1(CPLGetLastErrorMsg())));
 	}
 	
@@ -1384,3 +1388,6 @@ LatLon OgrFileImport::calcAverageLatLon(OGRDataSourceH data_source)
 	
 	return num_coords ? LatLon{ y / num_coords, x / num_coords } : LatLon{};
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gdal/ogr_file_format.h
+++ b/src/gdal/ogr_file_format.h
@@ -26,6 +26,8 @@
 
 class QIODevice;
 
+namespace OpenOrienteering {
+
 class Importer;
 class Map;
 class MapView;
@@ -60,5 +62,8 @@ public:
 	 */
 	Importer* createImporter(QIODevice* stream, Map *map, MapView *view) const override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_OGR_FILE_FORMAT_H

--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -36,6 +36,8 @@
 
 class QFile;
 
+namespace OpenOrienteering {
+
 class AreaSymbol;
 class Georeferencing;
 class LatLon;
@@ -109,7 +111,7 @@ namespace ogr
  */
 class OgrFileImport : public Importer
 {
-	Q_DECLARE_TR_FUNCTIONS(OgrFileImport)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OgrFileImport)
 	
 public:
 	/**
@@ -271,5 +273,6 @@ MapCoord OgrFileImport::toMapCoord(double x, double y) const
 }
 
 
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_OGR_FILE_FORMAT_P_H

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -52,8 +52,10 @@
 #include "templates/template_track.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	namespace literal
 	{
 		const auto crs_spec           = QLatin1String("crs_spec");
@@ -98,7 +100,7 @@ namespace
 		return false;
 	}
 	
-}
+}  // namespace
 
 
 
@@ -499,3 +501,6 @@ void OgrTemplate::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) c
 		explicit_georef->save(xml);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gdal/ogr_template.h
+++ b/src/gdal/ogr_template.h
@@ -34,6 +34,8 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Georeferencing;
 class Map;
 
@@ -104,5 +106,8 @@ private:
 	bool center_in_view               { false };  //  transient
 	bool reload_pending               { false };  //  transient
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_OGR_TEMPLATE_H

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -30,6 +30,8 @@
 #include "gdal/ogr_file_format.h"
 
 
+namespace OpenOrienteering {
+
 void doStaticInitializations()
 {
 	// Register the supported file formats
@@ -46,3 +48,6 @@ void doStaticInitializations()
 #endif
 #endif
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/global.h
+++ b/src/global.h
@@ -20,10 +20,15 @@
 #ifndef OPENORIENTEERING_GLOBAL_H
 #define OPENORIENTEERING_GLOBAL_H
 
+namespace OpenOrienteering {
+
 /** 
  * This is called at startup in main() and by the test cases
  * to do the global initializations.
  */
 void doStaticInitializations();
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/about_dialog.cpp
+++ b/src/gui/about_dialog.cpp
@@ -28,6 +28,8 @@
 #include "mapper_config.h"
 
 
+namespace OpenOrienteering {
+
 namespace {
 
 /**
@@ -77,7 +79,9 @@ QString formatBlock(const QStringList& items)
 	return block;
 }
 
+
 }  // namespace
+
 
 
 AboutDialog::AboutDialog(QWidget* parent)
@@ -189,3 +193,6 @@ QString AboutDialog::about()
 	
 	return mapper_about;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/about_dialog.h
+++ b/src/gui/about_dialog.h
@@ -29,6 +29,8 @@ class QWidget;
 
 #include "gui/text_browser_dialog.h"
 
+namespace OpenOrienteering {
+
 
 /**
  * @brief A dialog which shows information about Mapper and its components.
@@ -59,5 +61,8 @@ protected:
 	 */
 	void updateWindowTitle() override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/autosave_dialog.cpp
+++ b/src/gui/autosave_dialog.cpp
@@ -29,6 +29,9 @@
 
 #include "main_window.h"
 
+
+namespace OpenOrienteering {
+
 AutosaveDialog::AutosaveDialog(const QString& path, const QString& autosave_path, const QString& actual_path, MainWindow* parent, Qt::WindowFlags f)
 : QDialog(parent, f)
 , main_window(parent)
@@ -190,3 +193,6 @@ const QTextDocument* AutosaveDialog::textDoc(const QModelIndex& index) const
 	
 	return ret;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/autosave_dialog.h
+++ b/src/gui/autosave_dialog.h
@@ -34,6 +34,8 @@ class QCloseEvent;
 class QListWidget;
 class QModelIndex;
 
+namespace OpenOrienteering {
+
 class MainWindow;
 
 
@@ -132,5 +134,8 @@ private:
 	QBoxLayout* layout;
 	QListWidget* list_widget;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_AUTOSAVE_DIALOG_H

--- a/src/gui/color_dialog.cpp
+++ b/src/gui/color_dialog.cpp
@@ -61,14 +61,17 @@
 #include "util/translation_util.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	constexpr QSize coloriconSize()
 	{
 		return QSize{32, 32};
 	}
-
-}
+	
+	
+}  // namespace
 
 
 
@@ -269,7 +272,7 @@ ColorDialog::ColorDialog(const Map& map, const MapColor& source_color, QWidget* 
 	layout->addWidget(color_preview_label, row, col); col++;
 	layout->addWidget(color_name_label, row, col, 1, 4);
 	row++; col = 0;
-	layout->addWidget(new QLabel(QApplication::translate("MapSymbolTranslation", "Text source:")), row, col, 1, 2); col+=2;
+	layout->addWidget(new QLabel(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Text source:")), row, col, 1, 2); col+=2;
 	layout->addWidget(language_combo, row, col); col++;
 	layout->addWidget(name_edit_button, row, col);
 	row++; col = 0;
@@ -511,8 +514,8 @@ void ColorDialog::reset()
 	updateWidgets();
 	
 	language_combo->clear();
-	language_combo->addItem(QApplication::translate("MapSymbolTranslation", "Map (%1)")
-	                        .arg(QApplication::translate("MapSymbolTranslation", "undefined language")));
+	language_combo->addItem(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Map (%1)")
+	                        .arg(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "undefined language")));
 	auto name = color.getName();
 	auto display_name = map.raw_translation(name);
 	if (display_name.isEmpty())
@@ -527,10 +530,10 @@ void ColorDialog::reset()
 		auto language = TranslationUtil::languageFromSettings(QSettings());
 		if (!language.isValid())
 		{
-			language.displayName = QApplication::translate("MapSymbolTranslation", "undefined language");
+			language.displayName = QApplication::translate("OpenOrienteering::MapSymbolTranslation", "undefined language");
 		}
 
-		language_combo->addItem(QApplication::translate("MapSymbolTranslation", "Translation (%1)").arg(language.displayName));
+		language_combo->addItem(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Translation (%1)").arg(language.displayName));
 		language_combo->setCurrentIndex(1);
 		language_combo->setEnabled(true);
 		name_edit_button->setEnabled(true);
@@ -582,14 +585,14 @@ void ColorDialog::editClicked()
 	auto question = QString{};
 	if (language_combo->currentIndex() == 1)
 	{
-		question = QApplication::translate("MapSymbolTranslation",
+		question = QApplication::translate("OpenOrienteering::MapSymbolTranslation",
 		             "Before editing, the stored text will be "
 		             "replaced with the current translation. "
 		             "Do you want to continue?");
 	}
 	else
 	{
-		question = QApplication::translate("MapSymbolTranslation",
+		question = QApplication::translate("OpenOrienteering::MapSymbolTranslation",
 		             "After modifying the stored text, "
 		             "the translation may no longer be found. "
 		             "Do you want to continue?");
@@ -790,3 +793,5 @@ void ColorDialog::rgbValueChanged()
 	}
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/color_dialog.h
+++ b/src/gui/color_dialog.h
@@ -41,8 +41,11 @@ class QRadioButton;
 class QTabWidget;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class ColorDropDown;
 class Map;
+
 
 /**
  * A dialog for editing a single map color.
@@ -52,7 +55,7 @@ class ColorDialog: public QDialog
 Q_OBJECT
 public:
 	/** Constructs a new dialog for the given map and color. */
-	ColorDialog(const Map& map, const MapColor& source_color, QWidget* parent = nullptr, Qt::WindowFlags f = {});
+	ColorDialog(const Map& map, const MapColor& source_color, QWidget* parent = nullptr, Qt::WindowFlags f = 0);
 	
 	~ColorDialog() override;
 	
@@ -150,5 +153,8 @@ protected:
 	int stretch_col0;
 	QWidget* stretch;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/configure_grid_dialog.cpp
+++ b/src/gui/configure_grid_dialog.cpp
@@ -50,6 +50,9 @@
 #include "gui/util_gui.h"
 #include "util/backports.h"  // IWYU pragma: keep
 
+
+namespace OpenOrienteering {
+
 class MapCoordF;
 
 
@@ -272,3 +275,6 @@ void ConfigureGridDialog::showHelp()
 {
 	Util::showHelp(this, "grid.html");
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/configure_grid_dialog.h
+++ b/src/gui/configure_grid_dialog.h
@@ -36,7 +36,10 @@ class QPushButton;
 class QRadioButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
+
 
 class ConfigureGridDialog : public QDialog
 {
@@ -92,5 +95,8 @@ inline bool ConfigureGridDialog::gridVisible() const
 {
 	return grid_visible;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/file_dialog.cpp
+++ b/src/gui/file_dialog.cpp
@@ -56,6 +56,8 @@ namespace
 
 
 
+namespace OpenOrienteering {
+
 bool FileDialog::needUpperCaseExtensions()
 {
 #if QTBUG_51712_QUIRK_ENABLED
@@ -120,3 +122,6 @@ void FileDialog::adjustParameters(QString& filter, QFileDialog::Options& options
 	if (has_long_filters)
 		options |= QFileDialog::HideNameFilterDetails;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/file_dialog.h
+++ b/src/gui/file_dialog.h
@@ -27,11 +27,13 @@
 class QWidget;
 
 
+namespace OpenOrienteering {
+
 /**
  * A collection of file dialog utility functions.
  */
-namespace FileDialog
-{
+namespace FileDialog {
+	
 	/**
 	 * Returns true if upper case extensions have to be added explicitly
 	 * to filters in file dialogs.
@@ -84,6 +86,10 @@ namespace FileDialog
 		return QFileDialog::getSaveFileName(parent, caption, dir, filter, selected_filter, options);
 	}
 	
-}
+	
+}  // namespace FileDialog
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -74,6 +74,8 @@
 #include "util/scoped_signals_blocker.h"
 
 
+namespace OpenOrienteering {
+
 // ### GeoreferencingDialog ###
 
 GeoreferencingDialog::GeoreferencingDialog(MapEditorController* controller, const Georeferencing* initial, bool allow_no_georeferencing)
@@ -765,3 +767,6 @@ const QCursor& GeoreferencingTool::getCursor() const
 	static auto const cursor = scaledToScreen(QCursor{ QPixmap{ QString::fromLatin1(":/images/cursor-crosshair.png") }, 11, 11 });
 	return cursor;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/georeferencing_dialog.h
+++ b/src/gui/georeferencing_dialog.h
@@ -40,6 +40,8 @@ class QRadioButton;
 class QNetworkReply;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class CRSSelector;
 class Georeferencing;
 class Map;
@@ -326,5 +328,6 @@ private:
 };
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/home_screen_controller.cpp
+++ b/src/gui/home_screen_controller.cpp
@@ -28,6 +28,8 @@
 #include "gui/widgets/home_screen_widget.h"
 
 
+namespace OpenOrienteering {
+
 HomeScreenController::HomeScreenController()
 : widget(nullptr)
 , current_tip(-1)
@@ -156,3 +158,6 @@ void HomeScreenController::goToTip(int index)
 		widget->setTipOfTheDay(tips[current_tip]);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/home_screen_controller.h
+++ b/src/gui/home_screen_controller.h
@@ -25,8 +25,11 @@
 
 #include <QObject>
 
+namespace OpenOrienteering {
+
 class AbstractHomeScreenWidget;
 class MainWindow;
+
 
 /**
  * The controller of the OpenOrienteering Mapper home screen.
@@ -78,5 +81,8 @@ protected:
 	/** The index of the tip-of-the-day currently displayed. */
 	int current_tip;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -64,6 +64,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 constexpr int MainWindow::max_recent_files;
 
 int MainWindow::num_open_files = 0;
@@ -1195,3 +1197,6 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 	
 	return false;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -41,6 +41,8 @@ class QStackedWidget;
 class QToolBar;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MainWindowController;
 
 
@@ -566,5 +568,8 @@ bool MainWindow::homeScreenDisabled() const
 {
 	return homescreen_disabled;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/main_window_controller.cpp
+++ b/src/gui/main_window_controller.cpp
@@ -28,6 +28,8 @@
 #include "gui/map/map_editor.h"
 
 
+namespace OpenOrienteering {
+
 MainWindowController::~MainWindowController() = default;
 
 
@@ -81,3 +83,6 @@ MainWindowController* MainWindowController::controllerForFile(const QString& fil
 	
 	return nullptr;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/main_window_controller.h
+++ b/src/gui/main_window_controller.h
@@ -28,6 +28,8 @@
 class QKeyEvent;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MainWindow;
 class FileFormat;
 
@@ -130,5 +132,8 @@ MainWindow* MainWindowController::getWindow() const
 {
 	return window;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_dialog_rotate.cpp
+++ b/src/gui/map/map_dialog_rotate.cpp
@@ -39,6 +39,8 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
+
 RotateMapDialog::RotateMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint), map(map)
 {
 	setWindowTitle(tr("Rotate map"));
@@ -162,3 +164,6 @@ void RotateMapDialog::okClicked()
 	map->rotateMap(rotation, center, adjust_georeferencing_check->isChecked(), adjust_declination_check->isChecked(), adjust_templates_check->isChecked());
 	accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_dialog_rotate.h
+++ b/src/gui/map/map_dialog_rotate.h
@@ -29,6 +29,8 @@ class QCheckBox;
 class QRadioButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 
 
@@ -69,5 +71,8 @@ private:
 	
 	Map* map;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_dialog_scale.cpp
+++ b/src/gui/map/map_dialog_scale.cpp
@@ -33,6 +33,9 @@
 #include "templates/template.h"
 #include "gui/util_gui.h"
 
+
+namespace OpenOrienteering {
+
 ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint), map(map)
 {
 	setWindowTitle(tr("Change map scale"));
@@ -139,3 +142,6 @@ void ScaleMapDialog::okClicked()
 	map->changeScale(scale, center, adjust_symbols_check->isChecked(), adjust_objects_check->isChecked(), adjust_georeferencing_check->isChecked(), adjust_templates_check->isChecked());
 	accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_dialog_scale.h
+++ b/src/gui/map/map_dialog_scale.h
@@ -31,7 +31,10 @@ class QRadioButton;
 class QDoubleSpinBox;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
+
 
 /**
  * Dialog for scaling the whole map.
@@ -63,5 +66,8 @@ private:
 	
 	Map* map;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -165,8 +165,10 @@
 #include "util/backports.h" // IWYU pragma: keep
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	/**
 	 * Creates a partial, resizable widget overlay over the main window.
 	 * 
@@ -212,7 +214,8 @@ namespace
 		});
 	}
 	
-} // namespace
+	
+}  // namespace
 
 
 
@@ -224,7 +227,8 @@ QString OpenOrienteeringObjects()
 	return QStringLiteral("openorienteering/objects");
 }
 
-}
+
+}  // namespace MimeType
 
 
 
@@ -859,7 +863,7 @@ void MapEditorController::createActions()
 	select_all_act = newAction("select-all", tr("Select all"), this, SLOT(selectAll()), nullptr, QString{}, "edit_menu.html");
 	select_nothing_act = newAction("select-nothing", tr("Select nothing"), this, SLOT(selectNothing()), nullptr, QString{}, "edit_menu.html");
 	invert_selection_act = newAction("invert-selection", tr("Invert selection"), this, SLOT(invertSelection()), nullptr, QString{}, "edit_menu.html");
-	select_by_current_symbol_act = newAction("select-by-symbol", QApplication::translate("SymbolRenderWidget", "Select all objects with selected symbols"), this, SLOT(selectByCurrentSymbols()), nullptr, QString{}, "edit_menu.html");
+	select_by_current_symbol_act = newAction("select-by-symbol", QApplication::translate("OpenOrienteering::SymbolRenderWidget", "Select all objects with selected symbols"), this, SLOT(selectByCurrentSymbols()), nullptr, QString{}, "edit_menu.html");
 	find_feature.reset(new MapFindFeature(*this));
 	
 	clear_undo_redo_history_act = newAction("clearundoredohistory", tr("Clear undo / redo history"), this, SLOT(clearUndoRedoHistory()), nullptr, tr("Clear the undo / redo history to reduce map file size."), "edit_menu.html");
@@ -1279,7 +1283,7 @@ void MapEditorController::createMobileGUI()
 	
 	mobile_symbol_button_menu = new QMenu(window);
 	mobile_symbol_button_menu->addAction(QString{}); // reserved for symbol name
-	auto description_action = mobile_symbol_button_menu->addAction(QApplication::translate("SymbolPropertiesWidget", "Description"));
+	auto description_action = mobile_symbol_button_menu->addAction(QApplication::translate("OpenOrienteering::SymbolPropertiesWidget", "Description"));
 	connect(description_action, &QAction::triggered, [this]() {
 		auto symbol = symbol_widget->getSingleSelectedSymbol();
 		auto document = QString{ symbol->getNumberAsString() + QLatin1Char(' ')
@@ -1292,7 +1296,7 @@ void MapEditorController::createMobileGUI()
 		description_dialog.exec();
 	});
 	mobile_symbol_button_menu->addSeparator();
-	auto hide_symbol_action = mobile_symbol_button_menu->addAction(QApplication::translate("SymbolRenderWidget", "Hide objects with this symbol"));
+	auto hide_symbol_action = mobile_symbol_button_menu->addAction(QApplication::translate("OpenOrienteering::SymbolRenderWidget", "Hide objects with this symbol"));
 	hide_symbol_action->setCheckable(true);
 	connect(hide_symbol_action, &QAction::triggered, [this](bool value) {
 		auto symbol = symbol_widget->getSingleSelectedSymbol();
@@ -1303,7 +1307,7 @@ void MapEditorController::createMobileGUI()
 		map->setSymbolsDirty();
 		selectedSymbolsChanged();
 	});
-	auto protected_symbol_action = mobile_symbol_button_menu->addAction(QApplication::translate("SymbolRenderWidget", "Protect objects with this symbol"));
+	auto protected_symbol_action = mobile_symbol_button_menu->addAction(QApplication::translate("OpenOrienteering::SymbolRenderWidget", "Protect objects with this symbol"));
 	protected_symbol_action->setCheckable(true);
 	connect(protected_symbol_action, &QAction::triggered, [this](bool value) {
 		auto symbol = symbol_widget->getSingleSelectedSymbol();
@@ -3944,15 +3948,17 @@ bool MapEditorController::importMapFile(const QString& filename, bool show_error
 			QFile crt_file{ crt_filename };
 			if (!crt_file.open(QFile::ReadOnly))
 			{
-				QMessageBox::warning(window, Map::tr("Error"),
-				                     Map::tr("Cannot open file:\n%1\nfor reading.").arg(crt_filename));
+				QMessageBox::warning(window,
+				                     ::OpenOrienteering::Map::tr("Error"),
+				                     ::OpenOrienteering::Map::tr("Cannot open file:\n%1\nfor reading.").arg(crt_filename));
 				return false;
 			}
 			if (!ReplaceSymbolSetDialog::showDialogForCRT(window, imported_map, *map, crt_file))
 			{
-				auto choice = QMessageBox::question(window, Map::tr("Import..."),
-				                                    Map::tr("Symbol replacement was canceled.\n"
-				                                            "Import the data anyway?"),
+				auto choice = QMessageBox::question(window,
+				                                    ::OpenOrienteering::Map::tr("Import..."),
+				                                    ::OpenOrienteering::Map::tr("Symbol replacement was canceled.\n"
+				                                                                "Import the data anyway?"),
 				                                    QMessageBox::Yes | QMessageBox::No,
 				                                    QMessageBox::No);
 				if (choice == QMessageBox::No)
@@ -4051,3 +4057,6 @@ void MapEditorToolAction::triggeredImpl(bool checked)
 	else
 		setChecked(true);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -48,21 +48,23 @@ class QToolBar;
 class QToolButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class ActionGridBar;
 class CompassDisplay;
 class EditorDockWidget;
 class FileFormat;
-class GeoreferencingDialog;
-class MainWindow;
-class Map;
-class MapView;
-class MapWidget;
-class MapEditorActivity;
-class MapEditorTool;
-class MapFindFeature;
 class GPSDisplay;
 class GPSTemporaryMarkers;
 class GPSTrackRecorder;
+class GeoreferencingDialog;
+class MainWindow;
+class Map;
+class MapEditorActivity;
+class MapEditorTool;
+class MapFindFeature;
+class MapView;
+class MapWidget;
 class PrintWidget;
 class ReopenTemplateDialog;
 class Symbol;
@@ -782,5 +784,8 @@ Symbol* MapEditorController::activeSymbol() const
 {
 	return active_symbol;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_editor_activity.cpp
+++ b/src/gui/map/map_editor_activity.cpp
@@ -21,6 +21,8 @@
 #include "map_editor_activity.h"
 
 
+namespace OpenOrienteering {
+
 MapEditorActivity::~MapEditorActivity() = default;
 
 void MapEditorActivity::init()
@@ -33,3 +35,5 @@ void MapEditorActivity::draw(QPainter*, MapWidget*)
 	// nothing
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_editor_activity.h
+++ b/src/gui/map/map_editor_activity.h
@@ -25,6 +25,8 @@
 
 class QPainter;
 
+namespace OpenOrienteering {
+
 class MapWidget;
 
 
@@ -89,5 +91,7 @@ void* MapEditorActivity::getActivityObject() const
 	return activity_object;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_editor_p.h
+++ b/src/gui/map/map_editor_p.h
@@ -33,6 +33,8 @@ class QSizeGrip; // IWYU pragma: keep
 class QString;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class Template;
 
@@ -78,5 +80,8 @@ signals:
 private slots:
 	void triggeredImpl(bool checked);
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -43,8 +43,10 @@
 #include "gui/map/map_editor.h"
 #include "gui/widgets/tag_select_widget.h"
 
-class Object;
 
+namespace OpenOrienteering {
+
+class Object;
 
 MapFindFeature::MapFindFeature(MapEditorController& controller)
 : QObject{nullptr}
@@ -172,7 +174,7 @@ void MapFindFeature::findNext()
 	if (!query)
 	{
 		if (auto window = controller.getWindow())
-			window->showStatusBarMessage(TagSelectWidget::tr("Invalid query"), 2000);
+			window->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("Invalid query"), 2000);
 		return;
 	}
 		
@@ -218,7 +220,7 @@ void MapFindFeature::findAll()
 	auto query = makeQuery();
 	if (!query)
 	{
-		controller.getWindow()->showStatusBarMessage(TagSelectWidget::tr("Invalid query"), 2000);
+		controller.getWindow()->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("Invalid query"), 2000);
 		return;
 	}
 	
@@ -226,7 +228,7 @@ void MapFindFeature::findAll()
 		map->addObjectToSelection(object, false);
 	}, std::cref(query));
 	map->emitSelectionChanged();
-	controller.getWindow()->showStatusBarMessage(TagSelectWidget::tr("%n object(s) selected", nullptr, map->getNumSelectedObjects()), 2000);
+	controller.getWindow()->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("%n object(s) selected", nullptr, map->getNumSelectedObjects()), 2000);
 	
 	if (!map->selectedObjects().empty())
 		controller.setEditTool();
@@ -257,3 +259,5 @@ void MapFindFeature::tagSelectorToggled(bool active)
 	}
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_find_feature.h
+++ b/src/gui/map/map_find_feature.h
@@ -30,6 +30,8 @@ class QStackedLayout;
 class QTextEdit;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class ObjectQuery;
 class TagSelectWidget;
@@ -81,5 +83,8 @@ private:
 	
 	Q_DISABLE_COPY(MapFindFeature)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/map_widget.cpp
+++ b/src/gui/map/map_widget.cpp
@@ -70,6 +70,8 @@ class QGesture;
 // IWYU pragma: no_forward_declare QPinchGesture
 
 
+namespace OpenOrienteering {
+
 MapWidget::MapWidget(bool show_help, bool force_antialiasing, QWidget* parent)
  : QWidget(parent)
  , view(nullptr)
@@ -1354,3 +1356,6 @@ void MapWidget::shiftCache(int sx, int sy, QPixmap& cache)
 		cache.scroll(sx, sy, cache.rect());
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/map_widget.h
+++ b/src/gui/map/map_widget.h
@@ -58,12 +58,15 @@ class QPixmap;
 class QResizeEvent;
 class QWheelEvent;
 
+namespace OpenOrienteering {
+
+class GPSDisplay;
+class GPSTemporaryMarkers;
 class MapEditorActivity;
 class MapEditorTool;
 class PieMenu;
 class TouchCursor;
-class GPSDisplay;
-class GPSTemporaryMarkers;
+
 
 /**
  * QWidget for displaying a map. Needs a pointer to a MapView which defines
@@ -588,5 +591,8 @@ MapWidget::CoordsType MapWidget::getCoordsDisplay() const
 {
 	return coords_type;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/map/new_map_dialog.cpp
+++ b/src/gui/map/new_map_dialog.cpp
@@ -58,6 +58,8 @@
 // IWYU pragma: no_forward_declare QVBoxLayout
 
 
+namespace OpenOrienteering {
+
 NewMapDialog::NewMapDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
 	this->setWhatsThis(Util::makeWhatThis("new_map.html"));
@@ -310,3 +312,6 @@ void NewMapDialog::loadSymbolSetDir(const QDir& symbol_set_dir)
 		item->second.append(symbol_set_files);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/map/new_map_dialog.h
+++ b/src/gui/map/new_map_dialog.h
@@ -37,6 +37,9 @@ class QListWidgetItem;
 class QPushButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
+
 /**
  * Dialog for creating a new map.
  * Shows scale and symbol set selection.
@@ -130,4 +133,6 @@ private:
 	QPushButton* create_button;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/gui/modifier_key.cpp
+++ b/src/gui/modifier_key.cpp
@@ -24,6 +24,8 @@
 #include <QKeySequence>
 
 
+namespace OpenOrienteering {
+
 ModifierKey::ModifierKey(int key)
  : native_text { QKeySequence((int)key).toString(QKeySequence::NativeText) }
 {
@@ -99,3 +101,5 @@ const ModifierKey& ModifierKey::escape()
 	return key;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/modifier_key.h
+++ b/src/gui/modifier_key.h
@@ -23,6 +23,9 @@
 #include <Qt>
 #include <QString>
 
+namespace OpenOrienteering {
+
+
 /**
  * A class that helps to deal efficiently with platform and localization issues
  * of modifier keys.
@@ -109,5 +112,7 @@ ModifierKey::operator QString() const
 	return native_text;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/print_progress_dialog.cpp
+++ b/src/gui/print_progress_dialog.cpp
@@ -29,6 +29,8 @@
 #include "core/map_printer.h"
 
 
+namespace OpenOrienteering {
+
 PrintProgressDialog::PrintProgressDialog(MapPrinter* map_printer, QWidget* parent, Qt::WindowFlags f)
  : QProgressDialog(parent, f)
  , map_printer(map_printer)
@@ -70,5 +72,8 @@ void PrintProgressDialog::setProgress(int value, const QString& status)
 	
 	QApplication::processEvents(); // Drawing and Cancel events
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/print_progress_dialog.h
+++ b/src/gui/print_progress_dialog.h
@@ -31,7 +31,10 @@
 class QPrinter;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapPrinter;
+
 
 /**
  * PrintProgressDialog is a variation of QProgressDialog to be used with MapPrinter.
@@ -84,5 +87,8 @@ private:
 };
 
 #endif
+
+
+}  // namespace OpenOrienteering
 
 #endif // QT_PRINTSUPPORT_LIB

--- a/src/gui/print_tool.cpp
+++ b/src/gui/print_tool.cpp
@@ -32,6 +32,8 @@
 #include "gui/map/map_widget.h"
 
 
+namespace OpenOrienteering {
+
 PrintTool::PrintTool(MapEditorController* editor, MapPrinter* map_printer)
 : MapEditorTool { editor, Other, nullptr }
 , map_printer   { map_printer }
@@ -375,3 +377,6 @@ void PrintTool::mouseMoved(MapCoordF mouse_pos_map, MapWidget* widget)
 }
 
 #endif // QT_PRINTSUPPORT_LIB
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/print_tool.h
+++ b/src/gui/print_tool.h
@@ -34,6 +34,8 @@ class QCursor;
 class QMouseEvent;
 class QPainter;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapPrinter;
 class MapWidget;
@@ -122,5 +124,8 @@ protected:
 };
 
 #endif // QT_PRINTSUPPORT_LIB
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_PRINT_TOOL_H

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -92,8 +92,10 @@
 #include "util/scoped_signals_blocker.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	QToolButton* createPrintModeButton(const QIcon& icon, const QString& label, QWidget* parent = nullptr)
 	{
 		static const QSize icon_size(48,48);
@@ -106,7 +108,10 @@ namespace
 		button->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 		return button;
 	}
-}
+	
+	
+}  // namespace
+
 
 //### PrintWidget ###
 
@@ -1349,3 +1354,6 @@ bool PrintWidget::checkForEmptyMap()
 }
 
 #endif
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/print_widget.h
+++ b/src/gui/print_widget.h
@@ -50,13 +50,15 @@ class QScrollArea;
 class QSpinBox;
 class QToolButton;
 
+namespace OpenOrienteering {
+
+class MainWindow;
 class Map;
 class MapEditorController;
 class MapPrinter;
 class MapPrinterOptions;
 class MapPrinterPageFormat;
 class MapView;
-class MainWindow;
 class PrintTool;
 
 
@@ -326,8 +328,14 @@ private:
 	bool active;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(PrintWidget::TaskFlags)
 
 #endif
+
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::PrintWidget::TaskFlags)
+
 
 #endif

--- a/src/gui/select_crs_dialog.cpp
+++ b/src/gui/select_crs_dialog.cpp
@@ -36,6 +36,8 @@
 #include "gui/widgets/crs_selector.h"
 
 
+namespace OpenOrienteering {
+
 namespace {
 
 enum SpecialCRS {
@@ -44,7 +46,10 @@ enum SpecialCRS {
 	Geographic = 3
 };
 
-}
+
+}  // namespace
+
+
 
 SelectCRSDialog::SelectCRSDialog(
         const Georeferencing& georef,
@@ -85,7 +90,7 @@ SelectCRSDialog::SelectCRSDialog(
 		form_layout->addRow(new QLabel(description));
 		form_layout->addItem(Util::SpacerItem::create(this));
 	}
-	form_layout->addRow(QCoreApplication::translate("GeoreferencingDialog", "&Coordinate reference system:"), crs_selector);
+	form_layout->addRow(QCoreApplication::translate("OpenOrienteering::GeoreferencingDialog", "&Coordinate reference system:"), crs_selector);
 	form_layout->addRow(tr("Status:"), status_label);
 	form_layout->addItem(Util::SpacerItem::create(this));
 	crs_selector->setDialogLayout(form_layout);
@@ -135,3 +140,6 @@ void SelectCRSDialog::updateWidgets()
 	else
 		status_label->setText(QLatin1String("<b style=\"color:red\">") + georef.getErrorText() + QLatin1String("</b>"));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/select_crs_dialog.h
+++ b/src/gui/select_crs_dialog.h
@@ -31,6 +31,8 @@ class QDialogButtonBox;
 class QLabel;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class CRSSelector;
 class Georeferencing;
 
@@ -87,6 +89,11 @@ private:
 	QDialogButtonBox* button_box;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(SelectCRSDialog::GeorefAlternatives)
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::SelectCRSDialog::GeorefAlternatives)
+
 
 #endif

--- a/src/gui/settings_dialog.cpp
+++ b/src/gui/settings_dialog.cpp
@@ -52,6 +52,8 @@
 #endif
 
 
+namespace OpenOrienteering {
+
 SettingsDialog::SettingsDialog(QWidget* parent)
  : QDialog        { parent }
  , tab_widget     { nullptr }
@@ -224,3 +226,6 @@ void SettingsDialog::buttonPressed(QAbstractButton* button)
 		qDebug("%s: Unexpected button '0x%x'", Q_FUNC_INFO, id);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/settings_dialog.h
+++ b/src/gui/settings_dialog.h
@@ -32,6 +32,8 @@ class QStackedWidget;
 class QTabWidget;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class SettingsPage;
 
 
@@ -98,5 +100,8 @@ private:
 	 */
 	QDialogButtonBox* button_box;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/area_symbol_settings.cpp
+++ b/src/gui/symbols/area_symbol_settings.cpp
@@ -59,6 +59,8 @@
 #include "util/scoped_signals_blocker.h"
 
 
+namespace OpenOrienteering {
+
 // ### AreaSymbol ###
 
 SymbolPropertiesWidget* AreaSymbol::createPropertiesWidget(SymbolSettingDialog* dialog)
@@ -570,3 +572,6 @@ void AreaSymbolSettings::patternPointDistChanged(double value)
 	active_pattern->point_distance = qRound(1000.0 * value);
 	emit propertiesModified();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/area_symbol_settings.h
+++ b/src/gui/symbols/area_symbol_settings.h
@@ -37,6 +37,8 @@ class QListWidget;
 class QPushButton;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class ColorDropDown;
 class Map;
 class MapEditorController;
@@ -115,5 +117,8 @@ private:
 	
 	QComboBox*      pattern_clipping_edit;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/combined_symbol_settings.cpp
+++ b/src/gui/symbols/combined_symbol_settings.cpp
@@ -50,6 +50,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 // ### CombinedSymbol ###
 
 SymbolPropertiesWidget* CombinedSymbol::createPropertiesWidget(SymbolSettingDialog* dialog)
@@ -274,3 +276,6 @@ void CombinedSymbolSettings::showEditDialog(int index)
 		emit propertiesModified();
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/combined_symbol_settings.h
+++ b/src/gui/symbols/combined_symbol_settings.h
@@ -30,6 +30,8 @@
 
 class QSpinBox;
 
+namespace OpenOrienteering {
+
 class CombinedSymbol;
 class Symbol;
 class SymbolSettingDialog;
@@ -64,5 +66,8 @@ private:
 	struct Widgets;
 	std::vector<Widgets> widgets;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/line_symbol_settings.cpp
+++ b/src/gui/symbols/line_symbol_settings.cpp
@@ -50,6 +50,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 // ### LineSymbol ###
 
 SymbolPropertiesWidget* LineSymbol::createPropertiesWidget(SymbolSettingDialog* dialog)
@@ -784,3 +786,6 @@ void LineSymbolSettings::reset(Symbol* symbol)
 	setUpdatesEnabled(true);
 	old_symbol->cleanupPointSymbols();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/line_symbol_settings.h
+++ b/src/gui/symbols/line_symbol_settings.h
@@ -37,6 +37,8 @@ class QScrollArea;
 class QSpinBox;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class ColorDropDown;
 class LineSymbol;
 struct LineSymbolBorder;
@@ -186,5 +188,8 @@ private:
 	QScrollArea* scroll_area;
 	QWidget* widget_to_ensure_visible;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -82,6 +82,8 @@
 // IWYU pragma: no_forward_declare QVBoxLayout
 
 
+namespace OpenOrienteering {
+
 PointSymbolEditorWidget::PointSymbolEditorWidget(MapEditorController* controller, PointSymbol* symbol, qreal offset_y, bool permanent_preview, QWidget* parent)
 : QWidget(parent)
 , symbol(symbol)
@@ -1050,3 +1052,6 @@ void PointSymbolEditorActivity::draw(QPainter* painter, MapWidget* map_widget)
 	painter->drawLine(midpoint + QPoint(0, -cross_radius), midpoint + QPoint(0, cross_radius));
 	painter->drawLine(midpoint + QPoint(-cross_radius, 0), midpoint + QPoint(cross_radius, 0));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/point_symbol_editor_widget.h
+++ b/src/gui/symbols/point_symbol_editor_widget.h
@@ -43,6 +43,8 @@ class QPushButton;
 class QStackedWidget;
 class QTableWidget;
 
+namespace OpenOrienteering {
+
 class ColorDropDown;
 class Map;
 class MapEditorController;
@@ -52,6 +54,7 @@ class PointObject;
 class PointSymbol;
 class PointSymbolEditorActivity;
 class Symbol;
+
 
 /** A Widget for editing point symbol definitions */
 class PointSymbolEditorWidget : public QWidget
@@ -219,5 +222,8 @@ private:
 	
 	static const int cross_radius; // NOTE: This could be a configuration option.
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/point_symbol_settings.cpp
+++ b/src/gui/symbols/point_symbol_settings.cpp
@@ -32,6 +32,8 @@
 #include "gui/symbols/symbol_setting_dialog.h"
 
 
+namespace OpenOrienteering {
+
 // ### PointSymbol ###
 
 SymbolPropertiesWidget* PointSymbol::createPropertiesWidget(SymbolSettingDialog* dialog)
@@ -90,3 +92,6 @@ void PointSymbolSettings::tabChanged(int /*index*/)
 {
 	symbol_editor->setEditorActive( currentWidget()==point_tab );
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/point_symbol_settings.h
+++ b/src/gui/symbols/point_symbol_settings.h
@@ -29,6 +29,8 @@
 class QVBoxLayout;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class PointSymbol;
 class PointSymbolEditorWidget;
 class Symbol;
@@ -54,5 +56,8 @@ private:
 	QWidget* point_tab;
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -83,6 +83,8 @@
 // IWYU pragma: no_forward_declare QTableWidgetItem
 
 
+namespace OpenOrienteering {
+
 ReplaceSymbolSetDialog::ReplaceSymbolSetDialog(QWidget* parent, Map& object_map, const Map& symbol_set, SymbolRuleSet& replacements, Mode mode)
  : QDialog{ parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint }
  , object_map{ object_map }
@@ -282,7 +284,7 @@ void ReplaceSymbolSetDialog::openCrtFile(const QString& path)
 					stream.setStatus(QTextStream::ReadCorruptData);
 					auto error_msg = tr("There are multiple replacements for symbol %1.")
 					                 .arg(item.query.symbolOperand()->getNumberAsString());
-					QMessageBox::warning(this, Map::tr("Error"),
+					QMessageBox::warning(this, ::OpenOrienteering::Map::tr("Error"),
 					  tr("Cannot open file:\n%1\n\n%2").arg(path, error_msg) );
 					return;
 				}
@@ -340,7 +342,7 @@ bool ReplaceSymbolSetDialog::saveCrtFile()
 			return true;
 		}
 		/// \todo Reused translation, consider generalized context
-		QMessageBox::warning(this, Map::tr("Error"),
+		QMessageBox::warning(this, ::OpenOrienteering::Map::tr("Error"),
 		                     tr("Cannot save file:\n%1\n\n%2")
 		                     .arg(path, crt_file.errorString()) );
 	}
@@ -420,27 +422,27 @@ void ReplaceSymbolSetDialog::updateMappingTable()
 				{
 				case Symbol::Area:
 					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
-					original_string = QGuiApplication::translate("SymbolRenderWidget", "Area");
+					original_string = QGuiApplication::translate("OpenOrienteering::SymbolRenderWidget", "Area");
 					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
 					break;
 				case Symbol::Combined:
 					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
-					original_string = QGuiApplication::translate("SymbolRenderWidget", "Combined");
+					original_string = QGuiApplication::translate("OpenOrienteering::SymbolRenderWidget", "Combined");
 					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
 					break;
 				case Symbol::Line:
 					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
-					original_string = QGuiApplication::translate("SymbolRenderWidget", "Line");
+					original_string = QGuiApplication::translate("OpenOrienteering::SymbolRenderWidget", "Line");
 					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
 					break;
 				case Symbol::Point:
 					original_icon = object_map.getUndefinedPoint()->getIcon(&object_map);
-					original_string = QGuiApplication::translate("SymbolRenderWidget", "Point");
+					original_string = QGuiApplication::translate("OpenOrienteering::SymbolRenderWidget", "Point");
 					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
 					break;
 				case Symbol::Text:
 					original_icon = object_map.getUndefinedText()->getIcon(&object_map);
-					original_string = QGuiApplication::translate("SymbolRenderWidget", "Text");
+					original_string = QGuiApplication::translate("OpenOrienteering::SymbolRenderWidget", "Text");
 					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
 					break;
 				case Symbol::AllSymbols:
@@ -702,3 +704,6 @@ QString ReplaceSymbolSetDialog::discoverCrtFile(const QString& source_id, const 
 #endif
 	return name;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/replace_symbol_set_dialog.h
+++ b/src/gui/symbols/replace_symbol_set_dialog.h
@@ -34,6 +34,8 @@ class QComboBox;
 class QTableWidget;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 class SymbolDropDownDelegate;
 class SymbolRuleSet;
@@ -115,5 +117,8 @@ private:
 	
 	Mode mode;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/symbol_properties_widget.cpp
+++ b/src/gui/symbols/symbol_properties_widget.cpp
@@ -49,6 +49,8 @@
 // IWYU pragma: no_forward_declare QLabel
 
 
+namespace OpenOrienteering {
+
 // ### Symbol ###
 
 SymbolPropertiesWidget* Symbol::createPropertiesWidget(SymbolSettingDialog* dialog)
@@ -78,7 +80,7 @@ SymbolPropertiesWidget::SymbolPropertiesWidget(Symbol* symbol, SymbolSettingDial
 		editor->setValidator(new QIntValidator(0, 99999, editor));
 	}
 	
-	auto language_label = new QLabel(QApplication::translate("MapSymbolTranslation", "Text source:"));
+	auto language_label = new QLabel(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Text source:"));
 	language_combo = new QComboBox();
 	edit_button = new QPushButton(tr("Edit"));
 	auto name_label = new QLabel(tr("Name:"));
@@ -211,14 +213,14 @@ void SymbolPropertiesWidget::editClicked()
 	auto question = QString{};
 	if (language_combo->currentIndex() == 1)
 	{
-		question = QApplication::translate("MapSymbolTranslation",
+		question = QApplication::translate("OpenOrienteering::MapSymbolTranslation",
 		             "Before editing, the stored text will be "
 		             "replaced with the current translation. "
 		             "Do you want to continue?");
 	}
 	else
 	{
-		question = QApplication::translate("MapSymbolTranslation",
+		question = QApplication::translate("OpenOrienteering::MapSymbolTranslation",
 		             "After modifying the stored text, "
 		             "the translation may no longer be found. "
 		             "Do you want to continue?");
@@ -320,8 +322,8 @@ void SymbolPropertiesWidget::reset(Symbol* symbol)
 	auto name_translated = dialog->getSourceMap()->raw_translation(symbol->getName());
 	auto description_translated = dialog->getSourceMap()->raw_translation(symbol->getDescription());
 	///: The language of the symbol name in the map file is not defined explicitly.
-	language_combo->addItem(QApplication::translate("MapSymbolTranslation", "Map (%1)").
-	                        arg(QApplication::translate("MapSymbolTranslation", "undefined language")));
+	language_combo->addItem(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Map (%1)").
+	                        arg(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "undefined language")));
 	if (name_translated.isEmpty() && description_translated.isEmpty())
 	{
 		language_combo->setEnabled(false);
@@ -334,10 +336,10 @@ void SymbolPropertiesWidget::reset(Symbol* symbol)
 		auto language = TranslationUtil::languageFromSettings(QSettings());
 		if (!language.isValid())
 		{
-			language.displayName = QApplication::translate("MapSymbolTranslation", "undefined language");
+			language.displayName = QApplication::translate("OpenOrienteering::MapSymbolTranslation", "undefined language");
 		}
 
-		language_combo->addItem(QApplication::translate("MapSymbolTranslation", "Translation (%1)").arg(language.displayName));
+		language_combo->addItem(QApplication::translate("OpenOrienteering::MapSymbolTranslation", "Translation (%1)").arg(language.displayName));
 		language_combo->setEnabled(true);
 		language_combo->setCurrentIndex(1);
 		edit_button->setEnabled(true);
@@ -347,3 +349,6 @@ void SymbolPropertiesWidget::reset(Symbol* symbol)
 	updateTextEdits();
 	helper_symbol_check->setChecked(symbol->isHelperSymbol());
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/symbol_properties_widget.h
+++ b/src/gui/symbols/symbol_properties_widget.h
@@ -36,6 +36,8 @@ class QPushButton;
 class QTextEdit;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Symbol;
 class SymbolSettingDialog;
 
@@ -104,5 +106,8 @@ protected:
 	QTextEdit* description_edit;
 	QCheckBox* helper_symbol_check;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_SYMBOL_PROPERTIES_WIDGET_H

--- a/src/gui/symbols/symbol_setting_dialog.cpp
+++ b/src/gui/symbols/symbol_setting_dialog.cpp
@@ -49,6 +49,8 @@
 #include "templates/template_image.h"
 
 
+namespace OpenOrienteering {
+
 SymbolSettingDialog::SymbolSettingDialog(const Symbol* source_symbol, Map* source_map, QWidget* parent)
 : QDialog(parent, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowMaximizeButtonHint)
 , source_map(source_map)
@@ -499,3 +501,6 @@ void SymbolSettingDialog::updateButtons()
 	ok_button->setEnabled(symbol_modified && symbol->getNumberComponent(0)>=0 && !symbol->getName().isEmpty());
 	reset_button->setEnabled(symbol_modified);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/symbol_setting_dialog.h
+++ b/src/gui/symbols/symbol_setting_dialog.h
@@ -33,6 +33,8 @@ class QPushButton;
 class QToolButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MainWindow;
 class Map;
 class MapEditorController;
@@ -40,6 +42,7 @@ class MapView;
 class Object;
 class Symbol;
 class SymbolPropertiesWidget;
+
 
 /** 
  * A dialog for editing symbol properties.
@@ -176,5 +179,8 @@ private:
 	
 	bool symbol_modified;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/symbols/text_symbol_settings.cpp
+++ b/src/gui/symbols/text_symbol_settings.cpp
@@ -57,6 +57,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 // ### DetermineFontSizeDialog ###
 
 /**
@@ -65,7 +67,7 @@
 class DetermineFontSizeDialog
 {
 public:
-	Q_DECLARE_TR_FUNCTIONS(DetermineFontSizeDialog)
+	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::DetermineFontSizeDialog)
 };
 
 
@@ -104,7 +106,7 @@ TextSymbolSettings::TextSymbolSettings(TextSymbol* symbol, SymbolSettingDialog* 
 	auto letter_size_layout = new QHBoxLayout();
 	letter_size_layout->setMargin(0);
 	
-	letter_size_layout->addWidget(new QLabel(DetermineFontSizeDialog::tr("Letter:")));
+	letter_size_layout->addWidget(new QLabel(::OpenOrienteering::DetermineFontSizeDialog::tr("Letter:")));
 	//: "A" is the default letter which is used for determining letter height.
 	letter_edit = new QLineEdit(DetermineFontSizeDialog::tr("A"));
 	letter_edit->setMaxLength(3);
@@ -112,7 +114,7 @@ TextSymbolSettings::TextSymbolSettings(TextSymbol* symbol, SymbolSettingDialog* 
 	
 	letter_size_layout->addSpacing(8);
 	
-	letter_size_layout->addWidget(new QLabel(DetermineFontSizeDialog::tr("Height:")));
+	letter_size_layout->addWidget(new QLabel(::OpenOrienteering::DetermineFontSizeDialog::tr("Height:")));
 	letter_size_edit = Util::SpinBox::create(2, 0.01, 10000.0, tr("mm"));
 	letter_size_layout->addWidget(letter_size_edit);
 	
@@ -598,3 +600,6 @@ void TextSymbolSettings::reset(Symbol* symbol)
 	updateFramingContents();
 	updateCompatibilityContents();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/symbols/text_symbol_settings.h
+++ b/src/gui/symbols/text_symbol_settings.h
@@ -38,6 +38,8 @@ class QPushButton;
 class QRadioButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class ColorDropDown;
 class Symbol;
 class SymbolSettingDialog;
@@ -126,5 +128,8 @@ private:
 	
 	bool react_to_changes;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/task_dialog.cpp
+++ b/src/gui/task_dialog.cpp
@@ -31,6 +31,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 TaskDialog::TaskDialog(QWidget* parent, const QString& title, const QString& text, QDialogButtonBox::StandardButtons buttons)
  : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
@@ -78,3 +80,6 @@ void TaskDialog::buttonClicked(QAbstractButton* button)
 	else
 		accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/task_dialog.h
+++ b/src/gui/task_dialog.h
@@ -27,12 +27,14 @@
 #include <QString>
 
 class QAbstractButton;
+class QCommandLinkButton;
 class QPushButton;
+class QSignalMapper;
+class QVBoxLayout;
 class QWidget;
 
-class QVBoxLayout;
-class QCommandLinkButton;
-class QSignalMapper;
+namespace OpenOrienteering {
+
 
 /**
  * Shows a dialog similar to a message box, but with the option to add
@@ -106,5 +108,8 @@ private:
 	QDialogButtonBox* button_box;
 	QSignalMapper* signal_mapper;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/text_browser_dialog.cpp
+++ b/src/gui/text_browser_dialog.cpp
@@ -32,6 +32,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 TextBrowserDialog::TextBrowserDialog(QWidget* parent)
 : QDialog(parent)
 , text_browser(new TextBrowser())
@@ -140,3 +142,6 @@ void TextBrowserDialog::highlighted(const QString& link)
 		QToolTip::showText(tooltip_pos, link, this, {});
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/text_browser_dialog.h
+++ b/src/gui/text_browser_dialog.h
@@ -32,6 +32,8 @@ class QTextBrowser;
 class QUrl;
 
 
+namespace OpenOrienteering {
+
 /**
  * @brief A dialog for basic browsing of HTML pages.
  */
@@ -81,5 +83,8 @@ protected:
 	 */
 	QTextBrowser* const text_browser;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/touch_cursor.cpp
+++ b/src/gui/touch_cursor.cpp
@@ -28,6 +28,8 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
+
 // TODO: convert these to settings
 const float touch_pos_offset_mm = 25;
 const float control_ring_radius_mm = 9.5f;
@@ -214,3 +216,6 @@ float TouchCursor::standardCursorRadiusPx() const
 {
 	return Util::mmToPixelLogical(1.5f);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/touch_cursor.h
+++ b/src/gui/touch_cursor.h
@@ -28,6 +28,8 @@
 class QMouseEvent;
 class QPainter;
 
+namespace OpenOrienteering {
+
 class MapWidget;
 
 
@@ -103,5 +105,8 @@ private:
 	QPoint last_touch_pos;
 	MapWidget* map_widget;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/util_gui.cpp
+++ b/src/gui/util_gui.cpp
@@ -54,6 +54,8 @@
 #include "gui/text_browser_dialog.h" // IWYU pragma: keep
 
 
+namespace OpenOrienteering {
+
 DoubleValidator::DoubleValidator(double bottom, double top, QObject* parent, int decimals)
 : QDoubleValidator(bottom, top, decimals, parent)
 {
@@ -75,8 +77,8 @@ QValidator::State DoubleValidator::validate(QString& input, int& pos) const
 
 
 
-namespace Util
-{
+namespace Util {
+	
 	// Implementation moved to settings.cpp
 	qreal mmToPixelPhysical(qreal millimeters);
 	
@@ -132,7 +134,7 @@ namespace Util
 			auto compiled_help = QFileInfo{ QString::fromUtf8("doc:Mapper " APP_VERSION " Manual.qch") };
 			if (!help_collection.exists() || !compiled_help.exists())
 			{
-				QMessageBox::warning(dialog_parent, QApplication::translate("Util", "Error"), QApplication::translate("Util", "Failed to locate the help files."));
+				QMessageBox::warning(dialog_parent, QApplication::translate("OpenOrienteering::Util", "Error"), QApplication::translate("OpenOrienteering::Util", "Failed to locate the help files."));
 				return;
 			}
 			
@@ -146,7 +148,7 @@ namespace Util
 				assistant_path = QStandardPaths::findExecutable(assistant);
 			if (assistant_path.isEmpty())
 			{
-				QMessageBox::warning(dialog_parent, QApplication::translate("Util", "Error"), QApplication::translate("Util", "Failed to locate the help browser (\"Qt Assistant\")."));
+				QMessageBox::warning(dialog_parent, QApplication::translate("OpenOrienteering::Util", "Error"), QApplication::translate("OpenOrienteering::Util", "Failed to locate the help browser (\"Qt Assistant\")."));
 				return;
 			}
 			
@@ -180,8 +182,8 @@ namespace Util
 			{
 				QMessageBox msg_box;
 				msg_box.setIcon(QMessageBox::Warning);
-				msg_box.setWindowTitle(QApplication::translate("Util", "Error"));
-				msg_box.setText(QApplication::translate("Util", "Failed to launch the help browser (\"Qt Assistant\")."));
+				msg_box.setWindowTitle(QApplication::translate("OpenOrienteering::Util", "Error"));
+				msg_box.setText(QApplication::translate("OpenOrienteering::Util", "Failed to launch the help browser (\"Qt Assistant\")."));
 				msg_box.setStandardButtons(QMessageBox::Ok);
 				auto details = assistant_process.readAllStandardError();
 				if (! details.isEmpty())
@@ -199,19 +201,19 @@ namespace Util
 	{
 		//: This "See more" is displayed as a link to the manual in What's-this tooltips.
 		return QStringLiteral("<a href=\"%1\">%2</a>").arg(
-				 QString::fromLatin1(reference_latin1), QApplication::translate("Util", "See more...") );
+				 QString::fromLatin1(reference_latin1), QApplication::translate("OpenOrienteering::Util", "See more...") );
 	}
 	
 	
 	
 	QString InputProperties<MapCoordF>::unit()
 	{
-		return QCoreApplication::translate("UnitOfMeasurement", "mm", "millimeters");
+		return QCoreApplication::translate("OpenOrienteering::UnitOfMeasurement", "mm", "millimeters");
 	}
 	
 	QString InputProperties<RealMeters>::unit()
 	{
-		return QCoreApplication::translate("UnitOfMeasurement", "m", "meters");
+		return QCoreApplication::translate("OpenOrienteering::UnitOfMeasurement", "m", "meters");
 	}
 	
 	
@@ -341,5 +343,9 @@ namespace Util
 		}
 		return maybe_markup;
 	}
+
 	
-}
+}  // namespace Util
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/util_gui.h
+++ b/src/gui/util_gui.h
@@ -34,6 +34,8 @@ class QSpacerItem;
 class QSpinBox;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapCoordF;
 
 
@@ -316,4 +318,6 @@ namespace Util
 	
 }
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/gui/widgets/action_grid_bar.cpp
+++ b/src/gui/widgets/action_grid_bar.cpp
@@ -30,6 +30,9 @@
 #include "settings.h"
 #include "gui/util_gui.h"
 
+
+namespace OpenOrienteering {
+
 ActionGridBar::ActionGridBar(Direction direction, int rows, QWidget* parent)
 : QWidget(parent)
 {
@@ -266,3 +269,6 @@ void ActionGridBar::resizeEvent(QResizeEvent* event)
 	
 	event->accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/action_grid_bar.h
+++ b/src/gui/widgets/action_grid_bar.h
@@ -33,6 +33,8 @@ class QResizeEvent;
 class QToolButton;
 
 
+namespace OpenOrienteering {
+
 /**
  * A toolbar with a grid layout, whose button size depends on the ppi.
  */
@@ -121,4 +123,6 @@ protected:
 	std::vector< ActionGridBar* > include_overflow_from_list;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/gui/widgets/color_dropdown.cpp
+++ b/src/gui/widgets/color_dropdown.cpp
@@ -32,6 +32,8 @@
 #include "core/map_color.h"
 
 
+namespace OpenOrienteering {
+
 ColorDropDown::ColorDropDown(const Map* map, const MapColor* initial_color, bool spot_colors_only, QWidget* parent)
 : QComboBox(parent)
 , map(map)
@@ -167,3 +169,6 @@ void ColorDropDown::onColorDeleted(int, const MapColor* color)
 {
 	removeColor(color);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/color_dropdown.h
+++ b/src/gui/widgets/color_dropdown.h
@@ -27,6 +27,8 @@
 
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapColor;
 
@@ -70,5 +72,8 @@ protected:
 	const Map* map;
 	const bool spot_colors_only;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -62,6 +62,8 @@
 // IWYU pragma: no_forward_declare QTableWidgetItem
 
 
+namespace OpenOrienteering {
+
 ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 : QWidget(parent)
 , map(map)
@@ -108,7 +110,7 @@ ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 	up_down_layout->addWidget(move_down_button);
 	
 	// TODO: In Mapper >= 0.6, switch to ColorWidget (or generic) translation context.
-	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")), QApplication::translate("MapEditorController", "&Edit").remove(QLatin1Char('&')));
+	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")), QApplication::translate("OpenOrienteering::MapEditorController", "&Edit").remove(QLatin1Char('&')));
 	edit_button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 	
 	auto help_button = newToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
@@ -499,3 +501,5 @@ void ColorListWidget::updateRow(int row)
 	react_to_changes = true;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/color_list_widget.h
+++ b/src/gui/widgets/color_list_widget.h
@@ -32,6 +32,8 @@ class QShowEvent;
 class QTableWidget;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class MainWindow;
 class Map;
 class MapColor;
@@ -92,5 +94,8 @@ private:
 	MainWindow* const window;
 	bool react_to_changes;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/compass_display.cpp
+++ b/src/gui/widgets/compass_display.cpp
@@ -26,6 +26,8 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
+
 CompassDisplay::CompassDisplay(QWidget* parent)
  : QWidget(parent)
  , azimuth(qSNaN())
@@ -114,3 +116,6 @@ void CompassDisplay::paintEvent(QPaintEvent*)
 		painter.drawLine(line);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/compass_display.h
+++ b/src/gui/widgets/compass_display.h
@@ -32,6 +32,8 @@ class QHideEvent;
 class QPaintEvent;
 class QShowEvent;
 
+namespace OpenOrienteering {
+
 
 /**
  * A widget which displays a compass.
@@ -73,5 +75,8 @@ protected:
 	qreal azimuth;
 	QTime last_update_time;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/crs_param_widgets.cpp
+++ b/src/gui/widgets/crs_param_widgets.cpp
@@ -37,6 +37,8 @@
 // IWYU pragma: no_forward_declare QPushButton
 
 
+namespace OpenOrienteering {
+
 UTMZoneEdit::UTMZoneEdit(CRSParameterWidgetObserver& observer, QWidget* parent)
  : QWidget(parent)
  , observer(observer)
@@ -100,3 +102,6 @@ bool UTMZoneEdit::calculateValue()
 	
 	return !zone.isNull();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/crs_param_widgets.h
+++ b/src/gui/widgets/crs_param_widgets.h
@@ -27,6 +27,8 @@
 
 class QLineEdit;
 
+namespace OpenOrienteering {
+
 class CRSParameterWidgetObserver;
 
 
@@ -50,5 +52,6 @@ private:
 };
 
 
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/crs_selector.cpp
+++ b/src/gui/widgets/crs_selector.cpp
@@ -38,9 +38,11 @@
 #include "core/georeferencing.h"
 
 
+namespace OpenOrienteering {
+
 // Helper functions for parameter widgets
-namespace
-{
+namespace {
+
 static const char* crsParameterWidgetProperty = "CRS parameter widget";
 static const char* crsParameterKeyProperty    = "CRS parameter key";
 
@@ -68,7 +70,7 @@ QString ParameterKey(const QWidget* w)
 	return w->property(crsParameterKeyProperty).toString();
 }
 
-} // namespace
+}  // namespace
 
 
 
@@ -383,3 +385,6 @@ void CRSSelector::changeEvent(QEvent* event)
 		; // nothing
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/crs_selector.h
+++ b/src/gui/widgets/crs_selector.h
@@ -34,6 +34,8 @@ class QEvent;
 class QFormLayout;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Georeferencing;
 
 
@@ -185,5 +187,8 @@ private:
 	int num_custom_items;
 	const CRSTemplate* configured_crs;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/editor_settings_page.cpp
+++ b/src/gui/widgets/editor_settings_page.cpp
@@ -35,6 +35,8 @@
 #include "gui/widgets/settings_page.h"
 
 
+namespace OpenOrienteering {
+
 EditorSettingsPage::EditorSettingsPage(QWidget* parent)
  : SettingsPage(parent)
 {
@@ -157,3 +159,5 @@ void EditorSettingsPage::updateWidgets()
 	rectangle_preview_line_width->setChecked(getSetting(Settings::RectangleTool_PreviewLineWidth).toBool());
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/editor_settings_page.h
+++ b/src/gui/widgets/editor_settings_page.h
@@ -32,6 +32,8 @@ class QSpinBox;
 class QWidget;
 
 
+namespace OpenOrienteering {
+
 class EditorSettingsPage : public SettingsPage
 {
 Q_OBJECT
@@ -68,5 +70,7 @@ private:
 	QCheckBox* rectangle_preview_line_width;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/general_settings_page.cpp
+++ b/src/gui/widgets/general_settings_page.cpp
@@ -69,6 +69,8 @@
 #include "util/translation_util.h"
 
 
+namespace OpenOrienteering {
+
 GeneralSettingsPage::GeneralSettingsPage(QWidget* parent)
 : SettingsPage(parent)
 , translation_file(getSetting(Settings::General_TranslationFile).toString())
@@ -114,10 +116,10 @@ GeneralSettingsPage::GeneralSettingsPage(QWidget* parent)
 	layout->addItem(Util::SpacerItem::create(this));
 	layout->addRow(Util::Headline::create(tr("Program start")));
 	
-	open_mru_check = new QCheckBox(AbstractHomeScreenWidget::tr("Open most recently used file"));
+	open_mru_check = new QCheckBox(::OpenOrienteering::AbstractHomeScreenWidget::tr("Open most recently used file"));
 	layout->addRow(open_mru_check);
 	
-	tips_visible_check = new QCheckBox(AbstractHomeScreenWidget::tr("Show tip of the day"));
+	tips_visible_check = new QCheckBox(::OpenOrienteering::AbstractHomeScreenWidget::tr("Show tip of the day"));
 	layout->addRow(tips_visible_check);
 	
 	layout->addItem(Util::SpacerItem::create(this));
@@ -421,3 +423,5 @@ bool GeneralSettingsPage::eventFilter(QObject* /* watched */, QEvent* event)
 	return false;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/general_settings_page.h
+++ b/src/gui/widgets/general_settings_page.h
@@ -35,6 +35,8 @@ class QSpinBox;
 class QWidget;
 
 
+namespace OpenOrienteering {
+
 class GeneralSettingsPage : public SettingsPage
 {
 Q_OBJECT
@@ -89,5 +91,8 @@ private:
 	QComboBox* encoding_box;
 	QCheckBox* ocd_importer_check;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/home_screen_widget.cpp
+++ b/src/gui/widgets/home_screen_widget.cpp
@@ -42,6 +42,8 @@
 #include "gui/settings_dialog.h"
 
 
+namespace OpenOrienteering {
+
 //### AbstractHomeScreenWidget ###
 
 AbstractHomeScreenWidget::AbstractHomeScreenWidget(HomeScreenController* controller, QWidget* parent)
@@ -440,7 +442,7 @@ void HomeScreenWidgetMobile::fileClicked(QListWidgetItem* item)
 {
 	QString hint_text = item->data(Qt::UserRole+1).toString();
 	if (!hint_text.isEmpty())
-		QMessageBox::warning(this, MainWindow::tr("Warning"), hint_text.arg(item->data(Qt::DisplayRole).toString()));
+		QMessageBox::warning(this, ::OpenOrienteering::MainWindow::tr("Warning"), hint_text.arg(item->data(Qt::DisplayRole).toString()));
 	
 	setEnabled(false);
 	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
@@ -570,3 +572,6 @@ void HomeScreenWidgetMobile::addFilesToFileList(QListWidget* file_list, const QS
 		file_list->addItem(new_item);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/home_screen_widget.h
+++ b/src/gui/widgets/home_screen_widget.h
@@ -40,6 +40,8 @@ class QPushButton;
 class QResizeEvent;
 class QStackedLayout;
 
+namespace OpenOrienteering {
+
 class HomeScreenController;
 
 
@@ -205,4 +207,6 @@ private:
 	QPushButton* examples_button;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/gui/widgets/key_button_bar.cpp
+++ b/src/gui/widgets/key_button_bar.cpp
@@ -36,9 +36,10 @@
 #include <QToolButton>
 
 
-namespace
-{
+namespace OpenOrienteering {
 
+namespace {
+	
 	int modifierFromKeyCode(Qt::Key key_code)
 	{
 		switch(key_code)
@@ -80,7 +81,8 @@ namespace
 		Q_UNREACHABLE();
 	}
 	
-}
+	
+}  // namespace
 
 
 
@@ -300,3 +302,6 @@ void KeyButtonBar::sendKeyReleaseEvent(Qt::Key key_code)
 	QKeyEvent event(QEvent::KeyRelease, key_code, active_modifiers);
 	QCoreApplication::sendEvent(receiver, &event);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/key_button_bar.h
+++ b/src/gui/widgets/key_button_bar.h
@@ -36,6 +36,8 @@ class QHideEvent;
 class QShowEvent;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 
 /**
  * Shows a set of buttons for simulating keyboard input.
@@ -142,5 +144,8 @@ private:
 	
 	Q_DISABLE_COPY(KeyButtonBar)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_KEY_BUTTON_BAR_H

--- a/src/gui/widgets/mapper_proxystyle.cpp
+++ b/src/gui/widgets/mapper_proxystyle.cpp
@@ -34,6 +34,8 @@
 #include "segmented_button_layout.h"
 
 
+namespace OpenOrienteering {
+
 MapperProxyStyle::MapperProxyStyle(QStyle* base_style)
  : QProxyStyle(base_style)
 {
@@ -181,3 +183,6 @@ int MapperProxyStyle::styleHint(QStyle::StyleHint hint, const QStyleOption* opti
 	
 	return QProxyStyle::styleHint(hint, option, widget, return_data);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/mapper_proxystyle.h
+++ b/src/gui/widgets/mapper_proxystyle.h
@@ -31,6 +31,8 @@ class QStyleHintReturn;
 class QStyleOption;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * MapperProxyStyle customizes the platform's base style.
@@ -90,5 +92,8 @@ private:
 	
 	Q_DISABLE_COPY(MapperProxyStyle)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_MAPPER_PROXYSTYLE_H

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -31,6 +31,8 @@
 #include "core/symbols/line_symbol.h"
 
 
+namespace OpenOrienteering {
+
 MeasureWidget::MeasureWidget(Map* map, QWidget* parent)
 : QTextBrowser(parent)
 , map(map)
@@ -158,3 +160,6 @@ void MeasureWidget::objectSelectionChanged()
 		body.append(QLatin1String("<p>") + extra_text + QLatin1String("</p>"));
 	setHtml(QLatin1String("<p><b>") + headline + QLatin1String("</b></p>") + body);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/measure_widget.h
+++ b/src/gui/widgets/measure_widget.h
@@ -27,7 +27,10 @@
 
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
+
 
 /**
  * The widget which is shown in a dock widget when the measure tool is active.
@@ -53,5 +56,8 @@ protected slots:
 private:
 	Map* map;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/pie_menu.cpp
+++ b/src/gui/widgets/pie_menu.cpp
@@ -32,6 +32,9 @@
 #include "settings.h"
 #include "util/backports.h"
 
+
+namespace OpenOrienteering {
+
 PieMenu::PieMenu(QWidget* parent)
 : QWidget(parent, Qt::Popup | Qt::FramelessWindowHint),	// NOTE: use Qt::Window for debugging to avoid mouse grab
    minimum_action_count(3),
@@ -387,3 +390,6 @@ void PieMenu::updateCachedState()
 		actions_changed = false;
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/pie_menu.h
+++ b/src/gui/widgets/pie_menu.h
@@ -37,6 +37,8 @@ class QHideEvent;
 class QMouseEvent;
 class QPaintEvent;
 
+namespace OpenOrienteering {
+
 
 /** 
  * Displays a pie menu.
@@ -164,5 +166,7 @@ QPoint PieMenu::getPoint(double radius, double angle) const
 	return QPoint(total_radius + qRound(radius * -sin(angle)), total_radius + qRound(radius * -cos(angle)));
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/segmented_button_layout.cpp
+++ b/src/gui/widgets/segmented_button_layout.cpp
@@ -24,6 +24,8 @@
 #include <QWidget>
 
 
+namespace OpenOrienteering {
+
 SegmentedButtonLayout::SegmentedButtonLayout()
  : QHBoxLayout()
 {
@@ -72,3 +74,6 @@ void SegmentedButtonLayout::invalidate()
 	
 	QHBoxLayout::invalidate();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/segmented_button_layout.h
+++ b/src/gui/widgets/segmented_button_layout.h
@@ -27,6 +27,8 @@
 
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * SegmentedButtonLayout is a horizontal box layout with no margin and no
@@ -75,5 +77,8 @@ public:
 private:
 	Q_DISABLE_COPY(SegmentedButtonLayout)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_SEGMENTED_BUTTON_LAYOUT_H

--- a/src/gui/widgets/settings_page.cpp
+++ b/src/gui/widgets/settings_page.cpp
@@ -21,6 +21,8 @@
 #include "settings_page.h"
 
 
+namespace OpenOrienteering {
+
 SettingsPage::SettingsPage(QWidget* parent)
 : QWidget(parent)
 {
@@ -28,3 +30,6 @@ SettingsPage::SettingsPage(QWidget* parent)
 }
 
 SettingsPage::~SettingsPage() = default;
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/settings_page.h
+++ b/src/gui/widgets/settings_page.h
@@ -28,6 +28,8 @@
 
 #include "settings.h"
 
+namespace OpenOrienteering {
+
 
 /**
  * A widget which serves as a page in the SettingsDialog.
@@ -90,5 +92,7 @@ void SettingsPage::setSetting(Settings::SettingsEnum setting, T value)
 	Settings::getInstance().setSetting(setting, QVariant{ value });
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/symbol_dropdown.cpp
+++ b/src/gui/widgets/symbol_dropdown.cpp
@@ -39,10 +39,14 @@
 #include "util/backports.h"
 
 
-// ### SymbolDropDown ###
-
 // allow explicit use of Symbol pointers in QVariant
-Q_DECLARE_METATYPE(Symbol*)
+Q_DECLARE_METATYPE(OpenOrienteering::Symbol*)
+
+
+
+namespace OpenOrienteering {
+
+// ### SymbolDropDown ###
 
 
 SymbolDropDown::SymbolDropDown(const Map* map, int filter, const Symbol* initial_symbol, const Symbol* excluded_symbol, QWidget* parent)
@@ -177,3 +181,6 @@ void SymbolDropDownDelegate::emitCommitData()
 {
 	emit commitData(qobject_cast<QWidget*>(sender()));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/symbol_dropdown.h
+++ b/src/gui/widgets/symbol_dropdown.h
@@ -33,6 +33,8 @@ class QModelIndex;
 class QStyleOptionViewItem;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 class Symbol;
 
@@ -105,5 +107,8 @@ private slots:
 private:
 	const int symbol_type_filter;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -49,6 +49,8 @@
 #include "util/overriding_shortcut.h"
 
 
+namespace OpenOrienteering {
+
 namespace MimeType {
 
 /// The index of a symbol during drag-and-drop
@@ -63,7 +65,9 @@ const QString OpenOrienteeringSymbols()
 	return QStringLiteral("openorienteering/symbols");
 }
 
+
 }  // namespace MimeType
+
 
 
 //### SymbolIconDecorator ###
@@ -1256,3 +1260,6 @@ void SymbolRenderWidget::sort(T compare)
 	
 	update();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/symbol_render_widget.h
+++ b/src/gui/widgets/symbol_render_widget.h
@@ -43,10 +43,12 @@ class QPaintEvent;
 class QPainter;
 class QResizeEvent;
 
+namespace OpenOrienteering {
+
 class Map;
 class Symbol;
-class SymbolToolTip;
 class SymbolIconDecorator;
+class SymbolToolTip;
 
 
 /**
@@ -373,5 +375,8 @@ int SymbolRenderWidget::selectedSymbolsCount() const
 {
 	return (int)selected_symbols.size();
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/symbol_tooltip.cpp
+++ b/src/gui/widgets/symbol_tooltip.cpp
@@ -48,6 +48,8 @@
 // IWYU pragma: no_forward_declare QWidget
 
 
+namespace OpenOrienteering {
+
 SymbolToolTip::SymbolToolTip(QWidget* parent, QShortcut* shortcut)
 : QWidget{ parent }
 , shortcut{ shortcut }
@@ -236,3 +238,6 @@ const Symbol* SymbolToolTip::getSymbol() const
 {
 	return symbol;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/symbol_tooltip.h
+++ b/src/gui/widgets/symbol_tooltip.h
@@ -35,6 +35,8 @@ class QShortcut;
 class QShowEvent;
 // IWYU pragma: no_forward_declare QWidget
 
+namespace OpenOrienteering {
+
 class Map;
 class Symbol;
 
@@ -139,5 +141,8 @@ private:
 	bool description_shown;    /// If true, the full description is visible.
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/symbol_widget.cpp
+++ b/src/gui/widgets/symbol_widget.cpp
@@ -31,6 +31,8 @@
 // IWYU pragma: no_forward_declare QWidget
 
 
+namespace OpenOrienteering {
+
 SymbolWidget::SymbolWidget(Map* map, bool mobile_mode, QWidget* parent)
 : QScrollArea(parent)
 {
@@ -85,3 +87,6 @@ void SymbolWidget::contextMenuEvent(QContextMenuEvent* event)
 	render_widget->showContextMenu(event->globalPos());
 	event->accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/symbol_widget.h
+++ b/src/gui/widgets/symbol_widget.h
@@ -28,6 +28,8 @@
 class QContextMenuEvent;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 class Symbol;
 class SymbolRenderWidget;
@@ -127,5 +129,8 @@ protected:
 private:
 	SymbolRenderWidget* render_widget;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -47,6 +47,8 @@
 #include "gui/widgets/segmented_button_layout.h"
 
 
+namespace OpenOrienteering {
+
 // ### TagSelectWidget ###
 
 TagSelectWidget::TagSelectWidget(QWidget* parent)
@@ -372,3 +374,6 @@ ObjectQuery TagSelectWidget::makeQuery() const
 
 	return query;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/tag_select_widget.h
+++ b/src/gui/widgets/tag_select_widget.h
@@ -32,6 +32,8 @@ class QShowEvent;
 class QToolButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class ObjectQuery;
 
 
@@ -74,5 +76,8 @@ private:
 
 	Q_DISABLE_COPY(TagSelectWidget)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/tags_widget.cpp
+++ b/src/gui/widgets/tags_widget.cpp
@@ -35,6 +35,8 @@
 #include "undo/object_undo.h"
 
 
+namespace OpenOrienteering {
+
 TagsWidget::TagsWidget(Map* map, MapView* main_view, MapEditorController* controller, QWidget* parent)
  : QWidget(parent),
   map(map), 
@@ -262,3 +264,6 @@ void TagsWidget::cellChange(int row, int column)
 	
 	react_to_changes = true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/tags_widget.h
+++ b/src/gui/widgets/tags_widget.h
@@ -29,6 +29,8 @@ class QIcon;
 class QTableWidget;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorController;
 class MapView;
@@ -94,5 +96,8 @@ private:
 	
 	QTableWidget* tags_table;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // TAGS_WIDGET_H

--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -53,6 +53,8 @@
 #include "util/item_delegates.h"
 
 
+namespace OpenOrienteering {
+
 // ### ApplyTemplateTransform ###
 
 /**
@@ -97,12 +99,12 @@ TemplateListWidget::TemplateListWidget(Map* map, MapView* main_view, MapEditorCo
 	auto top_bar_layout = new QHBoxLayout(top_bar_widget);
 	
 	// Reuse the translation from MapEditorController action.
-	all_hidden_check = new QCheckBox(MapEditorController::tr("Hide all templates"));
+	all_hidden_check = new QCheckBox(::OpenOrienteering::MapEditorController::tr("Hide all templates"));
 	top_bar_layout->addWidget(all_hidden_check);
 	
 	if (mobile_mode)
 	{
-		auto close_action = new QAction(QIcon(QString::fromLatin1(":/images/close.png")), MainWindow::tr("Close"), this);
+		auto close_action = new QAction(QIcon(QString::fromLatin1(":/images/close.png")), ::OpenOrienteering::MainWindow::tr("Close"), this);
 		connect(close_action, &QAction::triggered, this, &TemplateListWidget::closeClicked );
 		
 		auto close_button = new QToolButton();
@@ -235,7 +237,8 @@ TemplateListWidget::TemplateListWidget(Map* map, MapView* main_view, MapEditorCo
 	position_action->setCheckable(true);
 	import_action =  edit_menu->addAction(tr("Import and remove"), this, SLOT(importClicked()));
 	
-	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")), MapEditorController::tr("&Edit").remove(QLatin1Char('&')));
+	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")),
+	                            ::OpenOrienteering::MapEditorController::tr("&Edit").remove(QLatin1Char('&')));
 	edit_button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 	edit_button->setPopupMode(QToolButton::InstantPopup);
 	edit_button->setMenu(edit_menu);
@@ -687,7 +690,7 @@ void TemplateListWidget::cellChange(int row, int column)
 							template_table->item(row, 0)->setCheckState(Qt::PartiallyChecked);
 							auto item_rect = template_table->visualItemRect(template_table->item(row, 1));
 							QToolTip::showText(template_table->mapToGlobal(item_rect.bottomLeft()),
-							                   qApp->translate("MainWindow", "Opening %1").arg(temp->getTemplateFilename()) );
+							                   qApp->translate("OpenOrienteering::MainWindow", "Opening %1").arg(temp->getTemplateFilename()) );
 							// QToolTip seems to need to event loop runs.
 							qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 							qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
@@ -700,8 +703,9 @@ void TemplateListWidget::cellChange(int row, int column)
 							QToolTip::hideText();
 							if (temp->getTemplateState() != Template::Loaded)
 							{
-								QMessageBox::warning(this, qApp->translate("MainWindow", "Error"),
-								                     qApp->translate("Importer", "Failed to load template '%1', reason: %2")
+								QMessageBox::warning(this,
+								                     qApp->translate("OpenOrienteering::MainWindow", "Error"),
+								                     qApp->translate("OpenOrienteering::Importer", "Failed to load template '%1', reason: %2")
 								                     .arg(temp->getTemplateFilename(), temp->errorString()) );
 							}
 						}
@@ -1331,3 +1335,6 @@ void TemplateListWidget::showOpacitySlider(int row)
 	
 	dialog.exec();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/template_list_widget.h
+++ b/src/gui/widgets/template_list_widget.h
@@ -37,6 +37,8 @@ class QIcon;
 class QTableWidget;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorController;
 class Template;
@@ -152,5 +154,8 @@ private:
 	//QToolButton* group_button;
 	//QToolButton* more_button;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/text_alignment_widget.cpp
+++ b/src/gui/widgets/text_alignment_widget.cpp
@@ -30,8 +30,9 @@
 #include "tools/text_object_editor_helper.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
 
 struct AlignmentOption
 {
@@ -41,19 +42,20 @@ struct AlignmentOption
 };
 
 const AlignmentOption horizontal_options[] = { 
-    { TextObject::AlignLeft,    QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Left"),    ":/images/text-align-left.png" },
-    { TextObject::AlignHCenter, QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Center"),  ":/images/text-align-hcenter.png" },
-    { TextObject::AlignRight,   QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Right"),   ":/images/text-align-right.png" },
+    { TextObject::AlignLeft,    QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Left"),    ":/images/text-align-left.png" },
+    { TextObject::AlignHCenter, QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Center"),  ":/images/text-align-hcenter.png" },
+    { TextObject::AlignRight,   QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Right"),   ":/images/text-align-right.png" },
 };
 
 const AlignmentOption vertical_options[] = { 
-    { TextObject::AlignTop,     QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Top"),     ":/images/text-align-top.png" },
-    { TextObject::AlignVCenter, QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Center"),  ":/images/text-align-vcenter.png" },
-    { TextObject::AlignBaseline,QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Baseline"),":/images/text-align-baseline.png" },
-    { TextObject::AlignBottom,  QT_TRANSLATE_NOOP("TextObjectAlignmentDockWidget", "Bottom"),  ":/images/text-align-bottom.png" },
+    { TextObject::AlignTop,     QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Top"),     ":/images/text-align-top.png" },
+    { TextObject::AlignVCenter, QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Center"),  ":/images/text-align-vcenter.png" },
+    { TextObject::AlignBaseline,QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Baseline"),":/images/text-align-baseline.png" },
+    { TextObject::AlignBottom,  QT_TRANSLATE_NOOP("OpenOrienteering::TextObjectAlignmentDockWidget", "Bottom"),  ":/images/text-align-bottom.png" },
 };
 
-}
+
+}  // namespace
 
 
 TextObjectAlignmentDockWidget::TextObjectAlignmentDockWidget(TextObjectEditorHelper* text_editor, QWidget* parent)
@@ -110,7 +112,6 @@ TextObjectAlignmentDockWidget::~TextObjectAlignmentDockWidget()
 {
 	// nothing, not inlined
 }
-
 
 bool TextObjectAlignmentDockWidget::event(QEvent* event)
 {
@@ -180,3 +181,6 @@ QPushButton* TextObjectAlignmentDockWidget::makeButton(const QString& icon_path,
 	button->setCheckable(true);
 	return button;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/text_alignment_widget.h
+++ b/src/gui/widgets/text_alignment_widget.h
@@ -31,6 +31,8 @@ class QKeyEvent;
 class QPushButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class TextObjectEditorHelper;
 
 
@@ -68,5 +70,8 @@ private:
 	int horizontal_alignment;
 	int vertical_alignment;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/gui/widgets/text_browser.cpp
+++ b/src/gui/widgets/text_browser.cpp
@@ -21,6 +21,8 @@
 #include "text_browser.h"
 
 
+namespace OpenOrienteering {
+
 TextBrowser::TextBrowser(QWidget* parent)
 : QTextBrowser{ parent }
 {
@@ -50,3 +52,6 @@ QVariant TextBrowser::loadResource(int type, const QUrl& name)
 	}
 	return result;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/text_browser.h
+++ b/src/gui/widgets/text_browser.h
@@ -28,6 +28,8 @@
 class QUrl;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * A text browser which handles .txt files.
@@ -45,5 +47,8 @@ public:
 	
 	QVariant loadResource(int type, const QUrl& name) override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,9 +56,17 @@
 
 // IWYU pragma: no_forward_declare QTranslator
 
+using namespace OpenOrienteering;
+
 
 // From map.h
+
+namespace OpenOrienteering {
+
 extern QPointer<QTranslator> map_symbol_translator;
+
+}  // namespace OpenOrienteering
+
 
 
 #if MAPPER_USE_QTSINGLEAPPLICATION

--- a/src/mapper_resource.cpp
+++ b/src/mapper_resource.cpp
@@ -28,8 +28,9 @@
 #include "mapper_config.h"
 
 
-namespace MapperResource
-{
+namespace OpenOrienteering {
+
+namespace MapperResource {
 
 void setSeachPaths()
 {
@@ -78,4 +79,8 @@ void setSeachPaths()
 	QDir::setSearchPaths(QLatin1String("doc"), doc_paths);
 }
 
-} // namespace MapperResource
+
+}  // namespace MapperResource
+
+
+}  // namespace OpenOrienteering

--- a/src/mapper_resource.h
+++ b/src/mapper_resource.h
@@ -17,12 +17,14 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #ifndef OPENORIENTEERING_MAPPER_RESOURCE_H
 #define OPENORIENTEERING_MAPPER_RESOURCE_H
 
+namespace OpenOrienteering {
 
-namespace MapperResource
-{
+
+namespace MapperResource {
 
 /**
  * Initializes QDir::searchPaths for Mapper resource prefixes.
@@ -36,8 +38,10 @@ namespace MapperResource
  */
 void setSeachPaths();
 
-}
+}  // namespace MapperResource
 
+
+}  // namespace OpenOrienteering
 
 
 #endif

--- a/src/qmake/mapper_config.h
+++ b/src/qmake/mapper_config.h
@@ -23,7 +23,7 @@
 #define OPENORIENTEERING_MAPPER_CONFIG_H
 
 #if !defined(APP_NAME)
-#define APP_NAME qApp->translate("Global", QT_TRANSLATE_NOOP("Global", "OpenOrienteering Mapper"))
+#define APP_NAME qApp->translate("OpenOrienteering::Global", QT_TRANSLATE_NOOP("Global", "OpenOrienteering Mapper"))
 #endif
 
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)

--- a/src/sensors/compass.cpp
+++ b/src/sensors/compass.cpp
@@ -28,12 +28,26 @@
 #include <QMutex>  // IWYU pragma: keep
 #include <QTime>
 
+#ifdef QT_SENSORS_LIB
+#include <QThread>
+#include <QDebug>
+#include <QWaitCondition>
+#include <QtSensors/QAccelerometer>
+#include <QtSensors/QMagnetometer>
+#include <QtSensors/QGyroscope>
+
+#ifdef Q_OS_ANDROID
+#include <QtAndroidExtras/QAndroidJniObject>
+#endif
+
 
 // clazy:excludeall=missing-qobject-macro
 
 
-namespace SensorHelpers
-{
+namespace OpenOrienteering {
+
+namespace SensorHelpers {
+	
 	void matrixMultiplication(float* A, float* B, float* result)
 	{
 		result[0] = A[0] * B[0] + A[1] * B[3] + A[2] * B[6];
@@ -207,20 +221,11 @@ namespace SensorHelpers
 		R[7] = q2_q3 + q1_q0;
 		R[8] = 1 - sq_q1 - sq_q2;
     }
-}
+	
+	
+}  // namespace OpenOrienteering
 
 
-#ifdef QT_SENSORS_LIB
-#include <QThread>
-#include <QDebug>
-#include <QWaitCondition>
-#include <QtSensors/QAccelerometer>
-#include <QtSensors/QMagnetometer>
-#include <QtSensors/QGyroscope>
-
-#ifdef Q_OS_ANDROID
-#include <QtAndroidExtras/QAndroidJniObject>
-#endif
 
 class CompassPrivate : public QGyroscopeFilter
 {
@@ -595,3 +600,6 @@ void Compass::emitAzimuthChanged(float value)
 {
 	emit azimuthChanged(value);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/compass.h
+++ b/src/sensors/compass.h
@@ -23,8 +23,11 @@
 
 #include <QObject>
 
-class CompassPrivate;
 class QMetaMethod;
+
+namespace OpenOrienteering {
+
+class CompassPrivate;
 
 
 /** Provides access to the device's compass. Singleton class. */
@@ -74,5 +77,8 @@ private:
 	int reference_counter;
 	CompassPrivate* p;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/sensors/gps_display.cpp
+++ b/src/sensors/gps_display.cpp
@@ -38,6 +38,8 @@
 #include "util/backports.h"
 
 
+namespace OpenOrienteering {
+
 GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, QObject* parent)
  : QObject(parent)
  , widget(widget)
@@ -360,3 +362,6 @@ void GPSDisplay::updateMapWidget()
 	// TODO: Limit update region to union of old and new bounding rect
 	widget->update();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/gps_display.h
+++ b/src/sensors/gps_display.h
@@ -35,8 +35,10 @@ class QGeoPositionInfoSource;  // IWYU pragma: keep
 
 class QPainter;
 
-class MapWidget;
+namespace OpenOrienteering {
+
 class Georeferencing;
+class MapWidget;
 
 
 /**
@@ -131,5 +133,8 @@ private:
 	bool distance_rings_enabled;
 	bool heading_indicator_enabled;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/sensors/gps_temporary_markers.cpp
+++ b/src/sensors/gps_temporary_markers.cpp
@@ -28,6 +28,8 @@
 #include "tools/tool.h"
 
 
+namespace OpenOrienteering {
+
 GPSTemporaryMarkers::GPSTemporaryMarkers(MapWidget* widget, GPSDisplay* gps_display): QObject()
 {
 	this->widget = widget;
@@ -124,3 +126,6 @@ void GPSTemporaryMarkers::updateMapWidget()
 	// NOTE: could limit the updated area here
 	widget->update();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/gps_temporary_markers.h
+++ b/src/sensors/gps_temporary_markers.h
@@ -29,6 +29,8 @@
 class QPainter;
 // IWYU pragma: no_forward_declare QPointF
 
+namespace OpenOrienteering {
+
 class MapCoordF;
 class MapWidget;
 class GPSDisplay;
@@ -66,5 +68,8 @@ private:
 	GPSDisplay* gps_display;
 	MapWidget* widget;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/sensors/gps_track.cpp
+++ b/src/sensors/gps_track.cpp
@@ -34,6 +34,8 @@
 #include "util/dxfparser.h"
 
 
+namespace OpenOrienteering {
+
 // There is some (mis?)use of TrackPoint's gps_coord LatLon
 // as sort-of MapCoordF.
 // This function serves both for explicit conversion and highlighting.
@@ -414,7 +416,7 @@ bool Track::loadFromDXF(QFile* file, bool project_points, QWidget* dialog_parent
 	QString result = parser->parse();
 	if (!result.isEmpty())
 	{
-		QMessageBox::critical(dialog_parent, TemplateTrack::tr("Error reading"), TemplateTrack::tr("There was an error reading the DXF file %1:\n\n%2").arg(file->fileName(), result));
+		QMessageBox::critical(dialog_parent, OpenOrienteering::TemplateTrack::tr("Error reading"), OpenOrienteering::TemplateTrack::tr("There was an error reading the DXF file %1:\n\n%2").arg(file->fileName(), result));
 		delete parser;
 		return false;
 	}
@@ -425,7 +427,7 @@ bool Track::loadFromDXF(QFile* file, bool project_points, QWidget* dialog_parent
 	//       It does not fit here as this method is called again every time a map
 	//       containing a track is re-loaded, and in this case the question should
 	//       not be asked again.
-	//int res = QMessageBox::question(dialog_parent, TemplateTrack::tr("Question"), TemplateTrack::tr("Are the coordinates in the DXF file in degrees?"), QMessageBox::Yes|QMessageBox::No);
+	//int res = QMessageBox::question(dialog_parent, OpenOrienteering::TemplateTrack::tr("Question"), OpenOrienteering::TemplateTrack::tr("Are the coordinates in the DXF file in degrees?"), QMessageBox::Yes|QMessageBox::No);
 	for (auto&& path : paths)
 	{
 		if (path.type == POINT)
@@ -492,7 +494,7 @@ bool Track::loadFromOSM(QFile* file, bool project_points, QWidget* dialog_parent
 	{
 		if (xml.name() != QLatin1String("osm"))
 		{
-			QMessageBox::critical(dialog_parent, TemplateTrack::tr("Error"), TemplateTrack::tr("%1:\nNot an OSM file."));
+			QMessageBox::critical(dialog_parent, OpenOrienteering::TemplateTrack::tr("Error"), OpenOrienteering::TemplateTrack::tr("%1:\nNot an OSM file."));
 			return false;
 		}
 		else
@@ -501,15 +503,15 @@ bool Track::loadFromOSM(QFile* file, bool project_points, QWidget* dialog_parent
 			const double osm_version = attributes.value(QLatin1String("version")).toDouble();
 			if (osm_version < min_supported_version)
 			{
-				QMessageBox::critical(dialog_parent, TemplateTrack::tr("Error"),
-				                      TemplateTrack::tr("The OSM file has version %1.\nThe minimum supported version is %2.").arg(
+				QMessageBox::critical(dialog_parent, OpenOrienteering::TemplateTrack::tr("Error"),
+				                      OpenOrienteering::TemplateTrack::tr("The OSM file has version %1.\nThe minimum supported version is %2.").arg(
 				                          attributes.value(QLatin1String("version")).toString(), QString::number(min_supported_version, 'g', 1)));
 				return false;
 			}
 			if (osm_version > max_supported_version)
 			{
-				QMessageBox::critical(dialog_parent, TemplateTrack::tr("Error"),
-				                      TemplateTrack::tr("The OSM file has version %1.\nThe maximum supported version is %2.").arg(
+				QMessageBox::critical(dialog_parent, OpenOrienteering::TemplateTrack::tr("Error"),
+				                      OpenOrienteering::TemplateTrack::tr("The OSM file has version %1.\nThe maximum supported version is %2.").arg(
 				                          attributes.value(QLatin1String("version")).toString(), QString::number(max_supported_version, 'g', 1)));
 				return false;
 			}
@@ -609,7 +611,7 @@ bool Track::loadFromOSM(QFile* file, bool project_points, QWidget* dialog_parent
 	}
 	
 	if (node_problems > 0)
-		QMessageBox::warning(dialog_parent, TemplateTrack::tr("Problems"), TemplateTrack::tr("%1 nodes could not be processed correctly.").arg(node_problems));
+		QMessageBox::warning(dialog_parent, OpenOrienteering::TemplateTrack::tr("Problems"), OpenOrienteering::TemplateTrack::tr("%1 nodes could not be processed correctly.").arg(node_problems));
 	
 	return true;
 }
@@ -637,3 +639,6 @@ void Track::projectPoints()
 			segment_points[i].map_coord = map_georef.toMapCoordF(track_crs, fakeMapCoordF(segment_points[i].gps_coord), nullptr); // FIXME: check for errors
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/gps_track.h
+++ b/src/sensors/gps_track.h
@@ -35,6 +35,8 @@ class QFile;
 class QWidget;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 
 /**
  * A point in a track or a waypoint, which stores position on ellipsoid and
@@ -174,5 +176,7 @@ const Track::ElementTags& Track::tags() const
 	return element_tags;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/sensors/gps_track_recorder.cpp
+++ b/src/sensors/gps_track_recorder.cpp
@@ -20,11 +20,13 @@
 
 #include "gps_track_recorder.h"
 
-#include "gps_display.h"
-#include "templates/template_track.h"
 #include "core/map.h"
 #include "gui/map/map_widget.h"
+#include "sensors/gps_display.h"
+#include "templates/template_track.h"
 
+
+namespace OpenOrienteering {
 
 GPSTrackRecorder::GPSTrackRecorder(GPSDisplay* gps_display, TemplateTrack* target_template, int draw_update_interval_milliseconds, MapWidget* widget)
  : QObject()
@@ -99,3 +101,6 @@ void GPSTrackRecorder::drawUpdate()
 		track_changed_since_last_update = false;
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/gps_track_recorder.h
+++ b/src/sensors/gps_track_recorder.h
@@ -24,6 +24,8 @@
 #include <QObject>
 #include <QTimer>
 
+namespace OpenOrienteering {
+
 class MapWidget;
 class Template;
 class TemplateTrack;
@@ -51,5 +53,8 @@ private:
 	bool track_changed_since_last_update;
 	bool is_active;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -31,6 +31,8 @@
 #include <QStringList>
 
 
+namespace OpenOrienteering {
+
 /*
  * Implementation for some functions which need a Settings instance.
  * 
@@ -322,3 +324,6 @@ int Settings::getStartDragDistancePx()
 {
 	return getSettingCached(Settings::General_StartDragDistance).toInt();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,6 +31,8 @@
 class QSettings;
 
 
+namespace OpenOrienteering {
+
 /** Singleton which handles the global application settings.
  *  If you need to do any action when the application settings are changed, connect to the settingsChanged() signal.
  */
@@ -137,5 +139,8 @@ private:
 	QHash<SettingsEnum, QString> setting_paths;
 	QHash<SettingsEnum, QVariant> setting_defaults;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template.cpp
+++ b/src/templates/template.cpp
@@ -46,6 +46,8 @@
 #include "util/xml_stream_util.h"
 
 
+namespace OpenOrienteering {
+
 class Template::ScopedOffsetReversal
 {
 public:
@@ -486,7 +488,7 @@ bool Template::execSwitchTemplateFileDialog(QWidget* dialog_parent)
 	switchTemplateFile(new_path, true);
 	if (getTemplateState() != Loaded)
 	{
-		QString error_template = QCoreApplication::translate("TemplateListWidget", "Cannot open template\n%1:\n%2").arg(new_path);
+		QString error_template = QCoreApplication::translate("OpenOrienteering::TemplateListWidget", "Cannot open template\n%1:\n%2").arg(new_path);
 		QString error = errorString();
 		Q_ASSERT(!error.isEmpty());
 		QMessageBox::warning(dialog_parent,
@@ -974,3 +976,6 @@ void Template::updateTransformationMatrices()
 	
 	template_to_map.invert(map_to_template);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -44,6 +44,8 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapView;
 
@@ -689,5 +691,8 @@ protected:
 	Matrix template_to_map;
 	Matrix template_to_map_other;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_adjust.cpp
+++ b/src/templates/template_adjust.cpp
@@ -45,6 +45,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 float TemplateAdjustActivity::cross_radius = 4;
 
 TemplateAdjustActivity::TemplateAdjustActivity(Template* temp, MapEditorController* controller) : controller(controller)
@@ -614,7 +616,7 @@ bool TemplateAdjustAddTool::mousePressEvent(QMouseEvent* event, MapCoordF map_co
 		setDirtyRect(map_coord);
 		
 		setStatusBarText(tr("<b>Click</b>: Set the map position of the pass point. ") +
-		                 MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape()) );
+		                 OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape()) );
 	}
 	else
 	{
@@ -870,3 +872,6 @@ bool TemplateAdjustDeleteTool::mouseMoveEvent(QMouseEvent* event, MapCoordF map_
 	findHoverPoint(event->pos(), widget);
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_adjust.h
+++ b/src/templates/template_adjust.h
@@ -44,12 +44,15 @@ class QPushButton;
 class QTableWidget;
 class QCheckBox;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 class Template;
 class TemplateAdjustDockWidget;
 class TemplateAdjustWidget;
 struct TemplateTransform;
+
 
 /**
  * Activity which allows the positioning of a template by
@@ -229,5 +232,8 @@ public:
 	void init() override;
 	const QCursor& getCursor() const override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_dialog_reopen.cpp
+++ b/src/templates/template_dialog_reopen.cpp
@@ -30,6 +30,9 @@
 #include "template.h"
 #include "gui/util_gui.h"
 
+
+namespace OpenOrienteering {
+
 ReopenTemplateDialog::ReopenTemplateDialog(QWidget* parent, Map* map, const QString& map_directory)
 : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 , map(map)
@@ -163,3 +166,6 @@ void ReopenTemplateDialog::OpenTemplateList::dropEvent(QDropEvent* event)
 	// Always re-fill this list to update the list indices in the item data
 	dialog->updateClosedTemplateList();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_dialog_reopen.h
+++ b/src/templates/template_dialog_reopen.h
@@ -32,6 +32,8 @@ class QDropEvent;
 class QPushButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 
 
@@ -73,5 +75,8 @@ private:
 	Map* map;
 	QString map_directory;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -67,6 +67,8 @@
 // IWYU pragma: no_forward_declare QVBoxLayout
 
 
+namespace OpenOrienteering {
+
 const std::vector<QByteArray>& TemplateImage::supportedExtensions()
 {
 	static std::vector<QByteArray> extensions;
@@ -694,3 +696,6 @@ void TemplateImageOpenDialog::doAccept()
 	templ->getMap()->setImageTemplateDefaults(mpp_radio->isChecked(), mpp_edit->text().toDouble(), dpi_edit->text().toDouble(), scale_edit->text().toDouble());
 	accept();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_image.h
+++ b/src/templates/template_image.h
@@ -48,6 +48,8 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Georeferencing;
 class Map;
 class MapCoordF;
@@ -175,5 +177,8 @@ private:
 	
 	TemplateImage* templ;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -40,6 +40,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 QStringList TemplateMap::locked_maps;
 
 const std::vector<QByteArray>& TemplateMap::supportedExtensions()
@@ -203,3 +205,6 @@ void TemplateMap::calculateTransformation()
 		/// \todo proper error message
 	}
 }
+
+
+}   // namespace OpenOrienteering

--- a/src/templates/template_map.h
+++ b/src/templates/template_map.h
@@ -35,6 +35,8 @@ class QRectF;
 class QStringList;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 
 
@@ -89,5 +91,8 @@ private:
 	
 	static QStringList locked_maps;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_position_dock_widget.cpp
+++ b/src/templates/template_position_dock_widget.cpp
@@ -32,6 +32,9 @@
 #include "gui/map/map_editor.h"
 #include "templates/template.h"
 
+
+namespace OpenOrienteering {
+
 TemplatePositionDockWidget::TemplatePositionDockWidget(Template* temp, MapEditorController* controller, QWidget* parent)
  : QDockWidget(tr("Positioning"), parent), temp(temp), controller(controller)
 {
@@ -178,3 +181,6 @@ void TemplatePositionDockWidget::valueChanged()
 	controller->getMap()->emitTemplateChanged(temp);
 	react_to_changes = true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_position_dock_widget.h
+++ b/src/templates/template_position_dock_widget.h
@@ -29,6 +29,8 @@ class QCloseEvent;
 class QLineEdit;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class Template;
 
@@ -61,5 +63,8 @@ private:
 	Template* temp;
 	MapEditorController* controller;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -33,6 +33,8 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
+
 TemplatePositioningDialog::TemplatePositioningDialog(QWidget* parent)
 : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
@@ -84,3 +86,6 @@ bool TemplatePositioningDialog::centerOnView() const
 {
 	return view_center_radio->isChecked();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -31,6 +31,8 @@ class QDoubleSpinBox;
 class QRadioButton;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * Dialog allowing for positioning of a template.
@@ -53,5 +55,8 @@ private:
 	
 	Q_DISABLE_COPY(TemplatePositioningDialog)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_tool_move.cpp
+++ b/src/templates/template_tool_move.cpp
@@ -30,6 +30,9 @@
 #include "templates/template.h"
 #include "util/transformation.h"
 
+
+namespace OpenOrienteering {
+
 TemplateMoveTool::TemplateMoveTool(Template* templ, MapEditorController* editor, QAction* tool_action)
 : MapEditorTool(editor, Other, tool_action), templ(templ)
 {
@@ -123,3 +126,6 @@ void TemplateMoveTool::updateDragging(MapCoordF mouse_pos_map)
 	map()->setTemplatesDirty();
 	map()->emitTemplateChanged(templ);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_tool_move.h
+++ b/src/templates/template_tool_move.h
@@ -32,6 +32,8 @@ class QAction;
 class QCursor;
 class QMouseEvent;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 class Template;
@@ -64,5 +66,8 @@ private:
 	
 	Q_DISABLE_COPY(TemplateMoveTool)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_tool_paint.cpp
+++ b/src/templates/template_tool_paint.cpp
@@ -50,6 +50,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 // ### PaintOnTemplateTool ###
 
 int PaintOnTemplateTool::erase_width = 4;
@@ -391,3 +393,6 @@ void PaintOnTemplateSelectDialog::currentTemplateChanged(QListWidgetItem* curren
 	if (current)
 		selection = reinterpret_cast<Template*>(current->data(Qt::UserRole).value<void*>());
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_tool_paint.h
+++ b/src/templates/template_tool_paint.h
@@ -46,11 +46,13 @@ class QPainter;
 class QPushButton;
 class QRect;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorController;
 class MapWidget;
-class Template;
 class PaintOnTemplatePaletteWidget;
+class Template;
 
 
 /** Tool to paint on image templates. */
@@ -143,5 +145,8 @@ private:
 	Template* selection;
 	QPushButton* draw_button;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -39,6 +39,9 @@
 #include "undo/object_undo.h"
 #include "util/util.h"
 
+
+namespace OpenOrienteering {
+
 const std::vector<QByteArray>& TemplateTrack::supportedExtensions()
 {
 	static std::vector<QByteArray> extensions = { "dxf", "gpx", "osm" };
@@ -575,3 +578,6 @@ void TemplateTrack::applyProjectedCrsSpec()
 	georef.setProjectedRefPoint({});
 	track.changeMapGeoreferencing(georef);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/templates/template_track.h
+++ b/src/templates/template_track.h
@@ -40,6 +40,8 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Georeferencing;
 class Map;
 class MapCoordF;
@@ -121,5 +123,8 @@ protected:
 private:
 	Q_DISABLE_COPY(TemplateTrack)
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/templates/world_file.cpp
+++ b/src/templates/world_file.cpp
@@ -30,6 +30,8 @@
 #include <QTextStream>
 
 
+namespace OpenOrienteering {
+
 WorldFile::WorldFile()
 {
 	loaded = false;
@@ -99,3 +101,5 @@ bool WorldFile::tryToLoadForImage(const QString& image_path)
 	return false;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/templates/world_file.h
+++ b/src/templates/world_file.h
@@ -26,6 +26,8 @@
 #include <QTransform>
 
 
+namespace OpenOrienteering {
+
 /**
  * Handles pixel-to-world transformations given by world files.
  * 
@@ -46,5 +48,8 @@ struct WorldFile
 	/// Tries to find and load a world file for the given image path.
 	bool tryToLoadForImage(const QString& image_path);
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/cut_hole_tool.cpp
+++ b/src/tools/cut_hole_tool.cpp
@@ -45,6 +45,8 @@
 #include "undo/object_undo.h"
 
 
+namespace OpenOrienteering {
+
 CutHoleTool::CutHoleTool(MapEditorController* editor, QAction* tool_action, CutHoleTool::HoleType hole_type)
  : MapEditorTool(editor, Other, tool_action), hole_type(hole_type)
 {
@@ -247,3 +249,6 @@ void CutHoleTool::updateStatusText()
 		setStatusBarText(tr("<b>Click or drag</b>: Start drawing the hole. "));
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/cut_hole_tool.h
+++ b/src/tools/cut_hole_tool.h
@@ -35,11 +35,14 @@ class QMouseEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
+class DrawLineAndAreaTool;
 class MapCoordF;
 class MapEditorController;
 class MapWidget;
 class PathObject;
-class DrawLineAndAreaTool;
+
 
 /** Tool to cut holes into area objects */
 class CutHoleTool : public MapEditorTool
@@ -89,4 +92,6 @@ protected:
 	MapWidget* edit_widget;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/cut_tool.cpp
+++ b/src/tools/cut_tool.cpp
@@ -55,8 +55,10 @@
 #include "util/util.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	/**
 	 * Maximum number of objects in the selection for which point handles
 	 * will still be displayed (and can be edited).
@@ -67,7 +69,9 @@ namespace
 	 * The value which indicates that no point of the current object is hovered.
 	 */
 	static auto no_point = std::numeric_limits<MapCoordVector::size_type>::max();
-}
+	
+	
+}  // namespace OpenOrienteering
 
 
 
@@ -749,3 +753,6 @@ void CutTool::replaceObject(Object* object, const std::vector<PathObject*>& repl
 	
 	map->emitSelectionChanged();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/cut_tool.h
+++ b/src/tools/cut_tool.h
@@ -28,9 +28,12 @@
 #include <QRectF>
 #include <QScopedPointer>
 
-class MapEditorController;
-class MapRenderables;
-class MapWidget;
+#include "core/map_coord.h"
+#include "core/path_coord.h"
+#include "core/objects/object.h"
+#include "tools/edit_tool.h"
+#include "tools/tool_base.h"
+
 class QAction;
 class QEvent;
 class QFocusEvent;
@@ -39,13 +42,12 @@ class QMouseEvent;
 class QPainter;
 class QRectF;
 
-#include "core/map_coord.h"
-#include "core/path_coord.h"
-#include "core/objects/object.h"
-#include "tools/tool_base.h"
-#include "tools/edit_tool.h"
+namespace OpenOrienteering {
 
 class DrawPathTool;
+class MapEditorController;
+class MapRenderables;
+class MapWidget;
 
 
 /**
@@ -145,5 +147,8 @@ protected:
 	 */
 	QScopedPointer<MapRenderables> renderables;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/cutout_operation.cpp
+++ b/src/tools/cutout_operation.cpp
@@ -37,6 +37,8 @@
 #include "undo/undo.h"
 
 
+namespace OpenOrienteering {
+
 CutoutOperation::CutoutOperation(Map* map, PathObject* cutout_object, bool cut_away)
 : map(map)
 , cutout_object(cutout_object)
@@ -150,3 +152,6 @@ UndoStep* CutoutOperation::finish()
 	combined_step->push(delete_step);
 	return combined_step;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/cutout_operation.h
+++ b/src/tools/cutout_operation.h
@@ -26,6 +26,8 @@
 
 #include "core/objects/boolean_tool.h"
 
+namespace OpenOrienteering {
+
 class AddObjectsUndoStep;
 class Map;
 class Object;
@@ -87,5 +89,7 @@ private:
 	bool cut_away;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/cutout_tool.cpp
+++ b/src/tools/cutout_tool.cpp
@@ -47,6 +47,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 CutoutTool::CutoutTool(MapEditorController* editor, QAction* tool_action, bool cut_away)
 : MapEditorToolBase(QCursor(QPixmap(QString::fromLatin1(":/images/cursor-hollow.png")), 1, 1), Other, editor, tool_action)
 , object_selector(new ObjectSelector(map()))
@@ -151,7 +153,7 @@ void CutoutTool::updateStatusText()
 		text = tr("<b>%1+Click or drag</b>: Select the objects to be clipped. ").arg(ModifierKey::shift()) +
 		       tr("<b>%1</b>: Clip the selected objects. ").arg(ModifierKey::return_key());
 	}
-	text += MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
+	text += OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
 	setStatusBarText(text);	
 }
 
@@ -188,3 +190,6 @@ void CutoutTool::apply(Map* map, PathObject* cutout_object, bool cut_away)
 	CutoutOperation operation(map, cutout_object, cut_away);
 	map->getCurrentPart()->applyOnAllObjects(std::ref(operation));
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/cutout_tool.h
+++ b/src/tools/cutout_tool.h
@@ -33,6 +33,8 @@ class QKeyEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorController;
 class MapWidget;
@@ -109,4 +111,6 @@ private:
 	bool cut_away;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/distribute_points_tool.cpp
+++ b/src/tools/distribute_points_tool.cpp
@@ -40,6 +40,7 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
 
 bool DistributePointsTool::showSettingsDialog(
         QWidget* parent,
@@ -175,3 +176,6 @@ void DistributePointsSettingsDialog::getValues(DistributePointsTool::Settings& s
 	settings.rotate_symbols = rotate_symbols_check->isChecked();
 	settings.additional_rotation = qDegreesToRadians(additional_rotation_edit->value());
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/distribute_points_tool.h
+++ b/src/tools/distribute_points_tool.h
@@ -32,6 +32,8 @@ class QCheckBox;
 class QSpinBox;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class PathObject;
 class PointObject;
 class PointSymbol;
@@ -129,4 +131,6 @@ private:
 	QDoubleSpinBox* additional_rotation_edit;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/draw_circle_tool.cpp
+++ b/src/tools/draw_circle_tool.cpp
@@ -44,6 +44,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 DrawCircleTool::DrawCircleTool(MapEditorController* editor, QAction* tool_action, bool is_helper_tool)
  : DrawLineAndAreaTool(editor, DrawCircle, tool_action, is_helper_tool)
 {
@@ -312,7 +314,10 @@ void DrawCircleTool::updateStatusText()
 	{
 		text = tr("<b>Click</b>: Finish the circle. ")
 		       + tr("<b>Drag</b>: Draw an ellipse. ")
-		       + MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
+		       + OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
 	}
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_circle_tool.h
+++ b/src/tools/draw_circle_tool.h
@@ -34,6 +34,8 @@ class QKeyEvent;
 class QMouseEvent;
 class QPainter;
 
+namespace OpenOrienteering {
+
 class KeyButtonBar;
 class MapEditorController;
 class MapWidget;
@@ -77,5 +79,8 @@ protected:
 	bool second_point_set  = false;
 	QPointer<KeyButtonBar> key_button_bar;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/draw_freehand_tool.cpp
+++ b/src/tools/draw_freehand_tool.cpp
@@ -38,6 +38,8 @@
 #include "tools/tool.h"
 
 
+namespace OpenOrienteering {
+
 DrawFreehandTool::DrawFreehandTool(MapEditorController* editor, QAction* tool_action, bool is_helper_tool)
 : DrawLineAndAreaTool(editor, DrawFreehand, tool_action, is_helper_tool)
 {
@@ -285,6 +287,9 @@ void DrawFreehandTool::updateStatusText()
 {
 	QString text;
 	text = tr("<b>Drag</b>: Draw a path. ") +
-			MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
+			OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_freehand_tool.h
+++ b/src/tools/draw_freehand_tool.h
@@ -38,6 +38,8 @@ class QKeyEvent;
 class QMouseEvent;
 class QPainter;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 
@@ -79,5 +81,8 @@ private:
 	QPoint cur_pos;
 	MapCoordF cur_pos_map;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/draw_line_and_area_tool.cpp
+++ b/src/tools/draw_line_and_area_tool.cpp
@@ -45,6 +45,7 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
 
 DrawLineAndAreaTool::DrawLineAndAreaTool(MapEditorController* editor, Type type, QAction* tool_action, bool is_helper_tool)
 : MapEditorTool(editor, type, tool_action)
@@ -389,3 +390,5 @@ void DrawLineAndAreaTool::addPreviewPointSymbolsForBorder(const LineSymbol* line
 		preview_point_radius = qMax(preview_point_radius, preview->getInnerRadius() + preview->getOuterWidth());
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_line_and_area_tool.h
+++ b/src/tools/draw_line_and_area_tool.h
@@ -35,6 +35,8 @@ class QEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class CombinedSymbol;
 class LineSymbol;
 struct LineSymbolBorder;
@@ -137,4 +139,6 @@ protected:
 	
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/draw_path_tool.cpp
+++ b/src/tools/draw_path_tool.cpp
@@ -64,6 +64,8 @@
 #include "undo/object_undo.h"
 
 
+namespace OpenOrienteering {
+
 DrawPathTool::DrawPathTool(MapEditorController* editor, QAction* tool_action, bool is_helper_tool, bool allow_closing_paths)
 : DrawLineAndAreaTool(editor, DrawPath, tool_action, is_helper_tool)
 , cur_map_widget(mapWidget())
@@ -1167,7 +1169,7 @@ void DrawPathTool::updateStatusText()
 	
 	if (draw_dash_points && !is_helper_tool)
 	{
-		text += DrawLineAndAreaTool::tr("<b>Dash points on.</b> ") + QLatin1String("| ");
+		text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>Dash points on.</b> ") + QLatin1String("| ");
 	}
 	
 	QVarLengthArray<QString, 3> modifier_keys;
@@ -1175,7 +1177,7 @@ void DrawPathTool::updateStatusText()
 	{
 		if (shift_pressed)
 		{
-			text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap or append to existing objects. ").arg(ModifierKey::shift());
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap or append to existing objects. ").arg(ModifierKey::shift());
 		}
 		else
 		{
@@ -1183,8 +1185,8 @@ void DrawPathTool::updateStatusText()
 		
 			if (ctrl_pressed)
 			{
-				text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Pick direction from existing objects. ").arg(ModifierKey::control());
-				text += DrawLineAndAreaTool::tr("<b>%1+%2</b>: Segment azimuth and length. ").arg(ModifierKey::control(), ModifierKey::space());
+				text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Pick direction from existing objects. ").arg(ModifierKey::control());
+				text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+%2</b>: Segment azimuth and length. ").arg(ModifierKey::control(), ModifierKey::space());
 			}
 			else
 			{
@@ -1192,7 +1194,7 @@ void DrawPathTool::updateStatusText()
 			
 				text += tr("<b>Click</b>: Start a straight line. <b>Drag</b>: Start a curve. ");
 				
-				// text += DrawLineAndAreaTool::tr(draw_dash_points ? "<b>%1</b> Disable dash points. " : "<b>%1</b>: Enable dash points. ").arg(ModifierKey::space());
+				// text += ::OpenOrienteering::DrawLineAndAreaTool::tr(draw_dash_points ? "<b>%1</b> Disable dash points. " : "<b>%1</b>: Enable dash points. ").arg(ModifierKey::space());
 			}
 		}
 	}
@@ -1200,7 +1202,7 @@ void DrawPathTool::updateStatusText()
 	{
 		if (shift_pressed)
 		{
-			text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift())
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift())
 			        + tr("<b>%1+Drag</b>: Follow existing objects. ").arg(ModifierKey::shift());
 		}
 		else
@@ -1210,8 +1212,8 @@ void DrawPathTool::updateStatusText()
 			if (ctrl_pressed)
 			{
 				if (angle_helper->isActive())
-					text += DrawLineAndAreaTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
-				text += DrawLineAndAreaTool::tr("<b>%1+%2</b>: Segment azimuth and length. ").arg(ModifierKey::control(), ModifierKey::space());
+					text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
+				text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+%2</b>: Segment azimuth and length. ").arg(ModifierKey::control(), ModifierKey::space());
 			}
 			else
 			{
@@ -1220,8 +1222,8 @@ void DrawPathTool::updateStatusText()
 				text += tr("<b>Click</b>: Draw a straight line. <b>Drag</b>: Draw a curve. "
 				           "<b>Right or double click</b>: Finish the path. "
 				           "<b>%1</b>: Close the path. ").arg(ModifierKey::return_key())
-				        + DrawLineAndAreaTool::tr("<b>%1</b>: Undo last point. ").arg(ModifierKey::backspace())
-				        + MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
+				        + ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1</b>: Undo last point. ").arg(ModifierKey::backspace())
+				        + ::OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
 			}
 		}
 	}
@@ -1237,13 +1239,13 @@ void DrawPathTool::updateStatusText()
 		switch (modifier_keys.length())
 		{
 		case 1:
-			text_more = MapEditorTool::tr("More: %1").arg(modifier_keys[0]);
+			text_more = ::OpenOrienteering::MapEditorTool::tr("More: %1").arg(modifier_keys[0]);
 			break;
 		case 2:
-			text_more = MapEditorTool::tr("More: %1, %2").arg(modifier_keys[0], modifier_keys[1]);
+			text_more = ::OpenOrienteering::MapEditorTool::tr("More: %1, %2").arg(modifier_keys[0], modifier_keys[1]);
 			break;
 		case 3:
-			text_more = MapEditorTool::tr("More: %1, %2, %3").arg(modifier_keys[0], modifier_keys[1], modifier_keys[2]);
+			text_more = ::OpenOrienteering::MapEditorTool::tr("More: %1, %2, %3").arg(modifier_keys[0], modifier_keys[1], modifier_keys[2]);
 			break;
 		default:
 			Q_UNREACHABLE();
@@ -1253,3 +1255,6 @@ void DrawPathTool::updateStatusText()
 	
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_path_tool.h
+++ b/src/tools/draw_path_tool.h
@@ -39,6 +39,8 @@ class QMouseEvent;
 class QPainter;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class AzimuthInfoHelper;
 class ConstrainAngleToolHelper;
 class FollowPathToolHelper;
@@ -173,5 +175,8 @@ protected:
 	bool finished_path_is_selected = false;  ///< True just after finishing a path
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/draw_point_gps_tool.cpp
+++ b/src/tools/draw_point_gps_tool.cpp
@@ -46,6 +46,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 DrawPointGPSTool::DrawPointGPSTool(GPSDisplay* gps_display, MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase(QCursor(QPixmap(QString::fromLatin1(":/images/cursor-draw-point.png")), 11, 11), DrawPoint, editor, tool_action)
 , renderables(new MapRenderables(map()))
@@ -216,3 +218,6 @@ void DrawPointGPSTool::symbolDeleted(int pos, const Symbol* old_symbol)
 	if (last_used_symbol == old_symbol)
 		deactivate();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_point_gps_tool.h
+++ b/src/tools/draw_point_gps_tool.h
@@ -33,6 +33,8 @@ class QLabel;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class GPSDisplay;
 class MapCoordF;
 class MapEditorController;
@@ -79,4 +81,6 @@ protected:
 	QPointer<QLabel> help_label;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/draw_point_tool.cpp
+++ b/src/tools/draw_point_tool.cpp
@@ -58,6 +58,9 @@
 #include "undo/object_undo.h"
 #include "util/util.h"
 
+
+namespace OpenOrienteering {
+
 DrawPointTool::DrawPointTool(MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase(QCursor(QPixmap(QString::fromLatin1(":/images/cursor-draw-point.png")), 11, 11), DrawPoint, editor, tool_action)
 , renderables(new MapRenderables(map()))
@@ -356,3 +359,6 @@ void DrawPointTool::objectSelectionChangedImpl()
 {
 	// nothing
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_point_tool.h
+++ b/src/tools/draw_point_tool.h
@@ -36,6 +36,8 @@ class QPainter;
 class QPointF;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapCoordF;
 class MapEditorController;
 class MapRenderables;
@@ -97,5 +99,8 @@ protected:
 	std::unique_ptr<PointObject> preview_object;
 	std::unique_ptr<MapRenderables> renderables;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/draw_rectangle_tool.cpp
+++ b/src/tools/draw_rectangle_tool.cpp
@@ -56,6 +56,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 DrawRectangleTool::DrawRectangleTool(MapEditorController* editor, QAction* tool_action, bool is_helper_tool)
 : DrawLineAndAreaTool(editor, DrawRectangle, tool_action, is_helper_tool)
 , angle_helper(new ConstrainAngleToolHelper())
@@ -714,24 +716,24 @@ void DrawRectangleTool::updateDirtyRect()
 void DrawRectangleTool::updateStatusText()
 {
 	QString text;
-	static const QString text_more_shift_control_space(MapEditorTool::tr("More: %1, %2, %3").arg(ModifierKey::shift(), ModifierKey::control(), ModifierKey::space()));
-	static const QString text_more_shift_space(MapEditorTool::tr("More: %1, %2").arg(ModifierKey::shift(), ModifierKey::space()));
-	static const QString text_more_control_space(MapEditorTool::tr("More: %1, %2").arg(ModifierKey::control(), ModifierKey::space()));
+	static const QString text_more_shift_control_space(::OpenOrienteering::MapEditorTool::tr("More: %1, %2, %3").arg(ModifierKey::shift(), ModifierKey::control(), ModifierKey::space()));
+	static const QString text_more_shift_space(::OpenOrienteering::MapEditorTool::tr("More: %1, %2").arg(ModifierKey::shift(), ModifierKey::space()));
+	static const QString text_more_control_space(::OpenOrienteering::MapEditorTool::tr("More: %1, %2").arg(ModifierKey::control(), ModifierKey::space()));
 	QString text_more(text_more_shift_control_space);
 	
 	if (draw_dash_points)
-		text += DrawLineAndAreaTool::tr("<b>Dash points on.</b> ") + QLatin1String("| ");
+		text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>Dash points on.</b> ") + QLatin1String("| ");
 	
 	if (!editingInProgress())
 	{
 		if (ctrl_pressed)
 		{
-			text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Pick direction from existing objects. ").arg(ModifierKey::control());
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Pick direction from existing objects. ").arg(ModifierKey::control());
 			text_more = text_more_shift_space;
 		}
 		else if (shift_pressed)
 		{
-			text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift());
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift());
 			text_more = text_more_control_space;
 		}
 		else
@@ -745,7 +747,7 @@ void DrawRectangleTool::updateStatusText()
 		{
 			if (angles.size() == 1)
 			{
-				text += DrawLineAndAreaTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
+				text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
 			}
 			else
 			{
@@ -755,14 +757,14 @@ void DrawRectangleTool::updateStatusText()
 		}
 		else if (shift_pressed)
 		{
-			text += DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift());
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1+Click</b>: Snap to existing objects. ").arg(ModifierKey::shift());
 			text_more = text_more_control_space;
 		}
 		else
 		{
 			text += tr("<b>Click</b>: Set a corner point. <b>Right or double click</b>: Finish the rectangle. ");
-			text += DrawLineAndAreaTool::tr("<b>%1</b>: Undo last point. ").arg(ModifierKey::backspace());
-			text += MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
+			text += ::OpenOrienteering::DrawLineAndAreaTool::tr("<b>%1</b>: Undo last point. ").arg(ModifierKey::backspace());
+			text += ::OpenOrienteering::MapEditorTool::tr("<b>%1</b>: Abort. ").arg(ModifierKey::escape());
 		}
 	}
 	
@@ -770,3 +772,6 @@ void DrawRectangleTool::updateStatusText()
 	
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_rectangle_tool.h
+++ b/src/tools/draw_rectangle_tool.h
@@ -40,6 +40,8 @@ class QMouseEvent;
 class QPainter;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class ConstrainAngleToolHelper;
 class KeyButtonBar;
 class MapEditorController;
@@ -158,4 +160,6 @@ protected:
 	QPointer<QToolButton> dash_points_button;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/draw_text_tool.cpp
+++ b/src/tools/draw_text_tool.cpp
@@ -59,6 +59,8 @@
 #endif
 
 
+namespace OpenOrienteering {
+
 DrawTextTool::DrawTextTool(MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase { QCursor{ QPixmap(QString::fromLatin1(":/images/cursor-draw-text.png")), 11, 11 }, DrawText, editor, tool_action }
 , drawing_symbol { editor->activeSymbol() }
@@ -479,7 +481,10 @@ void DrawTextTool::updateStatusText()
 		if (!isDragging())
 			text = tr("<b>Click</b>: Create a text object with a single anchor. <b>Drag</b>: Create a text box. ");
 		if (!(active_modifiers & Qt::ShiftModifier))
-			text += EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
+			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
 	}
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/draw_text_tool.h
+++ b/src/tools/draw_text_tool.h
@@ -39,12 +39,14 @@ class QMouseEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapCoordF;
 class MapEditorController;
 class MapWidget;
+class Symbol;
 class TextObject;
 class TextObjectEditorHelper;
-class Symbol;
 
 
 /**
@@ -99,5 +101,8 @@ protected:
 	std::unique_ptr<TextObjectEditorHelper> text_editor;
 	bool waiting_for_mouse_release = false;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/edit_line_tool.cpp
+++ b/src/tools/edit_line_tool.cpp
@@ -70,6 +70,7 @@ namespace
 }
 
 
+namespace OpenOrienteering {
 
 EditLineTool::EditLineTool(MapEditorController* editor, QAction* tool_action)
  : EditTool(editor, EditLine, tool_action)
@@ -507,7 +508,7 @@ void EditLineTool::updateStatusText()
 	if (editingInProgress())
 	{
 		MapCoordF drag_vector = constrained_pos_map - click_pos_map;
-		text = EditTool::tr("<b>Coordinate offset:</b> %1, %2 mm  <b>Distance:</b> %3 m ").arg(
+		text = ::OpenOrienteering::EditTool::tr("<b>Coordinate offset:</b> %1, %2 mm  <b>Distance:</b> %3 m ").arg(
 		         QLocale().toString(drag_vector.x(), 'f', 1),
 		         QLocale().toString(-drag_vector.y(), 'f', 1),
 		         QLocale().toString(0.001 * map()->getScaleDenominator() * drag_vector.length(), 'f', 1))
@@ -516,23 +517,23 @@ void EditLineTool::updateStatusText()
 		if (angle_helper->isActive())
 			text += tr("<b>%1</b>: Free movement. ").arg(ModifierKey::control());
 		if (!(active_modifiers & Qt::ShiftModifier))
-			text += EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
+			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
 		else
 			text.chop(2); // Remove "| "
 	}
 	else
 	{
-		text = EditTool::tr("<b>Click</b>: Select a single object. <b>Drag</b>: Select multiple objects. <b>%1+Click</b>: Toggle selection. ").arg(ModifierKey::shift());
+		text = ::OpenOrienteering::EditTool::tr("<b>Click</b>: Select a single object. <b>Drag</b>: Select multiple objects. <b>%1+Click</b>: Toggle selection. ").arg(ModifierKey::shift());
 		if (map()->getNumSelectedObjects() > 0)
 		{
-			text += EditTool::tr("<b>%1</b>: Delete selected objects. ").arg(ModifierKey(DeleteObjectKey));
+			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Delete selected objects. ").arg(ModifierKey(DeleteObjectKey));
 			
 			if (map()->selectedObjects().size() <= max_objects_for_handle_display)
 			{
 				if (active_modifiers & Qt::ControlModifier)
 					text = tr("<b>%1+Click</b> on segment: Toggle between straight and curved. ").arg(ModifierKey::control());
 				else
-					text += MapEditorTool::tr("More: %1").arg(ModifierKey::control());
+					text += ::OpenOrienteering::MapEditorTool::tr("More: %1").arg(ModifierKey::control());
 			}
 		}
 	}
@@ -621,3 +622,6 @@ void EditLineTool::updateHoverState(MapCoordF cursor_pos)
 		updateDirtyRect();
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/edit_line_tool.h
+++ b/src/tools/edit_line_tool.h
@@ -36,6 +36,8 @@ class QMouseEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapRenderables;
 class MapWidget;
@@ -141,5 +143,8 @@ bool EditLineTool::hoveringOverFrame() const
 {
 	return hover_state == OverFrame;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/edit_point_tool.cpp
+++ b/src/tools/edit_point_tool.cpp
@@ -64,8 +64,10 @@
 #include "util/util.h"
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+	
 	/**
 	 * Maximum number of objects in the selection for which point handles
 	 * will still be displayed (and can be edited).
@@ -76,6 +78,8 @@ namespace
 	 * The value which indicates that no point of the current object is hovered.
 	 */
 	static auto no_point = std::numeric_limits<MapCoordVector::size_type>::max();
+	
+	
 }
 
 
@@ -714,14 +718,14 @@ void EditPointTool::updateStatusText()
 	else if (editingInProgress())
 	{
 		MapCoordF drag_vector = constrained_pos_map - click_pos_map;
-		text = EditTool::tr("<b>Coordinate offset:</b> %1, %2 mm  <b>Distance:</b> %3 m ").
+		text = ::OpenOrienteering::EditTool::tr("<b>Coordinate offset:</b> %1, %2 mm  <b>Distance:</b> %3 m ").
 		       arg(QLocale().toString(drag_vector.x(), 'f', 1),
 		           QLocale().toString(-drag_vector.y(), 'f', 1),
 		           QLocale().toString(0.001 * map()->getScaleDenominator() * drag_vector.length(), 'f', 1)) +
 		       QLatin1String("| ");
 		
 		if (!angle_helper->isActive())
-			text += EditTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
+			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Fixed angles. ").arg(ModifierKey::control());
 		
 		if (!(active_modifiers & Qt::ShiftModifier))
 		{
@@ -732,16 +736,16 @@ void EditPointTool::updateStatusText()
 			}	
 			else 
 			{
-				text += EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
+				text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
 			}
 		}
 	}
 	else
 	{
-		text = EditTool::tr("<b>Click</b>: Select a single object. <b>Drag</b>: Select multiple objects. <b>%1+Click</b>: Toggle selection. ").arg(ModifierKey::shift());
+		text = ::OpenOrienteering::EditTool::tr("<b>Click</b>: Select a single object. <b>Drag</b>: Select multiple objects. <b>%1+Click</b>: Toggle selection. ").arg(ModifierKey::shift());
 		if (map()->getNumSelectedObjects() > 0)
 		{
-			text += EditTool::tr("<b>%1</b>: Delete selected objects. ").arg(ModifierKey(DeleteObjectKey));
+			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Delete selected objects. ").arg(ModifierKey(DeleteObjectKey));
 			
 			if (map()->selectedObjects().size() <= max_objects_for_handle_display)
 			{
@@ -758,7 +762,7 @@ void EditPointTool::updateStatusText()
 				else if (switch_dash_points)
 					text = tr("<b>%1+Click</b> on point to switch between dash and normal point. ").arg(ModifierKey::space());
 				else
-					text += QLatin1String("| ") + MapEditorTool::tr("More: %1, %2").arg(ModifierKey::control(), ModifierKey::space());
+					text += QLatin1String("| ") + ::OpenOrienteering::MapEditorTool::tr("More: %1, %2").arg(ModifierKey::control(), ModifierKey::space());
 			}
 		}
 	}
@@ -947,3 +951,6 @@ bool EditPointTool::moveOppositeHandle() const
 	return !(active_modifiers & Qt::ShiftModifier)
 	       && hoveringOverCurveHandle();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/edit_point_tool.h
+++ b/src/tools/edit_point_tool.h
@@ -44,6 +44,8 @@ class QPainter;
 class QRectF;
 class QToolButton;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 class Object;
@@ -209,5 +211,8 @@ bool EditPointTool::hoveringOverFrame() const
 {
 	return hover_state == OverFrame;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/edit_tool.cpp
+++ b/src/tools/edit_tool.cpp
@@ -46,6 +46,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 EditTool::EditTool(MapEditorController* editor, MapEditorTool::Type type, QAction* tool_action)
  : MapEditorToolBase { QCursor(QPixmap(QString::fromLatin1(":/images/cursor-hollow.png")), 1, 1), type, editor, tool_action }
  , object_selector { new ObjectSelector(map()) }
@@ -271,3 +273,6 @@ void EditTool::drawBoundingPath(QPainter* painter, MapWidget* widget, const std:
 	painter_path.closeSubpath();
 	painter->drawPath(painter_path);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/edit_tool.h
+++ b/src/tools/edit_tool.h
@@ -41,10 +41,13 @@ class QPainter;
 class QPointF;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 class Object;
 class ObjectSelector;
+
 using SelectionInfoVector = std::vector<std::pair<int, Object*>>;
 
 
@@ -146,6 +149,11 @@ protected:
 	QScopedPointer<ObjectSelector> object_selector;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(EditTool::HoverState)
+
+}  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::EditTool::HoverState)
+
 
 #endif

--- a/src/tools/fill_tool.cpp
+++ b/src/tools/fill_tool.cpp
@@ -69,8 +69,10 @@ Q_STATIC_ASSERT((std::is_same<QRgb, unsigned int>::value));
 Q_STATIC_ASSERT(RGB_MASK == 0x00ffffff);
 
 
-namespace
-{
+namespace OpenOrienteering {
+
+namespace {
+
 /**
  * Helper structure used to represent a section of a traced path
  * while constructing the fill object.
@@ -536,3 +538,6 @@ bool FillTool::fillBoundary(const QImage& image, const std::vector<QPoint>& boun
 	
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/fill_tool.h
+++ b/src/tools/fill_tool.h
@@ -36,10 +36,13 @@ class QPainter;
 class QPoint;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorController;
 class RenderConfig;
 class Symbol;
+
 
 /** 
  * Tool to fill bounded areas with PathObjects.
@@ -103,5 +106,8 @@ protected:
 	
 	const Symbol* drawing_symbol;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/object_selector.cpp
+++ b/src/tools/object_selector.cpp
@@ -32,6 +32,8 @@
 #include "core/objects/object.h"
 
 
+namespace OpenOrienteering {
+
 ObjectSelector::ObjectSelector(Map* map)
  : map(map)
 {
@@ -177,3 +179,4 @@ bool ObjectSelector::selectionInfosEqual(const SelectionInfoVector& a, const Sel
 }
 
 
+}  // namespace OpenOrienteering

--- a/src/tools/object_selector.h
+++ b/src/tools/object_selector.h
@@ -24,9 +24,12 @@
 #include <utility>
 #include <vector>
 
+namespace OpenOrienteering {
+
 class Map;
 class MapCoordF;
 class Object;
+
 using SelectionInfoVector = std::vector<std::pair<int, Object*>>;
 
 
@@ -71,5 +74,7 @@ private:
 	Map* map;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/pan_tool.cpp
+++ b/src/tools/pan_tool.cpp
@@ -30,6 +30,8 @@
 #include "tools/tool.h"
 
 
+namespace OpenOrienteering {
+
 PanTool::PanTool(MapEditorController* editor, QAction* tool_action)
  : MapEditorToolBase(QCursor(Qt::OpenHandCursor), Pan, editor, tool_action)
 {
@@ -82,3 +84,6 @@ void PanTool::objectSelectionChangedImpl()
 {
 	// Nothing
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/pan_tool.h
+++ b/src/tools/pan_tool.h
@@ -28,6 +28,8 @@
 
 class QAction;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 
 
@@ -50,5 +52,8 @@ protected:
 	void dragFinish() override;
 	void dragCanceled() override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/point_handles.cpp
+++ b/src/tools/point_handles.cpp
@@ -36,6 +36,7 @@
 #include "gui/map/map_widget.h"
 
 
+namespace OpenOrienteering {
 
 PointHandles::PointHandles() noexcept
 {
@@ -233,3 +234,5 @@ const QImage PointHandles::loadHandleImage(unsigned int factor)
 	return shared_image;
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/tools/point_handles.h
+++ b/src/tools/point_handles.h
@@ -32,6 +32,8 @@
 
 class QPainter;
 
+namespace OpenOrienteering {
+
 class MapWidget;
 class Object;
 
@@ -166,5 +168,7 @@ private:
 	int display_radius = 0;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif // OPENORIENTEERING_POINT_HANDLES_H

--- a/src/tools/rotate_pattern_tool.cpp
+++ b/src/tools/rotate_pattern_tool.cpp
@@ -48,6 +48,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 RotatePatternTool::RotatePatternTool(MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase(QCursor(QPixmap(QString::fromLatin1(":/images/cursor-rotate.png")), 1, 1), Other, editor, tool_action)
 {
@@ -240,3 +242,6 @@ void RotatePatternTool::objectSelectionChangedImpl()
 	else
 		updateDirtyRect();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/rotate_pattern_tool.h
+++ b/src/tools/rotate_pattern_tool.h
@@ -31,6 +31,8 @@ class QKeyEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 
@@ -61,5 +63,8 @@ protected:
 	void updateStatusText() override;
 	void objectSelectionChangedImpl() override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/rotate_tool.cpp
+++ b/src/tools/rotate_tool.cpp
@@ -46,6 +46,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 RotateTool::RotateTool(MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase { QCursor { QString::fromLatin1(":/images/cursor-rotate.png"), 1, 1 }, Other, editor, tool_action }
 {
@@ -217,3 +219,6 @@ void RotateTool::updateStatusText()
 	
 	setStatusBarText(text);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/rotate_tool.h
+++ b/src/tools/rotate_tool.h
@@ -33,6 +33,8 @@ class QKeyEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 
@@ -72,4 +74,6 @@ protected:
 	qreal current_rotation  = 0;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/scale_tool.cpp
+++ b/src/tools/scale_tool.cpp
@@ -40,6 +40,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 ScaleTool::ScaleTool(MapEditorController* editor, QAction* tool_action)
 : MapEditorToolBase { scaledToScreen(QCursor{ QPixmap(QString::fromLatin1(":/images/cursor-scale.png")), 1, 1 }), Other, editor, tool_action }
 {
@@ -160,3 +162,4 @@ void ScaleTool::objectSelectionChangedImpl()
 }
 
 
+}  // namespace OpenOrienteering

--- a/src/tools/scale_tool.h
+++ b/src/tools/scale_tool.h
@@ -31,6 +31,8 @@ class QAction;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class MapEditorController;
 class MapWidget;
 
@@ -64,5 +66,8 @@ protected:
 	double reference_length = 0;
 	double scaling_factor   = 1;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/text_object_editor_helper.cpp
+++ b/src/tools/text_object_editor_helper.cpp
@@ -61,6 +61,9 @@
 #endif
 //#  define INPUT_METHOD_BUGS_RESOLVED
 
+
+namespace OpenOrienteering {
+
 // ### TextObjectEditorHelper::BatchEdit ###
 
 TextObjectEditorHelper::BatchEdit::BatchEdit(not_null<TextObjectEditorHelper*> editor, int actions)
@@ -910,3 +913,6 @@ void TextObjectEditorHelper::foreachLineRect(int begin, int end, const std::func
 		worker({left, line_info->line_y - line_info->ascent, width, line_info->ascent + line_info->descent});
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/text_object_editor_helper.h
+++ b/src/tools/text_object_editor_helper.h
@@ -37,6 +37,8 @@ class QRectF;
 class QVariant;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MapCoordF;
 class MapEditorController;
 class MapWidget;
@@ -317,5 +319,7 @@ TextObject* TextObjectEditorHelper::object() const
 	return text_object;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/tool.cpp
+++ b/src/tools/tool.cpp
@@ -41,6 +41,8 @@
 #include "gui/map/map_widget.h"
 
 
+namespace OpenOrienteering {
+
 namespace {
 
 /// Utility function for MapEditorTool::findHoverPoint
@@ -51,7 +53,8 @@ qreal distanceSquared(QPointF a, const QPointF& b)
 	return QPointF::dotProduct(a, a); // introduced in Qt 5.1
 }
 
-} // namespace
+
+}  // namespace
 
 
 
@@ -360,7 +363,7 @@ namespace
 			return 4;
 	}
 	
-} // namespace
+}  // namespace
 
 
 // slot
@@ -373,3 +376,5 @@ void MapEditorTool::settingsChanged()
 	draw_on_right_click = Settings::getInstance().getSettingCached(Settings::MapEditor_DrawLastPointOnRightClick).toBool();
 }
 
+
+}  // namespace OpenOrienteering

--- a/src/tools/tool.h
+++ b/src/tools/tool.h
@@ -46,6 +46,8 @@ class QPainter;
 class QPointF;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class MainWindow;
 class Map;
 class MapEditorController;
@@ -379,5 +381,7 @@ private:
 	bool draw_on_right_click  = false;
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/tools/tool_base.cpp
+++ b/src/tools/tool_base.cpp
@@ -41,6 +41,8 @@
 #include "undo/object_undo.h"
 
 
+namespace OpenOrienteering {
+
 // ### MapEditorToolBase::EditedItem ###
 
 MapEditorToolBase::EditedItem::EditedItem(Object* active_object)
@@ -644,3 +646,6 @@ void MapEditorToolBase::updateConstrainedPositions()
 		angle_helper->getConstrainedCursorPositions(constrained_pos_map, constrained_pos_map, constrained_pos, cur_map_widget);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/tool_base.h
+++ b/src/tools/tool_base.h
@@ -45,6 +45,8 @@ class QMouseEvent;
 class QPainter;
 class QRectF;
 
+namespace OpenOrienteering {
+
 class ConstrainAngleToolHelper;
 class KeyButtonBar;
 class MapEditorController;
@@ -318,4 +320,5 @@ private:
 };
 
 
+}  // namespace OpenOrienteering
 #endif

--- a/src/tools/tool_helpers.cpp
+++ b/src/tools/tool_helpers.cpp
@@ -56,6 +56,8 @@
 #include "util/util.h"
 
 
+namespace OpenOrienteering {
+
 // ### ConstrainAngleToolHelper ###
 
 ConstrainAngleToolHelper::ConstrainAngleToolHelper()
@@ -617,8 +619,8 @@ namespace
 AzimuthInfoHelper::AzimuthInfoHelper(const QWidget* widget, QColor color)
 : text_color(std::move(color))
 , text_font(widget->font())
-, azimuth_template(QCoreApplication::translate("UnitOfMeasurement", "%1°", "degree"))
-, distance_template(QCoreApplication::translate("UnitOfMeasurement", "%1 m", "meter"))
+, azimuth_template(QCoreApplication::translate("OpenOrienteering::UnitOfMeasurement", "%1°", "degree"))
+, distance_template(QCoreApplication::translate("OpenOrienteering::UnitOfMeasurement", "%1 m", "meter"))
 {
 	auto size = text_font.pixelSize();
 	if (size >= 0)
@@ -715,3 +717,6 @@ void AzimuthInfoHelper::draw(QPainter* painter, const MapWidget* widget, const M
 
 	painter->restore();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/tools/tool_helpers.h
+++ b/src/tools/tool_helpers.h
@@ -43,6 +43,8 @@ class QPointF;
 class QRectF;
 class QWidget;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapEditorTool;
 class MapWidget;
@@ -375,5 +377,7 @@ public:
 
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/undo/map_part_undo.cpp
+++ b/src/undo/map_part_undo.cpp
@@ -28,6 +28,7 @@
 #include "core/map_part.h"
 #include "util/xml_stream_util.h"
 
+
 namespace literal
 {
 	const QLatin1String change("change");
@@ -38,6 +39,10 @@ namespace literal
 	const QLatin1String modify("modify");
 	const QLatin1String name("name");
 }
+
+
+
+namespace OpenOrienteering {
 
 MapPartUndoStep::MapPartUndoStep(Map* map, MapPartChange change, const MapPart* part)
 : UndoStep(UndoStep::MapPartUndoStepType, map)
@@ -176,3 +181,6 @@ void MapPartUndoStep::loadImpl(QXmlStreamReader &xml, SymbolDictionary &)
 		name  = change_element.attribute<QString>(literal::name);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/undo/map_part_undo.h
+++ b/src/undo/map_part_undo.h
@@ -29,6 +29,8 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class MapPart;
 
@@ -100,5 +102,8 @@ protected:
 	
 	QString name;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif // MAP_PART_UNDO_H

--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -30,11 +30,15 @@
 #include "core/symbols/symbol.h"
 #include "util/xml_stream_util.h"
 
+
 namespace literal
 {
 	const QLatin1String source("source");
 	const QLatin1String part("part");
 }
+
+
+namespace OpenOrienteering {
 
 // ### ObjectModifyingUndoStep ###
 
@@ -767,3 +771,6 @@ void ObjectTagsUndoStep::loadImpl(QXmlStreamReader &xml, SymbolDictionary &symbo
 		UndoStep::loadImpl(xml, symbol_dict);
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/undo/object_undo.h
+++ b/src/undo/object_undo.h
@@ -37,7 +37,10 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
+
 
 /** 
  * Base class for undo steps which modify objects of a single map part.
@@ -438,5 +441,7 @@ int ObjectModifyingUndoStep::getPartIndex() const
 	return part_index;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/undo/undo.cpp
+++ b/src/undo/undo.cpp
@@ -29,11 +29,16 @@
 #include "map_part_undo.h"
 #include "util/xml_stream_util.h"
 
+
 namespace literal
 {
 	const QLatin1String step("step");
 	const QLatin1String steps("steps");
 }
+
+
+
+namespace OpenOrienteering {
 
 // ### UndoStep ###
 
@@ -292,5 +297,8 @@ bool NoOpUndoStep::load(QIODevice*, int)
 	qWarning("InvalidUndoStep::load(QIODevice*, int) must not be called");
 	return false;
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/undo/undo.h
+++ b/src/undo/undo.h
@@ -31,6 +31,8 @@ class QIODevice;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class Object;
 
@@ -375,5 +377,8 @@ UndoStep* CombinedUndoStep::getSubStep(int i)
 {
 	return steps[i];
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/undo/undo_manager.cpp
+++ b/src/undo/undo_manager.cpp
@@ -40,6 +40,8 @@
 #include "util/xml_stream_util.h"
 
 
+namespace OpenOrienteering {
+
 Q_STATIC_ASSERT(UndoManager::max_undo_steps < std::numeric_limits<int>::max());
 
 
@@ -503,3 +505,6 @@ UndoManager::StepList UndoManager::loadSteps(QXmlStreamReader& xml, SymbolDictio
 	}
 	return steps;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/undo/undo_manager.h
+++ b/src/undo/undo_manager.h
@@ -36,6 +36,8 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 class Map;
 class UndoStep;
 
@@ -342,5 +344,7 @@ private:
 	
 };
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/dxfparser.cpp
+++ b/src/util/dxfparser.cpp
@@ -24,6 +24,8 @@
 #include <QDebug>
 
 
+namespace OpenOrienteering {
+
 QString DXFParser::parse()
 {
 	Q_ASSERT(device); // Programmer's responsibility
@@ -33,7 +35,7 @@ QString DXFParser::parse()
 	{
 		if (!device->open(QIODevice::ReadOnly))
 		{
-			return QApplication::translate("DXFParser", "Could not open the file.");
+			return QApplication::translate("OpenOrienteering::DXFParser", "Could not open the file.");
 		}
 		must_close_device = true;
 	}
@@ -49,7 +51,7 @@ QString DXFParser::parse()
 	if (code != 0 || value != QLatin1String("SECTION"))
 	{
 		// File does not start with DXF section
-		return QApplication::translate("DXFParser", "The file is not an DXF file.");
+		return QApplication::translate("OpenOrienteering::DXFParser", "The file is not an DXF file.");
 	}
 
 	paths = QList<DXFPath>();
@@ -598,3 +600,6 @@ void DXFParser::parseUnknown(QIODevice *d)
 		; // nothing
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/dxfparser.h
+++ b/src/util/dxfparser.h
@@ -33,6 +33,7 @@
 class QIODevice;
 class QPointF;
 
+namespace OpenOrienteering {
 
 struct DXFCoordinate
 {
@@ -153,5 +154,8 @@ DXFParser::DXFParser()
 {
 	; // nothing
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/encoding.cpp
+++ b/src/util/encoding.cpp
@@ -26,8 +26,7 @@
 #include <QTextCodec>
 
 
-namespace
-{
+namespace {
 
 struct LanguageMapping
 {
@@ -50,7 +49,11 @@ const LanguageMapping mappings[] = {
 #endif
 };
 
-} //namespace
+}  // namespace
+
+
+
+namespace OpenOrienteering {
 
 const char* Util::codepageForLanguage(const QString& language_name)
 {
@@ -75,3 +78,6 @@ QTextCodec* Util::codecForName(const char* name)
 	else
 		return QTextCodec::codecForName(name);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/encoding.h
+++ b/src/util/encoding.h
@@ -23,8 +23,9 @@
 class QString;
 class QTextCodec;
 
-namespace Util
-{
+namespace OpenOrienteering {
+
+namespace Util {
 
 /**
  * Determines the name of the 8-bit legacy codepage for a language.
@@ -48,6 +49,9 @@ const char* codepageForLanguage(const QString& language_name);
  */
 QTextCodec* codecForName(const char* name);
 
-}
+
+}  // namespace Util
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/item_delegates.cpp
+++ b/src/util/item_delegates.cpp
@@ -31,6 +31,8 @@
 #include "gui/util_gui.h"
 
 
+namespace OpenOrienteering {
+
 // ### ColorItemDelegate ###
 
 ColorItemDelegate::ColorItemDelegate(QObject* parent)
@@ -259,3 +261,6 @@ QSize TextDocItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QM
 	
 	return QSize(text_doc->idealWidth(), text_doc->size().height());
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/item_delegates.h
+++ b/src/util/item_delegates.h
@@ -36,6 +36,8 @@ class QTextDocument;
 class QStyleOptionViewItem;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * An item delegate which respects colors from the model even when the item is selected.
@@ -242,5 +244,8 @@ protected:
 	 */
 	const Provider* const provider;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/matrix.cpp
+++ b/src/util/matrix.cpp
@@ -34,6 +34,8 @@
 #include "util/xml_stream_util.h"
 
 
+namespace OpenOrienteering {
+
 #ifndef NO_NATIVE_FILE_FORMAT
 
 void Matrix::load(QIODevice* file)
@@ -217,3 +219,6 @@ void Matrix::print() const
 	}
 	printf("\n");
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/matrix.h
+++ b/src/util/matrix.h
@@ -30,6 +30,8 @@ class QString;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 
 /** Dynamically sized matrix of doubles. */
 class Matrix
@@ -195,4 +197,6 @@ private:
 	int m;
 };
 
+
+}  // namespace OpenOrienteering
 #endif

--- a/src/util/overriding_shortcut.cpp
+++ b/src/util/overriding_shortcut.cpp
@@ -26,6 +26,8 @@
 #include <QWidget>
 
 
+namespace OpenOrienteering {
+
 // ### OverridingShortcut ###
 
 OverridingShortcut::OverridingShortcut(QWidget* parent)
@@ -71,3 +73,6 @@ bool OverridingShortcut::eventFilter(QObject* /*watched*/, QEvent* event)
 	
 	return false;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/overriding_shortcut.h
+++ b/src/util/overriding_shortcut.h
@@ -29,6 +29,8 @@
 class QEvent;
 class QWidget;
 
+namespace OpenOrienteering {
+
 
 /**
  * OverridingShortcut is a variation of QShortcut which takes precedence over
@@ -75,5 +77,8 @@ private:
 	QElapsedTimer timer;
 	
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/recording_translator.cpp
+++ b/src/util/recording_translator.cpp
@@ -24,6 +24,8 @@
 #include <QDebug>
 
 
+namespace OpenOrienteering {
+
 RecordingTranslator::RecordingTranslator(QObject* parent)
  : QTranslator(parent)
 {
@@ -46,3 +48,6 @@ QString RecordingTranslator::translate(const char* context, const char* sourceTe
 	static const QString null_string;
 	return null_string;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/recording_translator.h
+++ b/src/util/recording_translator.h
@@ -25,6 +25,8 @@
 #include <QString>
 #include <QTranslator>
 
+namespace OpenOrienteering {
+
 
 /** A QTranslator variation that doesn't actually translate,
  *  but instead dumps (TODO: records) the strings to be translated.
@@ -50,5 +52,8 @@ public:
 	 *  Note: This is the Qt5 signature of translate(). */
 	QString	translate(const char* context, const char* sourceText, const char* disambiguation = 0, int n = -1) const override;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/scoped_signals_blocker.cpp
+++ b/src/util/scoped_signals_blocker.cpp
@@ -24,6 +24,8 @@
 #include <QObject>
 
 
+namespace OpenOrienteering {
+
 ScopedMultiSignalsBlocker::~ScopedMultiSignalsBlocker()
 {
 #ifdef MAPPER_DEVELOPMENT_BUILD
@@ -45,3 +47,6 @@ void ScopedMultiSignalsBlocker::add(QObject* object)
 	items.push_back( {object, object && object->blockSignals(true)} );
 	Q_ASSERT(!object || object->signalsBlocked());
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/scoped_signals_blocker.h
+++ b/src/util/scoped_signals_blocker.h
@@ -25,6 +25,8 @@
 
 class QObject;
 
+namespace OpenOrienteering {
+
 
 /**
  * @brief A safe and scoped wrapper around QObject::blockSignals() of multiple objects.
@@ -108,5 +110,8 @@ void ScopedMultiSignalsBlocker::add() const noexcept
 {
 	// nothing
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/transformation.cpp
+++ b/src/util/transformation.cpp
@@ -32,6 +32,9 @@
 #include "util/matrix.h"
 #include "util/xml_stream_util.h"
 
+
+namespace OpenOrienteering {
+
 // ### PassPoint ###
 
 #ifndef NO_NATIVE_FILE_FORMAT
@@ -385,3 +388,6 @@ bool PassPointList::estimateNonIsometricSimilarityTransform(not_null<QTransform*
 		output.get(2, 0), output.get(5, 0), 1);
 	return true;
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/transformation.h
+++ b/src/util/transformation.h
@@ -31,6 +31,8 @@ class QTransform;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 struct TemplateTransform;
 
 
@@ -77,5 +79,8 @@ public:
 	/** Estimates an affine transformation without shearing. */
 	bool estimateNonIsometricSimilarityTransform(not_null<QTransform*> out);
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/translation_util.cpp
+++ b/src/util/translation_util.cpp
@@ -64,9 +64,11 @@ QString default_language()
 	return QLocale::system().name().left(2);
 }
 
-} // namespace
+}  // namespace
 
 
+
+namespace OpenOrienteering {
 
 QString TranslationUtil::base_name(QString::fromLatin1("qt_"));
 
@@ -204,3 +206,6 @@ TranslationUtil::Language TranslationUtil::languageFromSettings(const QSettings&
 	auto language_code = settings.value(QLatin1String("language"), default_language()).toString();
 	return languageFromCode(language_code);
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/translation_util.h
+++ b/src/util/translation_util.h
@@ -30,6 +30,8 @@
 class QSettings;
 // IWYU pragma: no_forward_declare QTranslator
 
+namespace OpenOrienteering {
+
 
 /**
  * A simplified interface to searching and loading translations.
@@ -167,5 +169,7 @@ bool operator<(const TranslationUtil::Language& first, const TranslationUtil::La
 	return first.code < second.code;
 }
 
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -33,6 +33,8 @@
 class QPointF;
 
 
+namespace OpenOrienteering {
+
 void blockSignalsRecursively(QObject* obj, bool block)
 {
 	if (!obj)
@@ -201,3 +203,6 @@ void loadString(QIODevice* file, QString& str)
 	else
 		str.clear();
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -37,25 +37,6 @@ class QString;
 // IWYU pragma: no_forward_declare QPointF
 // IWYU pragma: no_forward_declare QRectF
 
-class MapCoordF;
-
-
-// clazy:excludeall=missing-qobject-macro
-
-
-/** Value to calculate the optimum handle distance of 4 cubic bezier curves
- *  used to approximate a circle. */
-#define BEZIER_KAPPA 0.5522847498
-
-/** When drawing a cubic bezier curve, the distance between start and end point
- *  is multiplied by this value to get the handle distance from start respectively
- *  end points.
- * 
- *  Calculated as BEZIER_HANDLE_DISTANCE = BEZIER_KAPPA / sqrt(2) */
-#define BEZIER_HANDLE_DISTANCE 0.390524291729
-
-
-
 namespace std
 {
 	/**
@@ -73,11 +54,32 @@ namespace std
 	template< class T >
 	constexpr double log2(T value)
 	{
-		static_assert(std::is_floating_point<T>::value,
+		static_assert(::std::is_floating_point<T>::value,
 					  "The argument to std::log2 must be called a floating point value");
 		return log(value)/M_LN2;
 	}
 }
+
+
+
+namespace OpenOrienteering {
+
+class MapCoordF;
+
+
+// clazy:excludeall=missing-qobject-macro
+
+
+/** Value to calculate the optimum handle distance of 4 cubic bezier curves
+ *  used to approximate a circle. */
+#define BEZIER_KAPPA 0.5522847498
+
+/** When drawing a cubic bezier curve, the distance between start and end point
+ *  is multiplied by this value to get the handle distance from start respectively
+ *  end points.
+ * 
+ *  Calculated as BEZIER_HANDLE_DISTANCE = BEZIER_KAPPA / sqrt(2) */
+#define BEZIER_HANDLE_DISTANCE 0.390524291729
 
 
 
@@ -303,5 +305,8 @@ namespace Util
 	}
 	
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/src/util/xml_stream_util.cpp
+++ b/src/util/xml_stream_util.cpp
@@ -41,6 +41,8 @@
 #include "fileformats/xml_file_format.h"
 
 
+namespace OpenOrienteering {
+
 void writeLineBreak(QXmlStreamWriter& xml)
 {
 	if (!xml.autoFormatting())
@@ -196,7 +198,7 @@ void XmlElementReader::read(MapCoordVector& coords)
 			const QXmlStreamReader::TokenType token = xml.tokenType();
 			if (xml.error() || token == QXmlStreamReader::EndDocument)
 			{
-				throw FileFormatException(ImportExport::tr("Could not parse the coordinates."));
+				throw FileFormatException(::OpenOrienteering::ImportExport::tr("Could not parse the coordinates."));
 			}
 			else if (token == QXmlStreamReader::Characters && !xml.isWhitespace())
 			{
@@ -212,7 +214,7 @@ void XmlElementReader::read(MapCoordVector& coords)
 				{
 					Q_UNUSED(e)
 					qDebug("Could not parse the coordinates: %s", e.what());
-					throw FileFormatException(ImportExport::tr("Could not parse the coordinates."));
+					throw FileFormatException(::OpenOrienteering::ImportExport::tr("Could not parse the coordinates."));
 				}
 			}
 			else if (token == QXmlStreamReader::StartElement)
@@ -231,11 +233,14 @@ void XmlElementReader::read(MapCoordVector& coords)
 	}
 	catch (std::range_error &e)
 	{
-		throw FileFormatException(MapCoord::tr(e.what()));
+		throw FileFormatException(::OpenOrienteering::MapCoord::tr(e.what()));
 	}
 	
 	if (coords.size() != num_coords)
 	{
-		throw FileFormatException(ImportExport::tr("Expected %1 coordinates, found %2."));
+		throw FileFormatException(::OpenOrienteering::ImportExport::tr("Expected %1 coordinates, found %2."));
 	}
 }
+
+
+}  // namespace OpenOrienteering

--- a/src/util/xml_stream_util.h
+++ b/src/util/xml_stream_util.h
@@ -33,13 +33,17 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+// IWYU pragma: no_include "core/map_coord.h"
+
 class QRectF;
 class QSizeF;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
-// IWYU pragma: no_include "core/map_coord.h"
+namespace OpenOrienteering {
+
 class MapCoord;  // IWYU pragma: keep
+
 using MapCoordVector = std::vector<MapCoord>;
 
 
@@ -751,5 +755,8 @@ void XmlElementReader::read(QHash<QString, QString> &tags)
 			xml.skipCurrentElement();
 	}
 }
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/test/autosave_t.cpp
+++ b/test/autosave_t.cpp
@@ -25,7 +25,6 @@
 #include <QString>
 #include <QThread>
 
-
 #include "settings.h"
 
 

--- a/test/autosave_t.h
+++ b/test/autosave_t.h
@@ -24,6 +24,8 @@
 
 #include "core/autosave.h"
 
+using namespace OpenOrienteering;
+
 
 /**
  * @test A simple document class for AutosaveTest.

--- a/test/coord_xml_t.cpp
+++ b/test/coord_xml_t.cpp
@@ -26,6 +26,7 @@
 #include "fileformats/xml_file_format.h"
 #include "util/xml_stream_util.h"
 
+
 namespace literal
 {
 	static const QLatin1String x("x");
@@ -33,6 +34,8 @@ namespace literal
 	static const QLatin1String flags("flags");
 }
 
+
+namespace OpenOrienteering {
 
 void CoordXmlTest::initTestCase()
 {
@@ -1065,4 +1068,6 @@ bool CoordXmlTest::compare_all(MapCoordVector& coords, MapCoord& expected) const
 }
 
 
-QTEST_GUILESS_MAIN(CoordXmlTest)
+}  // namespace OpenOrienteering
+
+QTEST_GUILESS_MAIN(OpenOrienteering::CoordXmlTest)

--- a/test/coord_xml_t.h
+++ b/test/coord_xml_t.h
@@ -27,6 +27,8 @@
 
 class QXmlStreamWriter;
 
+namespace OpenOrienteering {
+
 
 /**
  * @test Benchmarks different implementations of saving and loading
@@ -105,5 +107,8 @@ private:
 	MapCoord proto_coord;
 	QBuffer buffer;
 };
+
+
+}  // namespace OpenOrienteering
 
 #endif

--- a/test/duplicate_equals_t.cpp
+++ b/test/duplicate_equals_t.cpp
@@ -28,6 +28,8 @@
 #include "core/map.h"
 #include "core/objects/object.h"
 
+using namespace OpenOrienteering;
+
 
 namespace
 {
@@ -36,7 +38,7 @@ static const auto test_files = {
   "data:test_map.omap",
 };
 
-} // namespace
+}  // namespace
 
 
 void DuplicateEqualsTest::initTestCase()

--- a/test/encoding_t.cpp
+++ b/test/encoding_t.cpp
@@ -28,6 +28,8 @@
 
 #include "util/encoding.h"
 
+using namespace OpenOrienteering;
+
 
 EncodingTest::EncodingTest(QObject* parent)
 : QObject(parent)

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -42,6 +42,8 @@
 #include "undo/undo_manager.h"
 #include "util/backports.h"
 
+using namespace OpenOrienteering;
+
 
 #ifdef QT_PRINTSUPPORT_LIB
 
@@ -325,7 +327,7 @@ namespace
 #endif
 	};
 	
-} // namespace
+}  // namespace
 
 
 

--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -26,6 +26,8 @@
 #include "core/crs_template.h"
 #include "fileformats/xml_file_format.h"
 
+using namespace OpenOrienteering;
+
 
 int XMLFileFormat::active_version = 6;
 

--- a/test/georeferencing_t.h
+++ b/test/georeferencing_t.h
@@ -24,6 +24,8 @@
 
 #include "core/georeferencing.h"
 
+using namespace OpenOrienteering;
+
 
 /**
  * @test Tests the Georeferencing class.

--- a/test/locale_t.cpp
+++ b/test/locale_t.cpp
@@ -27,11 +27,19 @@
 
 #include "util/translation_util.h"
 
+using namespace OpenOrienteering;
+
+
+namespace OpenOrienteering {
 
 inline
 bool operator==(const TranslationUtil::Language& first, const TranslationUtil::Language& second) {
 	return first.code == second.code && first.displayName == second.displayName;
 }
+
+
+}  // namespace OpenOrienteering
+
 
 
 LocaleTest::LocaleTest(QObject* parent)

--- a/test/map_color_t.cpp
+++ b/test/map_color_t.cpp
@@ -32,6 +32,8 @@
 
 #include "core/map_color.h"
 
+using namespace OpenOrienteering;
+
 
 namespace QTest
 {

--- a/test/map_t.cpp
+++ b/test/map_t.cpp
@@ -35,6 +35,8 @@
 #include "core/symbols/symbol.h"
 #include "core/symbols/point_symbol.h"
 
+using namespace OpenOrienteering;
+
 
 namespace
 {

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -34,6 +34,7 @@
 #include "core/objects/object_query.h"
 #include "core/symbols/point_symbol.h"
 
+using namespace OpenOrienteering;
 
 namespace QTest
 {

--- a/test/object_query_t.h
+++ b/test/object_query_t.h
@@ -23,7 +23,8 @@
 
 #include <QObject>
 
-class Object;
+namespace OpenOrienteering { class Object; }
+using OpenOrienteering::Object;
 
 
 /**

--- a/test/path_object_t.cpp
+++ b/test/path_object_t.cpp
@@ -27,6 +27,8 @@
 #include "core/objects/object.h"
 #include "core/symbols/line_symbol.h"
 
+using namespace OpenOrienteering;
+
 
 class DummyPathObject : public PathObject
 {

--- a/test/qpainter_t.cpp
+++ b/test/qpainter_t.cpp
@@ -26,6 +26,8 @@
 
 #include "core/image_transparency_fixup.h"
 
+using namespace OpenOrienteering;
+
 
 QPainterTest::QPainterTest(QObject* parent)
 : QObject(parent),

--- a/test/symbol_set_t.cpp
+++ b/test/symbol_set_t.cpp
@@ -64,6 +64,8 @@
 #include "util/backports.h"
 
 
+using namespace OpenOrienteering;
+
 namespace
 {
 

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -37,6 +37,8 @@
 #include "templates/template.h"
 #include "templates/world_file.h"
 
+using namespace OpenOrienteering;
+
 
 /**
  * @test Tests template classes.

--- a/test/tools_t.cpp
+++ b/test/tools_t.cpp
@@ -43,6 +43,8 @@
 #include "tools/edit_point_tool.h"
 #include "tools/edit_tool.h"
 
+using namespace OpenOrienteering;
+
 
 /// Creates a test map and provides pointers to specific map elements.
 /// NOTE: delete the map manually in case its ownership is not transferred to a MapEditorController or similar!

--- a/test/transform_t.cpp
+++ b/test/transform_t.cpp
@@ -26,6 +26,8 @@
 #include "templates/template.h"
 #include "util/transformation.h"
 
+using namespace OpenOrienteering;
+
 
 TransformTest::TransformTest(QObject* parent)
 : QObject(parent)

--- a/test/undo_manager_t.cpp
+++ b/test/undo_manager_t.cpp
@@ -24,7 +24,9 @@
 #include "undo/undo.h"
 #include "undo/undo_manager.h"
 
-class Map;
+namespace OpenOrienteering { class Map; }
+
+using namespace OpenOrienteering;
 
 
 // test

--- a/test/util_t.cpp
+++ b/test/util_t.cpp
@@ -25,6 +25,8 @@
 
 #include "util/util.h"
 
+using namespace OpenOrienteering;
+
 
 /**
  * @test Tests utility functions and structures.

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
 		endif()
 		add_custom_target(Mapper_${ts_filename}_update
 		  COMMAND "${Qt5_LUPDATE_EXECUTABLE}" ${lupdate_options} "@${listfile}" -ts "${CMAKE_CURRENT_SOURCE_DIR}/${translation}"
-		  COMMAND sed -i -e "/<name>Q[A-Z]/,/<context>/d" "${CMAKE_CURRENT_SOURCE_DIR}/${translation}"
+		  COMMAND sed -i -e "/<context>/N;/<name>Q[A-Z]/,/<.context>/d" "${CMAKE_CURRENT_SOURCE_DIR}/${translation}"
 		  VERBATIM
 		)
 		add_dependencies(Mapper_translations_update Mapper_${ts_filename}_update)

--- a/translations/OpenOrienteering_cs.ts
+++ b/translations/OpenOrienteering_cs.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="cs_CZ">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Mapa pro orientační běh</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Software pro kresbu map pro orientační běh</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Tento program je svobodným programovým vybavením. Můžete jej šířit a /nebo upravovat za podmínek &lt;a %1&gt;GNU General Public License (GPL), verze&amp;nbsp;3&lt;/a&gt;, jak byla zveřejněna Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Tento program je šířen v naději, že bude užitečný, ale BEZ JAKÉKOLI ZÁRUKY; také bez předpokládané záruky PRODEJNOSTI nebo POUŽITELNOSTI PRO NĚJAKÝ URČITÝ ÚČEL. &lt;a %1&gt;Další podrobnosti&lt;/a&gt; najdete v GNU General Public License (GPL), verze&amp;nbsp;3.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Vše o povoleních, upozorněních autorského práva, podmínkách a zřeknutí se právních nároků.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Vývojáři OpenOrienteering v abecedním pořadí:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(původce projektu)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Svobodný program na kreslení map pro orientační běh</translation>
@@ -54,7 +67,7 @@
         <translation type="vanished">Vývojáři v abecedním pořadí:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Poděkování za přispění:</translation>
     </message>
@@ -76,203 +89,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Otevřít naposledy používaný soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Ukázat radu dne</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Ukázat zbývající položky</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Nejmenší velikost:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Výplně</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Výplň linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Výplň vzoru</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Jednoduchá linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Souběžné linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Odstup linií:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Jeden řádek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Odstup vzoru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Posun vzoru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Posun řádku:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Souběžné řádky</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Odstup řádků:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Otočení výplně</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Úhel:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>Nastavitelný podle objektu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Kresba prvků na okraji plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Oříznout prvky na okraji plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Vykreslit prvky pokud jejich střed je uvnitř okraje plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Vykreslit prvky pokud jakákoliv jejich část je uvnitř okraje plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Vykreslit prvky pokud všechny body jsou uvnitř okraje plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Nastavení plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Vzorová výplň %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Výplň linie %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Nevybrána žádná výplň</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Barva plochy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Posun linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Barva linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Šířka linie:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automaticky uložený soubor</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byt</numerusform>
@@ -281,249 +294,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Soubor uložený uživatelem</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Obnova souboru</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Soubor %1 nebyl řádně zavřen. V současnosti jsou dvě verze tohoto souboru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Uložte aktivní soubor pro odstranění konfliktní verze.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Upravit barvu</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Upravit</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definovat přímou barvu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Míchání přímých barev (rastr a přetisk):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout: vymaže spodní barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Vlastní procesní barva:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Azurová</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Purpurová</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Žlutá</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Černá</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- bez názvu -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Vypočítat z přímých barev</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Vypočítat z RGB barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Vypočítat z CMYK barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Vlastní RGB barva:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Červená</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Zelená</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Modrá</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Pracovní plocha</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Profesionální tisk</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- žádná -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Neprůhlednost</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Přímá barva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Zdvojit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dvojklik na hodnotu barvy otevře dialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Potvrzení</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Mapa obsahuje symboly s touto barvou. Její smazání odstraní barvu z těchto objektů! Opravdu to chcete udělat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (kopie)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translatorcomment>Remove initial space from tr.</translatorcomment>
         <translation> (Zdvojit)</translation>
@@ -537,303 +550,303 @@
         <translation type="vanished">Zadejte, prosím, procento od 0 % po 100 %!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Dvojité klepnutí pro definování barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klepněte pro výběr názvu a klepněte znovu pro jeho upravení.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Počet částí:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>-Liniový podsymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Plošný podsymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Upravit podsymbol...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translatorcomment>Replace original with &quot;Composition&quot;</translatorcomment>
         <translation>Nastavení složení</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Změna na podsymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Použít původní symbol jako předlohu pro podsymbol?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbol %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Nastavit mřížku</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Ukázat mřížku</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translatorcomment>Improve original (unclear!)</translatorcomment>
         <translation>Přichytit na mřížku</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Vybrat...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Všechny linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Vodorovné linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Svislé linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Zarovnání</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Zarovnat dle magnetického severu</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Zarovnat dle souřadnicového systému</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Zarovnat dle zeměpisného severu</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Dodatečné otočení (proti směru hodinových ručiček):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Určování polohy</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>metry v terénu</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milimetry na mapě</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Vodorovné rozestupy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Svislé rozestupy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Vodorovný posun:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Svislý posun:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Jednotka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Barva linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translatorcomment>Add explanation to tr()</translatorcomment>
         <translation>Zobrazení:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Vybrat barvu linie mřížky</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Počátek v: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Počátek papírových souřadnic</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>Počátek reálných souřadnic</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klepnutí nebo táhnutí&lt;/b&gt;: Začne kreslit otvor. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Linie střihu musí končit na kraji plochy!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Začátek a konec linie střihu se nacházejí v různých částech objektu!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Začátek a konec linie střihu se nacházejí ve shodné poloze!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt; na linii: Rozdělí linii na dvě. &lt;b&gt;Táhnutí&lt;/b&gt;: Odstraní tuto část linie. &lt;b&gt;Klepnutí nebo tažení&lt;/b&gt; na okraji plochy: Začne linii střihu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Rozdělení otvorů v objektech plochy ještě není podporováno!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Oříznout celou mapu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klepnutí nebo tažení&lt;/b&gt;: Vybere objekty, které se mají ořezat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ořezat vybrané objekty. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Nepodařilo se otevřít soubor.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Soubor není ve formátu DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Určit velikost písma</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Písmeno:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -847,261 +860,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Výška:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Rozložit body rovnoměrně podél cesty</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Počet bodů na cestu:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Umístit objekty také na koncové body linie</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Nastavení rotace</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Zarovnat body se směrem linie</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Dodatečný úhel rotace (proti směru hodinových ručiček):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Od středu</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Začne kruh nebo elipsu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Kreslí kruh. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Podržet %1 pro započetí kreslení od středu.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Dokončí kruh. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Kreslí elipsu. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Kreslí cestu. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Čárkové body zapnuty.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt;: Přichytí nebo připojí ke stávajícím objektům. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+klepnutí&lt;/b&gt;: Převezme směr ze stávajících objektů. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Azimut a délka segmentu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt;: Přichytí k existujícím objektům. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pevné úhly. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vrátit zpět poslední bod. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Dokončit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Úhel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Čárka</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Přerušit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Délka:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Začne rovnou linii. &lt;b&gt;Táhnutí&lt;/b&gt;: Začne křivku. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1 + táhnutí&lt;/b&gt;: Sleduje stávající objekty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Kreslí rovnou linii. &lt;b&gt;Táhnutí&lt;/b&gt;: Kreslí křivku. &lt;b&gt;Pravé tlačítko nebo dvojité klepnutí myši&lt;/b&gt;: Ukončí kresbu. &lt;b&gt;%1&lt;/b&gt;: Uzavře linii. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Pro ukončení průměrování se dotkněte mapy</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Dokončí nastavení objektu. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Úhel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Resetovat</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Úhel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pevné úhly. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Vytvoří bodový objekt.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Vytvoří objekt a nastaví jeho natočení.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Resetuje natočení.</translation>
     </message>
@@ -1111,76 +1124,76 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Dokončit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Přichytit k linii</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Čárka</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klepnutí nebo tažení&lt;/b&gt;: Začne kreslit obdélník. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Přichytí na předchozí linie. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví rohový bod. &lt;b&gt;Pravé tlačítko nebo dvojité klepnutí myší&lt;/b&gt;: Dokončí obdélník. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Dokončí úpravy. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt; 1%1+%2&lt;/b&gt; 2: Zrušit editaci. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Vytvoří textový objekt s jednou kotvou. &lt;b&gt;Táhnutí&lt;/b&gt;: Vytvoří textové pole. </translation>
     </message>
@@ -1190,130 +1203,130 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Přepnout křivku</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Volný pohyb. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt; na úsek: Přepne mezi rovnou linií a křivkou. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Bod / Úhel</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Přepnout čárku</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Dokončí úpravy. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Zachová pozici protilehlého úchopu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt; na bod: Tento smazat; na cestu: Přidá nový čárkový bod; s &lt;b&gt;%2&lt;/b&gt;: Přidá normální bod. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt; na bod: Tento smazat; na cestu: Přidá nový bod; s &lt;b&gt;%2&lt;/b&gt;: Přidá čárkový bod. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1 + klepnutí&lt;/b&gt; na bod: Přepne mezi čárkovým a normálním bodem. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Posun souřadnic:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Vzdálenost:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pevné úhly. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Přichytí ke stávajícím objektům. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Označí jeden objekt. &lt;b&gt;Táhnutí&lt;/b&gt;: Označí více objektů. &lt;b&gt;%1 + klepnutí&lt;/b&gt;: Přepne výběr. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Smaže vybrané objekty. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Vysoká kvalita zobrazení mapy (vyhlazování)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Vyhlazování zlepší vzhled mapy, zpomalí ale její zobrazení</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Vysoká kvalita zobrazení textu v mapě (vyhlazování), pomalé</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolerance klepnutí:</translation>
     </message>
@@ -1322,315 +1335,315 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Vzdálenost pro přichycení (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Délka kroku v režimu pevného úhlu (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Velikost ikony symbolu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Když je vybrán objekt automaticky vybrat také příslušný symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Při oddalování se vzdálit od ukazovátka myši</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Kreslící nástroje: Při dokončení klepnutím pravým tlačítkem myši nastavit také poslední bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Podklady: zachovat nastavení zavřených podkladů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Nástroj pro úpravu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Podržet starý tvar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Resetovat vnější úchopy křivek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Zachovat vnější úchopy křivek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Činnost při smazání bodu křivky s %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Nástroj pro obdélník:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Poloměr pomocného kříže:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Náhled šířky linií s pomocným křížem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Nepodařilo se vytvořit nový soubor: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Formát (%1) nepodporuje export</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Plocha mapy je velká. Použití nástroje pro výplň může být velice pomalé. Přesto jej chcete použít?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Poklepaná plocha není ohraničena čarami nebo plochami. Tuto plochu není možné vyplnit.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Poklepaná poloha není prázdná. Vyplnění není možné.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Nepodařilo se vytvořit objekt výplně.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Vyplní plochu s aktivním symbolem. Plocha k vyplnění musí být ohraničena čarami nebo plochami. Na jiné symboly není brán zřetel. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS je zakázáno v nastavení zařízení. Otevřít nastavení nyní?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ano</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Import s GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parametr</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Vzhled</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Jazyk:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Obrazovka</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixelů na palec:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Spuštění programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Ukládání souborů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Zachovat kompatibilitu s Mapperem %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Uložit historii zpět/znovu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Uložit informace pro automatickou obnovu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Informace pro obnovu uložit každých:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Import a export souboru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8 bitové kódování:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Více...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Použít nový importér OCD také pro soubory verze 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Upozornění</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Program se musí spustit znovu, aby se projevila změna v nastavení jazyka!</translation>
     </message>
@@ -1639,48 +1652,48 @@
         <translation type="vanished">Použít soubor s překladem...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translatorcomment>-datei hinzugefügt</translatorcomment>
         <translation>Otevřít soubor s překladem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Soubory s překlady (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Vybraný soubor není platným překladem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Rozlišení hlavní obrazovky v pixelech:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Velikost hlavní obrazovky v palcích (úhlopříčně):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Souřadnice UTM</translation>
     </message>
@@ -1689,80 +1702,80 @@
         <translation type="vanished">Zóna UTM (číslo sever/jih, např. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>Zóna UTM (číslo sever/jih)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krüger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Souřadnice Gauss-Krüger</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Číslo zóny (1 až 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>pomocí kódu EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>Souřadnice EPSG @code@</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Místní souřadnice</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Kód EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Vlastní  PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Specifikace</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Údaj o měřítku mapy je buď neplatný nebo chybí.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Neplatný měřítkový koeficient mřížky: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Neznámý jazyk specifikace souřadnicového systému: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Nepodporovaná specifikace geografického souřadnicového systému: %1</translation>
     </message>
@@ -1771,7 +1784,7 @@
         <translation type="vanished">Jen měřítko</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Místní</translation>
     </message>
@@ -1781,73 +1794,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Nastavení souřadnicového systému</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Vyhledat...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Deklinace:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Rovinné souřadnice (m)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Stav:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Měřítkový koeficient:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Geografické souřadnice</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Ukázat referenční bod v:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>platný</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Vyhledání deklinace online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Souřadnicový systém mapy</translation>
     </message>
@@ -1860,7 +1873,7 @@
         <translation type="vanished">- ze specifikace Proj. 4 -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- místní -</translation>
     </message>
@@ -1869,112 +1882,112 @@
         <translation type="vanished">Definice souřadnicového systému:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Referenční bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>Vybrat na &amp;mapě</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Mapový sever</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Souřadnicový systém:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Papírové souřadnice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Geografické souřadnice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Při změně souřadnicového systému zachovat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Grivace:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Magnetická deklinace pro referenční bod %1° %2° bude nyní načtena z &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Změna deklinace</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Deklinace byla změněna. Chcete otočit odpovídajícím způsobem i obsah mapy?</translation>
     </message>
@@ -1983,66 +1996,66 @@
         <translation type="vanished">Rovinné souřadnice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Místní souřadnice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Nahrává se ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>zamknuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Nepodařilo se zpracovat data.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Hodnota deklinace nenalezena.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Online vyhledání deklinace se nezdařilo:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví referenční bod. Stiskněte jiné tlačítko myši pro zrušení.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví referenční bod. &lt;b&gt;Klepnutí pravým tlačítkem myši&lt;/b&gt;: Zrušit.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Vítejte v OpenOrienteering Mapperu!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Clear list</source>
         <translation type="vanished">Vyprázdnit seznam</translation>
@@ -2106,90 +2119,90 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Činnosti</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Vytvořit novou mapu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Otevřít mapu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>O %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Ukončit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Naposledy otevřené mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Otevřít naposledy používaný soubor při spuštění programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Vyprázdnit seznam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Rada dne</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Ukázat radu dne</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Příklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>O Mapperu</translation>
     </message>
@@ -2198,12 +2211,12 @@
         <translation type="vanished">O Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Seznam souborů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Nenalezeny žádné mapové soubory!&lt;br/&gt;&lt;br/&gt;Kopírujte soubory s mapami do složky v nejhořejší úrovni s názvem /OOMapper na zařízení nebo paměťové kartě.</translation>
     </message>
@@ -2213,19 +2226,19 @@
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Chyba při nahrávání symbolu typu %1, řádek %2, sloupec %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symbol ID &apos;%1&apos;, není jedinečný na řádku %2, sloupec %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Chyba při nahrávání symbolu typu %1, řádek %2, sloupec %3: %4</translation>
     </message>
@@ -2234,38 +2247,38 @@
         <translation type="vanished">Chyba při nahrávání symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Chyba při nahrávání objektu typu %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Chyba při nahrávání objektu typu %1 při %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Nelze najít symbol pro objekt při %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Bodový objekt s nedefinovaným nebo nesprávným symbolem při %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Verze 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2274,48 +2287,48 @@
         <translation type="vanished">Nepodařilo se zpracovat data.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Nepodařilo se zpracovat souřadnice.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Očekávány %1 souřadnice, nalezeno %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Chyba při načítání nastavení tisku v %1: %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Chyba při nahrávání kroků zpět/znovu v %1: %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Neexistuje volba: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Geoprostorová vektorová data</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Nalezen objekt bez symbolu.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Zahozen %n neregulérní objekt.</numerusform>
@@ -2324,36 +2337,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Chyba během následného zpracování symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Podklad &quot;%1&quot; byl nahrán z adresáře s mapou místo z relativní cesty k souboru s mapou, kde byl předtím.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Nepodařilo se nahrát podklad &apos;%1&apos;, důvod: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Varování při nahrávání podkladu &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Jeden nebo více souborů s podkladem se nepodařilo najít.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klepněte na červeně označený název souboru v Podklady -&gt; okno Spravovat podklady pro nalezení souborů s podkladem.</translation>
     </message>
@@ -2362,174 +2375,174 @@
         <translation type="vanished">Jeden nebo více souborů s podkladem se nepodařilo najít. Klepněte na červeně označený název souboru v Podklady -&gt; okno Spravovat podklady pro nalezení souborů s podkladem.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Tento soubor používá zastaralý formát. Podpora pro tento formát bude z tohoto programu brzy odstraněna. Pro opětovné otevření souboru v budoucnu jej znovu uložte.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Neplatná verze souborového formátu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Nepodporovaná stará verze souborového formátu. Použijte, prosím, starší verzi programu k otevření souboru a k jeho opětovnému uložení.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Nepodporovaná nová verze souborového formátu. Některé mapové prvky nejsou touto verzí nahrány nebo uloženy. Aktualizujte, prosím, program.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Geografický souřadnicový systém mapy byl &quot;%1&quot;. Tento souřadnicový systém není podporován. Používá se &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Chyba při nahrávání symbolu typu %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Chyba při nahrávání symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Chyba při nahrávání kroků zpět.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Chyba při nahrávání počtu částí mapy.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Chyba při nahrávání části mapy %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Nepodařilo se přečíst soubor: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Nepodporovaný souborový formát.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Nepodporovaná nová verze souborového formátu. Některé mapové prvky nejsou touto verzí nahrány nebo uloženy.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Formát (%1) nepodporuje import</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Nelze načíst &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Nastavení linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Šířka linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Barva linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Nejmenší délka linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Konec linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>rovný</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translatorcomment>Context required: cap vs. join.</translatorcomment>
         <translation>kulatý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>čtvercový</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>špičatý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Ohyb linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>ostrý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>plochý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Délka koncovky:</translation>
     </message>
@@ -2539,208 +2552,208 @@
         <translation>Linie je čárkovaná</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Ukázat alespoň jeden vnitřní symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Nejmenší počet vnitřních symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Nejmenší počet vnitřních symbolů zavřené linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Délka čárky:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Čárkovaná linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Mezera mezi čárkami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Seskupovat čárky:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>žádné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Mezera mezi čárkami ve skupině:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Poloviční délka první a poslední čárky</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Vnitřní symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translatorcomment>Must be improved.</translatorcomment>
         <translation>Vnitřních symbolů na místo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Vzdálenost mezi vnitřními symboly:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Okraje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Rozdílné okraje na pravé a levé straně</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Levý okraj:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Pravý okraj:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Počáteční symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Vnitřní symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Koncový symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Symbol pro čárku</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Zapnout okrajové čáry</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Vzdálenost mezi každým seskupením symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Vzdálenost od konce linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Potlačit symbol pro čárku na začátku a na konci linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Zvětšovat symbol čárky v rozích</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Šířka okraje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Barva okraje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translatorcomment>Re-check.</translatorcomment>
         <translation>Posunutí okraje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Okraj je čárkovaný</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Délka čárky okraje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Mezera mezi čárkami okraje:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2751,122 +2764,122 @@ File format not recognized.</source>
 Neznámý souborový formát.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nový</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Musíte zavřít současný soubor abyste mohli otevřít další.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Vytvořit novou mapu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Otevřít...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Otevřít stávající soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Otevřít &amp;nedávný soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Uložit</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Uložit &amp;jako...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Nastavení...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Zavřít tento soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>U&amp;končit</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translatorcomment>Ausführlicher</translatorcomment>
         <translation>Ukončit program</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translatorcomment>Kürzer</translatorcomment>
         <translation>&amp;Příručka</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Ukázat soubor s nápovědou k tomuto programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;O programu %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Ukázat informace o Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Chcete odstranit automaticky uloženou verzi?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Soubor byl změněn.
 Chcete uložit změny?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2875,18 +2888,18 @@ Do you want to scale the symbols to the selected scale?</source>
 Má se změnit velikost symbolů na vybrané měřítko?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Otevírá se %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Oznámení o pádu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Zdá se, že %1 spadl, když byl naposledy tento soubor otevřen:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Opravdu jej chcete zkusit znovu otevřít?</translation>
     </message>
@@ -2899,92 +2912,93 @@ Má se změnit velikost symbolů na vybrané měřítko?</translation>
         <translation type="vanished">Je k dispozici automaticky uložená verze souboru &lt;br /&gt;&lt;tt&gt;%1&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Nahrát tuto verzi?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Automatické ukládání...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Automatické uložení se nezdařilo!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Všechny mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Uložit soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Soubor se nepodařilo uložit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Při určení souborového formátu se vyskytly potíže.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Ohlaste to prosím jako chybu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Ukázat informace o tomto programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>Nápo&amp;věda</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Neuložený soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Soubor byl změněn.
 Chcete zahodit změny?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Všechny soubory</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translatorcomment>Nicht zu übersetzen</translatorcomment>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2996,23 +3010,23 @@ Stiskněte Ne pro vyhledání jiného souborového formátu.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3021,7 +3035,7 @@ because saving as %2 (.%3) is not supported.</source>
 protože uložení jako %2 (.%3) není podporováno.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3036,31 +3050,31 @@ protože formát je neznámý.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Při exportu mapy se vyskytla varovná hlášení.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Vnitřní chyba při ukládání:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Při importu mapy se vyskytla varovná hlášení.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3068,12 +3082,12 @@ for reading.</source>
 Soubor nelze otevřít pro čtení.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Neplatný typ souboru.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3084,7 +3098,7 @@ Soubor nelze otevřít pro čtení.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3093,17 +3107,17 @@ Soubor nelze otevřít pro čtení.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nic k importu.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Otázka</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3112,23 +3126,23 @@ Rescale the imported data?</source>
 Změnit měřítko importovaných dat na měřítko mapy?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Výchozí část</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nová barva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Import...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Nahrazení symbolů bylo zrušeno.
@@ -3136,311 +3150,311 @@ Importovat data tak jako tak?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Registrační černá (všechny tištěné barvy)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Souřadnice jsou mimo specifikovaný rozsah.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Tisk...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Poslední krok vrátit zpět</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Znovu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Poslední krok udělat znovu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Vyj&amp;mout</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>&amp;Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Vložit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Přiblížit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Oddálit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Přepnout zobrazení na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Nastavit vlastní zvětšení...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Okno se symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Ukázat/Skrýt okno se symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Okno s barvami</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Ukázat/Skrýt okno s barvami</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translatorcomment>Replace map file with either map or file</translatorcomment>
         <translation>Symboly nahradit symboly z jiného souboru</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Změnit velikost všech symbolů...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Změnit velikost celé sady symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Změnit měřítko mapy...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Změnit měřítko mapy a přizpůsobit velikost všech objektů a symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Poznámky k mapě...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Okno s nastavením podkladů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Ukázat/Skrýt okno s podklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Otevřít podklad...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Ukázat celou mapu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Zrušit výběr</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Obrátit výběr</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>ID sady symbolů...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Změnit ID sady symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Načíst CRT soubor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Přiřadit nové symboly pomocí cross-reference table</translation>
     </message>
@@ -3453,58 +3467,58 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Zobrazit/Skrýt okno s výběrem tagů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Upravit objekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Kreslit body</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Kreslit cesty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Kreslit kruhy a elipsy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Psát text</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Zdvojit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Zaměnit symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translatorcomment>Consider two separate actions or change text according to context</translatorcomment>
         <translation>Vyplnit / Vytvořit okraj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Obrátit směr symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Spojit cesty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Rozstřihnout objekt</translation>
     </message>
@@ -3513,67 +3527,67 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Otočit objekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Měřit délky a plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Vystřihnout z plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Sloučit díry plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Nastavení pro kreslení na podklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Povolit dotykové ukazovátko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Povolit zobrazení GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Povolit vzdálenostní kruhy GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Nastavit bodový objekt v poloze GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Nastavit dočasnou značku v poloze GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Vytvořit dočasnou trasu v poloze GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Smazat dočasné polohové značky GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Povolit zobrazení kompasu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Zarovnat mapu na sever</translation>
     </message>
@@ -3582,190 +3596,190 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Přepnout viditelnost podkladu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Přidat novou část mapy...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Přejmenovat nynější část...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Odstranit nynější část</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Sloučit všechny části</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Import...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>Úp&amp;ravy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Pohled</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Nástroje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>S&amp;ymboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>Po&amp;dklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Kreslení</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translatorcomment>To be checked</translatorcomment>
         <translation>Kreslit na podklad</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Mapa je nyní upravována</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Mapa je nyní upravována. Před uložením dokončete prosím úpravy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Mapa uložena</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Ukázat mřížku</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Nastavit mřížku...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Šrafování ploch</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Zobrazit základní linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Skrýt všechny podklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Nahradit sadu symbolů...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Nastavení souřadnicového systému...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Otočit mapu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Otočit celou mapu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Otevřít podklad znovu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Editor tagů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Ukázat/Skrýt okno s editorem tagů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Kreslit obdélníky</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Kreslit volnou rukou</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Vyplnit ohraničené plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Vystřihnout nepravidelně tvarovaný otvor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Vystřihnout kulatý otvor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Vystřihnout pravoúhlý otvor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Otočit vzor</translation>
     </message>
@@ -3774,12 +3788,12 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Změnit velikost objektů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Sloučit plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Protnout plochy</translation>
     </message>
@@ -3788,52 +3802,52 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Odečíst plochy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Odstranit překrytí (XOr)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Oříznout</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Vystřihnout</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Rozložit body podél cesty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Souřadnice mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Rovinné souřadnice (m)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Zeměpisná šířka/délka (desetinná)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Šířka/Délka (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Zobrazit souřadnice jako...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Vystřihnout otvor</translation>
     </message>
@@ -3842,71 +3856,71 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Falešný</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Části mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Vybrat podklad...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Úpravy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Pokročilé úpravy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Vybrat symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Skrýt horní pruh</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Ukázat horní pruh</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Tisk / Export není v této verzi programu dostupný!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Kroky zpět nejsou možné.</translation>
     </message>
@@ -3916,8 +3930,8 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Vyjmout %1 objekt(y)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Vyskytla se vnitřní chyba, promiňte!</translation>
     </message>
@@ -3926,7 +3940,7 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Zkopírován %1 objekt(y)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Ve schránce nejsou objekty, které by bylo možné vložit!</translation>
     </message>
@@ -3935,68 +3949,68 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Vložen %1 objekt(y)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Nastavit násobek zvětšení</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Násobek zvětšení:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>ID sady symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Změnit ID sady symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Změnit velikost všech symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Změnit velikost na procentní hodnotu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Poznámky k mapě</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translatorcomment>FIXME: Ersetzen durch ButtonBox.</translatorcomment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Podklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Editor tagů</translation>
     </message>
@@ -4005,7 +4019,7 @@ Importovat data tak jako tak?</translation>
         <translation type="vanished">Výběr tagů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4015,7 +4029,7 @@ selected</source>
 symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4025,43 +4039,43 @@ více
 symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Umístit bodové objekty na mapu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Vyberte bodový symbol, abyste mohli tento nástroj používat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translatorcomment>More information</translatorcomment>
         <translation>Kreslit hranaté nebo zahnuté linie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translatorcomment>Distinction between line and combined symbol probably not relevant here.</translatorcomment>
         <translation>Vyberte liniový, plošný nebo kombinovaný symbol, abyste mohli tento nástroj používat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Kreslit kruhy a elipsy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Kreslit cesty volnou rukou.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Vyplnit ohraničené plochy.</translation>
     </message>
@@ -4070,109 +4084,109 @@ symbolů</translation>
         <translation type="vanished">Smazat vybrané objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Nastavit směr vzorů výplně plochy nebo bodových objektů.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Vyberte objekt plochy s otočným vzorem výplně nebo otočný bodový objekt, abyste tento nástroj zapnuli a mohli jej používat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Výsledný symbol: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Vyberte alespoň dva plošné nebo liniové objekty, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Sloučí překrývající se objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Odstraní všechny části, které se nepřekrývají s prvním vybraným objektem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Odstraní všechny překryté části prvního vybraného objektu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Odstraní všechny části, které překrývají první vybraný objekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Sloučí díry v plochách, nebo díry spojí s okrajem objektu pro vystřižení této části.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Vyberte jeden objekty plochy s dírami, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Vytvoří oříznutí některých objektů nebo celé mapy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Vyberte uzavřený objekt cesty jako tvar oříznutí, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Vystřihne některé nebo všechny objekty nacházející se uvnitř vybrané (ohraničené) plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Umístí rovnoměrně rozestavené bodové objekty podél stávajícího objektu cesty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Vyberte alespoň jeden objekt cesty a jeden bodový symbol, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Sloučení děr se nezdařilo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Smazat dočasné značky</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Jste si jistý, že chcete smazat všechny dočasné značky GPS? Tento krok nelze vrátit zpět.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Sloučit tuto část s</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Přesunout vybrané objekty do</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Zadat název části mapy:</translation>
     </message>
@@ -4181,98 +4195,98 @@ symbolů</translation>
         <translation type="vanished">Chcete odstranit část mapy &quot;%1&quot; a všechny její objekty? Tento krok nelze vrátit zpět.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Sloučit mapové části</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Chcete přesunout všechny objekty z části mapy &quot;%1&quot; do &quot;%2&quot; a &quot;%1&quot; odstranit?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Chcete přesunout všechny objekty do části mapy &quot;%1&quot; a odstranit všechny ostatní části mapy?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Vybraný soubor s mapou nelze importovat, protože se jej nepodařilo nahrát.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Kreslit obdélníky.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Obrázek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Vyprázdnit historii kroků zpět/znovu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Smazat historii kroků zpět/znovu kvůli zmenšení velikosti souboru.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Posunovat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulovat přetisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Upravit linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Převést na křivky</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Zjednodušit cestu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Kopírovat polohu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Kopírovat souřadnice polohy do schránky.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exportovat jako ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Napíše text na mapu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Vyberte symbol pro text, abyste mohli tento nástroj používat.</translation>
     </message>
@@ -4281,26 +4295,26 @@ symbolů</translation>
         <translation type="vanished">Zdvojí vybrané objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Vyberte alespoň jeden objekt, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Přepne směr symbolů u liniových objektů.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Vyberte alespoň jeden objekt linie, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Spojí dohromady konce cest, jež jsou blízko.</translation>
     </message>
@@ -4309,17 +4323,17 @@ symbolů</translation>
         <translation type="vanished">Rozstřihne vybrané objekty na menší části.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Vyberte alespoň jeden liniový nebo plošný objekt, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Vystřihne otvor ve vybraném objektu plochy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Vyberte jeden objekt plochy, abyste tento nástroj zapnuli.</translation>
     </message>
@@ -4356,18 +4370,18 @@ symbolů</translation>
         <translation type="vanished">Vypočítat nepřekrývající se části objektů ploch.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Změní cesty sestávající z rovných částí na hladké Beziérovy křivky.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Vyberte jeden objekt cesty, abyste tento nástroj zapnuli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Zmenší počet bodů u objektů cesty se snahou zachovat jejich tvar.</translation>
     </message>
@@ -4376,8 +4390,8 @@ symbolů</translation>
         <translation type="vanished">Zamění symbol vybraného objektu za vybraný symbol.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Vyberte alespoň jeden objekt a vhodný náhradní symbol, abyste tento nástroj zapnuli.</translation>
     </message>
@@ -4390,7 +4404,7 @@ symbolů</translation>
         <translation type="vanished">%1 objekt(y) zdvojen(y)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Výběr objektu</translation>
     </message>
@@ -4399,83 +4413,83 @@ symbolů</translation>
         <translation type="vanished">Objekty nebyly vybrány, protože neexistují objekty s vybraným symbolem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Měření</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Sloučení se nezdařilo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Protnutí se nezdařilo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Odečtení se nezdařilo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Odstranit překrytí (XOr) se nezdařilo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Chcete odstranit část mapy &quot;%1&quot; a všechny objekty na ní?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Přepnuto na část mapy &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Kreslit volnou rukou na podklad</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translatorcomment>First part duplicated. Check punctuation.</translatorcomment>
         <translation>Kreslit volnou rukou na podklad. Vytvořte nebo nahrajte podklad, na který je možné kreslit, pro zapnutí tohoto nástroje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importovat soubor %1, GPX, OSM nebo DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importovatelné soubory</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Všechny soubory</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Vybraný soubor se nepodařilo importovat, protože jeho formát není podporován.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Rotovat objekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Změnit velikost objektů</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4485,7 +4499,7 @@ symbolů</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Zkopírován %n objekt</numerusform>
@@ -4494,7 +4508,7 @@ symbolů</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Vložen %n objekt</numerusform>
@@ -4503,42 +4517,42 @@ symbolů</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Smaže vybrané objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Zdvojí vybrané objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Otočí vybrané objekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Změní velikost vybraných objektů.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Rozstřihne vybrané objekty na menší části.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Zamění symbol vybraného objektu za vybraný symbol.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Vyplní vybraný liniový objekt nebo vytvoří okrajovou čáru pro vybrané plochy.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Zdvojen %n objekt</numerusform>
@@ -4547,178 +4561,178 @@ symbolů</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Objekty nebyly vybrány, protože objekty s označeným symbolem neexistují.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Zrušit. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Více: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Více: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Více: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Najít...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Najít &amp;další</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Najít objekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Najít další</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Najít &amp;vše</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Editor dotazů</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Probíhá zpracování separací na straně %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Probíhá zpracování strany %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Zrušeno</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Dokončeno</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Zdroj textu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Mapa (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>nedefinovaný jazyk</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Překlad (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Před změnami bude uložený text nahrazen současným překladem. Chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Po úpravě uloženého textu překlad nemusí být nalezen. Chcete pokračovat?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4733,7 +4747,7 @@ k otevření okna pro barvy
 a definování barev.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4748,7 +4762,7 @@ do pruhu se symboly a vyberte
 &quot;Nový symbol&quot;, abyste jeden vytvořili.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4761,7 +4775,7 @@ Pro nahrání podkladu klepněte na
 Podklady -&gt; Otevřít podklad...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Rada: Podržte prostřední tlačítko myši pro tažení
@@ -4769,124 +4783,124 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Obvod:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Délka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Plocha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nevybrán žádný objekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>Vybrán %1 objekt(y).</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Vybraný objekt není cesta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Tento objekt je příliš malý.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Nejmenší velikost plochy je %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Rada: Obvod a plocha jsou správné jen tehdy, pokud se nevyskytují vlastní protnutí a otvory se používají jako takové.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Tato linie je příliš krátká.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimální délka je %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Vytvořit novou mapu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Vyberte měřítko a sadu symbolů pro novou mapu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translatorcomment>Check spaces.</translatorcomment>
         <translation>Měřítko:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Sady symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Ukázat jen sady symbolů odpovídající vybranému měřítku</translation>
     </message>
@@ -4895,140 +4909,140 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         <translation type="vanished">Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Vytvořit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Prázdná sada symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Nahrát sadu symbolů ze souboru...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Všechny soubory se sadami symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Všechny soubory</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Mapa obsahuje více než 256 barev, což není podporováno v ocd verze 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>Chyba libocad. Vrácená hodnota %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Registrační černá je exportována jako běžná barva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Nelze exportovat posun vzoru výplně pro objekt plochy</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Nelze exportovat podklad: Souborový typ &quot;%1&quot; není podporován</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Souřadnice jsou upraveny aby odpovídaly oblasti kresby v OCAD 8 (-2 m ... 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Některé souřadnice zůstávají mimo oblast kresby v OCAD 8. Mohou být v OCADu nedosažitelné.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>V liniovém symbolu &quot;%1&quot; nelze znázornit kombinaci koncovek/napojení linií.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>V liniovém symbolu &quot;%1&quot; se přehlíží seskupení čárek.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>V liniovém symbolu &quot;%1&quot; je počet čárek v jedné skupině zmenšen na 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>V liniovém symbolu &quot;%1&quot; nemohou být okraje správně exportovány.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>V plošném symbolu &quot;%1&quot; vynechávám vzor výplně.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>V plošném symbolu &quot;%1&quot; předpokládám bodový vzor s &quot;posunutými řádky&quot;. To může být správně, ale také to může být chybně.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>V textovém symbolu &quot;%1&quot; je nastaven vlastní rozestup znaků. Jeho provedení prozatím neodpovídá chování v OCADu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>V textovém symbolu %1: přehlíží se podtržení</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>V textovém symbolu %1: přehlíží se podřezávání</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Řetězec znaků zkrácen (místo ukončení je označeno třemi &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Nepodařilo se přidělit vyrovnávací paměť.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>Chyba libocad. Vrácená hodnota %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>Soubory OCAD verze %1 nejsou podporovány!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>Byla přeskočena %n barevná separace. Důvod: Import zakázán.</numerusform>
@@ -5037,97 +5051,97 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Nepodařilo se nahrát definice přímých barev. Chyba: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Barva &quot;Registrační černá&quot; je importována jako zvláštní barva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Nelze importovat symbol &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Vrstva importu OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>V čárkovaném liniovém symbolu %1 jsou délky pro špičaté konce na začátku a na konci rozdílné (%2 a %3). Používá se %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>V čárkovaném liniovém symbolu %1 nelze importovat správně délku koncového kusu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>V čárkovaném liniovém symbolu %1 nelze importovat správně koncovou mezeru.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>V čárkovaném liniovém symbolu %1 jsou hlavní a koncová délka rozdílné (%2 a %3). Používá se %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>V čárkovaném liniovém symbolu %1 jsou mezery D a E rozdílné (%2 a %3). Používá se %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Liniový symbol %1: potlačuje se symbol čárkování na koncích linie.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Při importu textového symbolu %1: přehlíží se zarovnání do bloku</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Při importu textového symbolu %1 se ignoruje vlastní tloušťka písma (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Při importu textového symbolu %1 jsou nastaveny vlastní rozestupy znaků. Jeho provedení zatím neodpovídá chování v OCADu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Při importu textového symbolu %1 se přehlíží vlastní rozestupy slov (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Při importu textového symbolu %1 se ignoruje vlastní odsazení (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Při importu textového symbolu %1 se ignoruje rámování textu (režim %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Nelze nahrát objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Nelze importovat obdélníkový objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Textový symbol se neimportuje, nepodařilo se vypátrat cestu (npts=%1): %2</translation>
     </message>
@@ -5136,157 +5150,157 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         <translation type="obsolete">Kann Vorlage nicht importieren: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Nelze importovat podklad: Zdá se, že &quot;%1&quot; není rastrovým obrázkem</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Pokus o import textového objektu s neznámým formátem souřadnic</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>ID barvy nenalezeno: %1. Tato barva se ignoruje</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>je</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>není</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>obsahuje</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>a</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>nebo</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>neplatný</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>V liniovém symbolu %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>V textovém symbolu %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Nepodařilo se načíst souřadnicový systém: &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Informace o přímých barvách byla ignorována.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Nelze importovat symbol %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Nepodporovaný typ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Nelze importovat podklad: &quot;%1&quot; není podporovaný typ podkladu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Nepodporovaný styl linie &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Rozdílné délky pro špičaté konce na začátku (%1 mm) a konci (%2 mm) nejsou podporovány. Používá se %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Čárkovaný vzor se nepodařilo správně importovat.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Délku koncového kusu v čárkovaném vzoru (%1 mm) nelze správně importovat. Používá se %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Délku koncové mezery v čárkovaném vzoru (%1 mm) nelze správně importovat. Používá se %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Nepodporovaný styl linie rámování &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Přehlíží se dodatečný symbol bodu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Symbol pro čárkování na začátku a konci linie je potlačen.</translation>
     </message>
@@ -5315,84 +5329,84 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         <translation type="obsolete">Ignoriere Textrahmen (Modus %2) bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Tento symbol nelze znovu uložit jako řádný symbol OCD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Zarovnání do bloku není podporováno.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Svislé zarovnání &apos;%1&apos; není podporováno.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Přehlíží se vlastní tloušťka písma (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Vlastní rozestupy znaků nemusí být správně.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Přehlíží se vlastní rozestupy slov (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Přehlíží se vlastní odsazení (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Přehlíží se rámování textu (režim %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Liniové textové symboly ještě nejsou podporovány. Symbol je označen jako skrytý.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Kódování &apos;%1&apos; není k dispozici. Zkontrolujte nastavení.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>V plošném symbolu %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Nelze nahrát objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Nelze importovat obdélníkový objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Textový symbol nebyl importován: Nepodařilo se vypátrat cestu (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Pokus o import textového objektu s neznámým formátem souřadnic</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Neplatná data.</translation>
     </message>
@@ -5401,59 +5415,59 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         <translation type="vanished">Nevyzkoušená funkce importu pro souborový formát OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>Soubory OCD verze %1 nejsou podporovány!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>ID barvy nenalezeno: %1. Tato barva se ignoruje</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Nelze nastavit &quot;%1&quot; SRS pro GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Fialová</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Bod</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Plocha</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Nelze načíst vrstvu %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Nelze načíst %n objekt, důvod: %1</numerusform>
@@ -5462,469 +5476,456 @@ mapy. Změna zvětšení je možná pomocí kolečka myši.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Prázdná geometrie.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Nelze určit transformaci souřadnic: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Nepodařilo se transformovat souřadnice.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Neznámý nebo nepodporovaný typ geometrie.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Nedostatečné souřadnice.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Nemohu použít tento souřadnicový systém:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>Geoprostorová data mají nevhodnou prostorovou referenci.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Mapa pro orientační běh</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Software pro kresbu map pro orientační běh</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Vybrat podklad, na který se kreslí</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Kreslit</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klepnutí a táhnutí&lt;/b&gt;: Maluje. &lt;b&gt;Klepnutí pravým tlačítkem myši a táhnutí&lt;/b&gt;: Gumuje. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Výběr barvy</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Tažení&lt;/b&gt;: Posune mapu. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Přidá souřadnice. &lt;b&gt;%1 + klepnutí&lt;/b&gt;: Změní vybrané souřadnice. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Vždy orientováno na sever (není otočný)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Prvky</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Plocha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Vycentrovat všechny prvky</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Aktuální prvek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Průměr &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Vnitřní barva:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Šířka okraje &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Barva okraje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Šířka linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Barva linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Konec linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>rovný</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>kulatý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>čtvercový</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Spojení linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>ostrý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>plochý</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Zavřená linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Barva plochy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Souřadnice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Začátek křivky</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Vycentrovat dle průměru souřadnic</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Středový bod]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Neznámý</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Bodový symbol</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Při zpracování se vyskytla chyba.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Ziehen&lt;/b&gt;: Druckbereich oder dessen Ränder verschieben. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune mapu, oblast tisku nebo okraje oblasti. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune oblast tisku. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune mapu. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune okraj oblasti tisku. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune okraje oblasti tisku. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Export do PDF nebo PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Ukázat podklady</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Ukázat mřížku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientace stránky:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Tiskárna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Na výšku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Na šířku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Formát stránky:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Počet kopií:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Vlevo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Nahoře:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Šířka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Výška:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektorová
 grafika</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Rastrová
 grafika</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Separace
 barev</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Režim:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Náhled...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Jedna stránka</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Vlastní oblast</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Oblast mapy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Vycentrovat oblast tisku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Překrytí mezi stránkami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Volby</translation>
     </message>
@@ -5937,198 +5938,198 @@ barev</translation>
         <translation type="vanished">Separace barev</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Rozlišení:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Tisknout v jiném měřítku:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Vzhled podkladů se může lišit.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simulovat přetisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Zařízení CMYK (experimentální)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Barevný režim:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Export...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Exportovat jako PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Exportovat jako obrázek</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Uložit jako PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Není podporováno v systému Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Nepodařilo se připravit náhled.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Postup zobrazení náhledu tisku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Je aktivní nestandardní režim zobrazení. Opravdu chcete mapu takto vytisknout / exportovat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Nepodařilo se připravit export do PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Při tisku se vyskytla chyba.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Exportovat mapu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translatorcomment>Check original.</translatorcomment>
         <translation>Nepodařilo se uložit obrázek. Existuje cesta? Máte dostatečná práva?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Úspěšně exportováno do %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Nepodařilo se dokončit export do PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Nepodařilo se připravit tisk.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Průběh tisku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Nepodařilo se připravit obrázek. Nedostatek paměti.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Zrušeno.</translation>
     </message>
@@ -6137,176 +6138,176 @@ barev</translation>
         <translation type="vanished">Tisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Tiskovou úlohu se nepodařilo zastavit.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Tisková úloha úspěšně vytvořena</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Neznámý</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Oblast mapy je prázdná. Výstup zrušen.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Souřadnicový systém:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Otevřít podklad znovu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Přetáhněte položky ze seznamu vlevo na požadované místo v seznamu vpravo pro jejich opětovné nahrání.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Zavřené podklady:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Vyprázdnit seznam</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktivní podklady:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Nahradit sadu symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Nastavte, jak se mají symboly nahrazovat, a které.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importovat všechny nové symboly, i když nejsou použity pro nahrazení</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Smazat původní symboly, které nejsou po nahrazení používány</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Po nahrazení smazat nepoužité barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Přiřazení symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Zachovat skrytý / chráněný stav staré sady symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Přiřadit nahrazovací symboly podle čísla symbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Původní</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Změnit ID sady symbolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Nahrazení</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Spárovat dle názvu symbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Přiřadit nové symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Vzor</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Vymazat nahrazení</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Otevřít CRT soubor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Uložit CRT soubor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Mapování symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT soubor</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Existuje více náhrad pro symbol %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6317,7 +6318,7 @@ barev</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6328,281 +6329,281 @@ barev</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Cross reference table byla změněna.
 Chcete uložit vaše změny?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Žádný -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Vybrat soubor s mapou, ze které se mají symboly nahrát</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Nelze nahrát soubor s mapou. Přerušuje se.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Vybraná sada symbolů má měřítko1:%1, ale měřítko mapy je 1:%2. Opravdu chcete vybrat tuto sadu symbolů?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>Nemohu načíst CRT soubor, přerušuji.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Rotovat mapu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Úhel (proti směru hodinových ručiček):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parametry rotace</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotovat okolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Počátku souřadnicového systému mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Souřadnicového referenčního bodu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Jiného bodu,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Volby</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Upravit souřadnicový referenční bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Upravit deklinaci souřadnicového systému</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Rotovat negeoreferencované podklady</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Úhel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pevné úhly. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Nastaví směr vzorů u výplně ploch nebo bodových objektů. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotace:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pevné úhly. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví střed rotace. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Otočí vybrané objekty. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Změnit měřítko mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Parametry změny měřítka</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nové měřítko:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Střed změny měřítka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Počátek souřadnicového systému mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Souřadnicový referenční bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Jiný bod,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Volby</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Přizpůsobit velikost symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Přizpůsobit polohy objektů mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Upravit souřadnicový referenční bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Přizpůsobit negeoreferencované podklady</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translatorcomment>TODO: Check proper % escaping.</translatorcomment>
         <translation>&lt;b&gt;Změna velikosti:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví střed změny velikosti. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Změní velikost vybraných objektů. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Vybrat souřadnicový systém</translation>
     </message>
@@ -6611,17 +6612,17 @@ Chcete uložit vaše změny?</translation>
         <translation type="vanished">Stejný jako v mapě</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Stejný jako v mapě</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Místní</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Geografické souřadnice (WGS 84)</translation>
     </message>
@@ -6642,176 +6643,176 @@ Chcete uložit vaše změny?</translation>
         <translation type="vanished">Specifikace souřadnicového systému:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Stav:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>platný</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; je uložen v obvyklém úložišti.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; je umístěn v úložišti aplikace. Soubory budou při odinstalaci aplikace odstraněny.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; není zapisovatelný. Změny nemohou být uloženy.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; není platné umístění úložiště.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- žádný -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Žádný -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Číslo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Upravit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Název:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Popis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Pomocný symbol (není viditelný v hotové mapě)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Pokud je viditelná bublinová nápověda k symbolu, popis symbolu zobrazíte stiskem F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nový symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Bod</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Plocha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Kombinovaný</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Upravit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Zdvojit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Změnit velikost...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
@@ -6824,12 +6825,12 @@ Chcete uložit vaše změny?</translation>
         <translation type="vanished">Vyplnit/Vytvořit okraj pro vybrané objekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Vybrat symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Povolit tažení a upuštění</translation>
     </message>
@@ -6838,108 +6839,108 @@ Chcete uložit vaše změny?</translation>
         <translation type="vanished">Změnit velikost symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Vyskytla se vnitřní chyba, promiňte!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Ve schránce nejsou symboly, které by bylo možné vložit!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Vybrat všechny objekty s tímto symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Přidat všechny objekty s tímto symbolem do výběru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Odstranit všechny objekty s tímto symbolem z výběru</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Skrýt objekty s tímto symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Chránit objekty s tímto symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Přidat všechny objekty s vybranými symboly do výběru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Odstranit všechny objekty s vybranými symboly z výběru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Skrýt objekty s vybranými symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Chránit objekty s vybranými symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Vybrat nepoužívané</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Obrátit výběr</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Třídit symboly</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Třídit podle čísla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Třídit podle základní barvy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Třídit podle priority základní barvy</translation>
     </message>
@@ -6948,92 +6949,92 @@ Chcete uložit vaše změny?</translation>
         <translation type="obsolete">Symbol %1 skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Změnit velikost na procentní hodnotu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Potvrzení</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Mapa obsahuje objekty se symbolem &quot;%1&quot;. Při smazání symbolu budou tyto objekty z mapy a z historie odstraněny. Opravdu to chcete udělat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Vybrat všechny objekty dle vybraných symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Zaměnit symbol vybraných objektů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Vyplnit / Vytvořit okraj u označených objektů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Změnit velikost symbolů</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Nastavení symbolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Podklad:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Podklad:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translatorcomment>Standardize &quot;(none)&quot; vs &quot;- none -&quot;</translatorcomment>
         <translation>(žádná)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Otevřít...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Vycentrovat podklad...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>Obrys na počátku</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Těžiště na počátku</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Vybrat barvu pozadí</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -7049,58 +7050,58 @@ před chvílí, víme, vypadla z kabiny svého létadla.
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- bez názvu -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Bez popisu!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Relace</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Klíč</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Porovnání</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Přidat řádek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Odstranit řádek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Posunout dolů</translation>
     </message>
@@ -7113,7 +7114,7 @@ před chvílí, víme, vypadla z kabiny svého létadla.
         <translation type="vanished">Nápověda</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n objekt vybrán</numerusform>
@@ -7122,14 +7123,14 @@ před chvílí, víme, vypadla z kabiny svého létadla.
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Neplatný dotaz</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Add</source>
         <translation type="vanished">Přidat</translation>
@@ -7160,63 +7161,63 @@ před chvílí, víme, vypadla z kabiny svého létadla.
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Klíč</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Klíč existuje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Klíč &quot;%1&quot; již existuje a nesmí se použít dvakrát.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Najít přesunutý soubor s podkladem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Žádný takový soubor.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Je formát souboru pro tento typ podkladu správný?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Nedostatek volné paměti.</translation>
     </message>
@@ -7226,134 +7227,134 @@ před chvílí, víme, vypadla z kabiny svého létadla.
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Vlícování podkladu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Nepodařilo se spočítat vlícování!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví polohu vlícovacího bodu na podkladu. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Nastaví polohu vlícovacího bodu na mapě. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klepnutí&lt;/b&gt;: Smaže pasovací body. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune vlícovací body. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Vlícovací body:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Posunout</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>X (podklad)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Y (podklad)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>X (mapa)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Y (mapa)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Použít vlícovací body</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Použít a vše smazat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Smazat vše</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Nedostatek volné paměti (velikost obrázku: %1x%2 pixelů)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7362,98 +7363,98 @@ Ukládání ve formátu GIF není podporováno. Kresby na takovém podkladu nelz
 Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o problém.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Vyberte souřadnicový systém souřadnic uvedených v georeferenčním souboru</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Otevírá se %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Velikost obrázku:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Zadejte, jak umístit nebo změnit velikost obrázku:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Georeferenční soubor</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>žádné informace o georeferenci</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferencovaný</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metrů na pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Skenováno na</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Měřítko podkladu: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Ukázat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Neprůhlednost</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Skupina</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Název souboru</translation>
     </message>
@@ -7463,19 +7464,19 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
         <translation type="obsolete">Erstellen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Skica</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Otevřít...</translation>
     </message>
@@ -7500,7 +7501,7 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
         <translation type="obsolete">nein</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georeferencováno: %1</translation>
     </message>
@@ -7509,79 +7510,79 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
         <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Zdvojit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Posunout ručně</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Vlícovat...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translatorcomment>FIXME: Update original string</translatorcomment>
         <translation>Otevřít obrázek, trasu GPS nebo soubor DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Určení polohy...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Přidat podklad...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importovat a odstranit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Soubory podkladů</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Všechny soubory</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7590,19 +7591,19 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Neznámý souborový formát.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Nepodařilo se nahrát podklad. Existuje tento soubor a je platný?</translation>
     </message>
@@ -7611,210 +7612,210 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
         <translation type="obsolete">Geben Sie eine Zahl zwischen 0 und 1 oder einen Prozentwert zwischen 0 und 100 ein!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Zadejte prosím platné celé číslo pro nastavení skupiny nebo ponechejte pole prázdné pro zrušení seskupení podkladů!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Neměnit velikost</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Změnit velikost podle koeficientu měřítka mapy (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Změnit velikost podle nynějšího měřítka podkladu (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Import podkladu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Jak by se měla změnit velikost symbolů importovaného podkladu?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Podklad nebude při simulaci přetisku viditelný. Přepnout do normálního zobrazení?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Táhnutí&lt;/b&gt;: Posune aktuální podklad</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Určení polohy</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Měřítko X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Měřítko Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotace:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Změna velikosti a umístění cesty</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Souřadnicový systém</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Reálné</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Jedna jednotka souřadnic odpovídá:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Umístit cestu na zadané souřadnice</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Umístit cestu doprostřed pohledu na mapu</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Tento podklad musí být načten pomocí GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Vyberte souřadnicový systém pro souřadnice trasy</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Otevřít trasu...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Nahrát trasu v georeferencovaném nebo negeoreferencovaném režimu?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Umístí trasu podle nastavení souřadnicového systému mapy.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translatorcomment>Add explanation for &quot;these&quot;.</translatorcomment>
         <translation>Tyto ještě nejsou konfigurovány, takže se zobrazí jako další krok.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferencováno</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Negeoreferencováno</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Promítne trasu pomocí ortografické projekce se středem v průměru souřadnic trasy. Umožňuje úpravu transformace a nastavení polohy mapy pomocí upravené polohy trasy.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Trasa je prázdná. Není co importovat!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Otázka</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Mají se body GPS (cestovní body) importovat jako linie vedoucí skrze všechny body?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problémy při importu</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n objekt trasy se nepodařilo importovat (důvod: chybí souřadnice).</numerusform>
@@ -7823,7 +7824,7 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Chyba při čtení</translation>
     </message>
@@ -7836,7 +7837,7 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7845,39 +7846,39 @@ Pokud ovšem není vaším úmyslem na tento podklad kreslit, nejedná se o prob
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Není OSM soubor.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Soubor OSM má verzi %1.
 Nejnižší podporovaná verze je %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Soubor OSM má verzi %1.
 Nejvyšší podporovaná verze je %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problémy</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 uzlů se nepodařilo zpracovat správně.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Vnější odkaz: %1</translation>
@@ -7888,80 +7889,80 @@ Nejvyšší podporovaná verze je %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Zarovnání</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Vlevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Na střed</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Vpravo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Nahoře</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Základní čára</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Dole</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Nastavení textu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Rodina písma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Velikost písma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>bodů</translation>
     </message>
@@ -7970,277 +7971,277 @@ Nejvyšší podporovaná verze je %2.</translation>
         <translation type="vanished">Určit velikost...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Barva textu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>Tučné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>Kurzíva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translatorcomment>or &quot;underline&quot;/&quot;unterstreichen&quot;</translatorcomment>
         <translation>Podtržení</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Styl textu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Odstupy řádků:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Odstupy odstavců:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Odstupy znaků:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Podřezávání</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Text ikony symbolu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Rámování</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Nastavení kompatibility s OCADem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Barva rámování:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Obrys linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Stínování</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Posun vpravo/vlevo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Posun nahoru/dolů:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Kompatibilita s OCADem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>povoleno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Šířka linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Barva linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Pozice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linka pod odstavci</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Šířka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Odstup od základní linie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Vlastní polohy tabulátoru</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Přidat vlastní tabulátor</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Vypočítat</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translatorcomment>Original diskutabel</translatorcomment>
         <translation>Nelze vrátit zpět, protože poslední uložený krok je neplatný. To se může stát, když například změníte symbol objektu na jiný, a potom tento starý symbol smažete.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Potvrzení</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Tento krok zpět vede ke stavu před časovým bodem nahrání souboru. Jste si jistý?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Nelze provést znovu, protože první obnovovací krok je neplatný. To se může stát, když například smažete symbol objektu, který jste nekreslil.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Soubory s nápovědou se nepodařilo najít.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Program pro procházení souboru s nápovědou (&quot;Qt Assistant&quot;) se nepodařilo najít.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Program pro procházení souboru s nápovědou (&quot;Qt Assistant&quot;) se nepodařilo spustit.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Více...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Starší verze Mapperu nepodporují více mapových částí. Pro uložení souboru v režimu kompatibility musíte nejprve všechny části mapy sloučit.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Nepodporovaný prvek: %1 (řádek %2, sloupec %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Některé souřadnice byly mimo hranice tisku. Obsah mapy byl přizpůsoben.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>neznámý</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Části souboru nelze totuto verzí Mapperu přečíst. Nejnižší požadovaná verze: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Chyba na řádku %1, ve sloupci %2: %3</translation>
     </message>
@@ -8249,44 +8250,44 @@ Nejvyšší podporovaná verze je %2.</translation>
         <translation type="vanished">Mapové poznámky nebylo možné načíst.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Některé neplatné znaky musejí být odstraněny.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Neznámá chyba</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Nepodporovaná nebo neplatná specifikace souřadnicového systému &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Nelze nastavit vlastnosti vyřezání (knockout) u barvy &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Očekáváno %1 barev, nalezeno %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Přímá barva %1 nebyla při zpracování %2 (%3) nalezena.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Očekáváno %1 symbolů, nalezeno %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Očekáváno %1 částí mapy, nalezeno %2.</translation>
     </message>

--- a/translations/OpenOrienteering_da.ts
+++ b/translations/OpenOrienteering_da.ts
@@ -2,5104 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="da">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation>Om %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation>&lt;a %1&gt;Alt om licenser, copyright info, vilkår og ansvarsfralæggelser.&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation>OpenOrienteering udviklere i alfabetisk rækkefølge:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation>(initiativtagere)</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation type="unfinished">En gratis software til tegning af orienteringskort</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation type="unfinished">Dette program er en gratis software: du kan distribuere det videre og/eller ændre det iht. betingelserne i &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, publiceret af Free Software Foundation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation>For bidrag, tak til:</translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation>Åben sidst brugte fil</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation>Vis dagens tip</translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation>Vis resterende elementer</translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation>Mindstemål:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation>Fyld</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation>Liniefyld</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation>Mønsterfyld</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation>Enkelt linje</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation>Parallelle linjer</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation>Linjeafstand:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation>Enkelt række</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation>Mønsterinterval:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation>Mønsterforskydning:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation>Rækkeforskydning:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation>Parallelle rækker</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation>Rækkeafstand:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation>Rotation af fyld</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation>Vinkel:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation>justerbar pr. objekt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation>Områdeindstillinger</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation>Fyldmønster %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation>Liniefyld %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation>Ingen fyldning er valgt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation>Områdefarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation>Linieforskydning:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation>Liniefarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation>Liniebredde:</translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation>Automatisk gemt fil</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation>
-            <numerusform>%n byte</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation>Fil gemt af brugeren</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation>Fil genoprettelse</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation>Filen %1 blev ikke lukket ordentligt. Der findes derfor nu to versioner:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation>Gem den aktive fil for at fjerne konflikt med en anden version.</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation>Rediger kortfarve</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation>Definerer en spotfarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished">Blanding af spotfarver (skærme og overprint):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation>Knockout: fjerner lavere farver</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation>Beregn fra spotfarver</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation>Beregn fra RGB-farve</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation>Brugerdefineret procesfarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation>Cyan</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation>Magenta</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation>Gul</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation>Sort</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation>Beregn fra CMYK-farve</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation>Brugerdefineret RGB-farve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>Rød</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>Grøn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>Blå</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation>Skrivebord</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation type="unfinished">Professionel udskrivning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished">Navn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished">Advarsel</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation>-ingen-</translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>Navn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation>Gennemsigtighed</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation type="unfinished">Staffagefarve</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>Ny</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation>Slet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation>Dupliker</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation>Flyt op</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation>Flyt ned</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation>Hjælp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation type="unfinished">Dobbeltklik på en farveværdi for at åbne en dialogboks.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation type="unfinished">Bekræftelse</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation>Kortet indeholder symboler med denne farve. Sletning vil fjerne farven fra disse objekter! Sikker?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation> (Dupliker)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation>Dobbeltklik for at definere farven</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation>Klik for at vælge navnet og klik igen for at redigere det.</translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation type="unfinished">&amp;Antal dele:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation>-Privat liniesymbol-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation>- Privat områdesymbol -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation type="unfinished">Rediger privat symbol...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation>Kombinationindstillinger</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation>Skift fra offentlig til privat symbol</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation type="unfinished">Anvend det gamle symbol som skabelon for det private symbol?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation>Symbol %1:</translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished">Konfigurer gitter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation type="unfinished">Vis gitter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation type="unfinished">Fastgør til gitter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation>Vælg...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation>Alle linier</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation>Horisontale linier</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation>Vertikale linier</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation>Justering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation type="unfinished">Juster med magnetiske nordpol</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation type="unfinished">Yderligere rotation (mod uret):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation>meter i terræn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation>millimeter på kort</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation type="unfinished">Horisontal afstand:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation type="unfinished">Vertikal afstand</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation>Horisontal forskydning:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation>Vertikal forskydning:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation>Enhed:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation>Liniefarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation>Vis:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation type="unfinished">Vælg gitter stregfarve</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation>&lt;b&gt;Klik eller træk&lt;/b&gt;: Begynd at tegne hullet. </translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation>Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Klip hele kortet. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation>Kunne ikke åbne filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation>Filen er ikke en DXF-fil.</translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation>Bogstav:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation>Højde:</translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation type="unfinished">Antal punkter pr. sti:</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation>Rotationsindstillinger</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation type="unfinished">Juster punkter med retningen af linje</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation>Yderligere rotationsvinkel (mod uret):</translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation>Fra centrum</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation>&lt;b&gt;Klik&lt;/b&gt;: begynd en cirkel eller ellipse. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Tegn en cirkel. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation>&lt;b&gt;Klik&lt;/b&gt;: Afslut cirklen. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Tegn en ellipse. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation type="unfinished">&lt;b&gt;Træk&lt;/b&gt;: Tegn en sti. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation>&lt;b&gt;%1+Klik&lt;/b&gt;: Fastgør eller føj til eksisterende objekter. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1 +Klik&lt;/b&gt;: Fastgør til eksisterende objekter. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fortryd sidste punkt. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation>Afslut</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation type="unfinished">Luk</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>Vinkel</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation>Fortryd</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation>Afbryd</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation>&lt;b&gt;Længde:&lt;/b&gt; %1 m </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation>&lt;b&gt;%1+Træk&lt;/b&gt;: Følg eksisterende objekter. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>Vinkel</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation>Nulstil</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation>&lt;b&gt;Klik&lt;/b&gt;: Opret et punktobjekt.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Nulstil rotation.</translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation>Afslut</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation type="unfinished">Fastgør linie</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation>Fortryd</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation>Afbryd</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fastgør til foregående linier. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Annuller redigering. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Fastgør</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fastgør til eksisterende objekter. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished">Kliktolerance:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished">Fastgør afstand (%1):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation>Redigeringsværktøj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation>Rektangelværktøj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation>Kunne ikke oprette ny fil: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation>Advarsel</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished">Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished">Generelt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation>Programmet skal genstartes, før sprogændringen træder i kraft!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation>Åben oversættelse</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation>Oversættelsesfiler (*.qm)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation>Den valgte fil er ikke en gyldig oversættelse.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation>%1 x %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished">Primær skærmopløsning i pixel:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished">Primær skærmstørrelsen i tommer (diagonal):</translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation>UTM</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation>UTM koordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation>UTM Zone (nummer nord/syd)</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation>Gauss-Krueger, datum: Potsdam</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation>Gauss-Krueger koordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation>Zonenummer (1-119)</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished">af EPSG kode</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation>EPSG @code@ koordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation>Lokale koordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation>EPSG kode</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished">Brugerdefineret PROJ.4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation>Specifikation</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished">Ugyldig gitterskalafaktor: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation>Lokal</translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation>Status:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation>Geografiske koordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation>Vis referencepunkt i:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation>gyldig</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation>- lokal -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation>Referencepunkt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished">X</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished">Y</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation>Ø</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation>Ø</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation>Geografiske koordinater:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation>Lokale koordinater:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation>Indlæser...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation>låst</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation type="unfinished">Om %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished">Hjælp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished">Vis Dagens tip</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished">Liniebredde:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished">Liniefarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished">flad</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished">rund</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished">firkant</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation>ingen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation>2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation>3</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation>4</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation>Startsymbol</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation>Slutsymbol</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation>Aktiver kantlinjer</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation>Kantbredde:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation>Kantfarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation>&amp;Ny</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation>Opret et nyt kort</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;Åbne...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation>Åbne en eksisterende fil</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation>Åben &amp;seneste</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation>&amp;Gem</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation>Gem &amp;som...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation>Indstillinger...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation>Luk</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation>Luk filen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Afslut</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation>Afslut programmet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation>&amp;Fil</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished">Generelt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished">Åbn &amp;manualen</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation>Vis hjælp for programmet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation>&amp;Om %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation>Vis oplysninger om programmet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation>Om &amp;Qt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation>Vis oplysninger om Qt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation>&amp;Hjælp</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished">Advarsel</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished">Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation type="unfinished">Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation type="unfinished">Advarsel</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished">Importer...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished">Fortryd</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation>Skriv tekst</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished">Dupliker</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation>Klip objekt</translation>
-    </message>
-    <message>
-        <source>Rotate object(s)</source>
-        <translation type="vanished">Roter objekter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation>Aktiver GPS-visning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation>Aktiver GPS afstandsringe</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished">Angiv midlertidig markør på GPS-position</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished">Ryd midlertidige GPS markører</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation>Aktiver kompas visning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation>Juster kort mod nord</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation>Tilføj nye del...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation>Omdøb aktuelle del...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation>Fjern aktuelle del</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation>Flet alle dele</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation>Importer...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation>&amp;Rediger</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation>&amp;Vis</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation>Værk&amp;tøj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation>Sy&amp;mboler</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation>&amp;Kort</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation>&amp;Skabeloner</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation>Tegning</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation>Redigering i gang</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation>Kortet er gemt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation>Vis gitter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation>Konfigurer gitter...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation>Skjul alle skabeloner</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation>Erstat symbolsæt...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation>Roter kort...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation>Roter hele kortet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation>Genåbn skabelon...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation>Tegn rektangler</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation>Tegn frihånd</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation>Slet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation>Roter mønster</translation>
-    </message>
-    <message>
-        <source>Scale object(s)</source>
-        <translation type="vanished">Skaler objekter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation>Kortkoordinater</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation>Breddegrad/Længdegrad (Dec)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation>Breddegrad/Længdegrad (DMS)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation>Vis koordinater som...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation>Ctrl+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation>Ctrl+Shift+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation>Ctrl+I</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation type="unfinished">Ø</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation type="unfinished">Ctrl+R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation type="unfinished">N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation>Vælg alle</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation>Vælg intet</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation>Vis</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation>Vælg skabelon...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation>Redigering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation>Avanceret redigering</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation>Vælg symbol</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation>Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation>Brugerdefineret zoomfaktor</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation>Zoomfaktor:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation>Symboler</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation>Farver</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation>Skaler alle symboler</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation>Kortnoter</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation>Annuller</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation>Skabeloner</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation type="unfinished">Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation type="unfinished">Fejl</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation type="unfinished">mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="obsolete">Annuller</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished">libocad returnerede %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished">Kunne ikke allokere bufferen.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation>libocad returnerede %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation>OCAD filer af version %1 understøttes ikke!</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation>
-            <numerusform>%n farveseparation blev sprunget over, årsag: import deaktiveret.</numerusform>
-            <numerusform>%n farveseparationer blev sprunget over, årsag: import deaktiveret.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation>Kan ikke importere symbol &quot;%3&quot; (%1. %2)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation>OCAD import lag</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation>Objekt kan ikke indlæses</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation>Kan ikke importere rektangelobjekt</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation>Tekstsymbol ikke importeret: kunne ikke bestemme sti (npts =%1): % 2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation>Forsøger at importere et tekstobjekt med ukendt koordinatformat</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation>Farve-id blev ikke fundet: %1, ignorerer farven</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation>Kunne ikke indlæse koordinatreferencesystem &apos;%1&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation>Kan ikke importere symbol %1.%2 &quot;%3&quot;: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation>Ikke understøttet type &quot;%1&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation>Kan ikke importere skabelon: &quot;%1&quot; er en ikke understøttet skabelontype.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation>Ikke understøttet liniestil &apos;%1&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation>Symbolet kan ikke gemmes som et OCD-symbol igen.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation>Brugerdefineret tegnafstand kan være forkert.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation>Ignorerer brugerdefinerede ordmellemrum (%1%).</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation>Ignorerer brugerdefinerede indrykninger (%1/%2).</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation>Objekt kan ikke indlæses</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation>Kan ikke importere rektangelobjekt</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation>Tekstsymbol ikke importeret: kunne ikke bestemme sti (npts =%1): % 2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation>Forsøger at importere et tekstobjekt med ukendt koordinatformat</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation>Ugyldige data.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation>OCD-filer af version %1 understøttes ikke!</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished">Farve-id blev ikke fundet: %1, ignorerer farven</translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished">Punkt</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished">Linie</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished">Område</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5113,767 +15,2854 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
-        <translation>Vælg skabelon til at tegne på</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
+        <translation>Om %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
-        <translation type="unfinished">Annuller</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
+        <translation>&lt;a %1&gt;Alt om licenser, copyright info, vilkår og ansvarsfralæggelser.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation>Tegn</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation>OpenOrienteering udviklere i alfabetisk rækkefølge:</translation>
     </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation>(initiativtagere)</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
+        <translation type="unfinished">En gratis software til tegning af orienteringskort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
+        <translation type="unfinished">Dette program er en gratis software: du kan distribuere det videre og/eller ændre det iht. betingelserne i &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, publiceret af Free Software Foundation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
-        <translation>Farvevalg</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
+        <translation>For bidrag, tak til:</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flytter kortet. </translation>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
+        <translation>Åben sidst brugte fil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation>Vis dagens tip</translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation>Vis resterende elementer</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
+        <translation>Mindstemål:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
+        <translation>Fyld</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
+        <translation>Liniefyld</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
+        <translation>Mønsterfyld</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
+        <translation>Enkelt linje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
+        <translation>Parallelle linjer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
+        <translation>Linjeafstand:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
+        <translation>Enkelt række</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
+        <translation>Mønsterinterval:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
+        <translation>Mønsterforskydning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
+        <translation>Rækkeforskydning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
+        <translation>Parallelle rækker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
+        <translation>Rækkeafstand:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
+        <translation>Rotation af fyld</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
+        <translation>Vinkel:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
+        <translation>justerbar pr. objekt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation>Områdeindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation>Fyldmønster %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation>Liniefyld %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation>Ingen fyldning er valgt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <source>Area color:</source>
+        <translation>Områdefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
+        <translation>Linieforskydning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
+        <translation>Liniefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
+        <translation>Liniebredde:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AutosaveDialog</name>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation>Automatisk gemt fil</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation>
+            <numerusform>%n byte</numerusform>
+            <numerusform>%n bytes</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation>Fil gemt af brugeren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation>Fil genoprettelse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation>Filen %1 blev ikke lukket ordentligt. Der findes derfor nu to versioner:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
+        <translation>Gem den aktive fil for at fjerne konflikt med en anden version.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDialog</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
+        <translation>Rediger kortfarve</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation>Definerer en spotfarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished">Blanding af spotfarver (skærme og overprint):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
-</context>
-<context>
-    <name>PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PointSymbolEditorWidget</name>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation>Knockout: fjerner lavere farver</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
-        <translation>Elementer</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation>Beregn fra spotfarver</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
-        <translation>Punkt</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation>Beregn fra RGB-farve</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
-        <translation>Linie</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation>Brugerdefineret procesfarve:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
-        <translation>Område</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation>Centrer alle elementer</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation>Aktuelle element</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation>Diameter &lt;b&gt;a&lt;/b&gt;:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation>Sort</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation>Beregn fra CMYK-farve</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
-        <translation>Indvendig farve:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation>Brugerdefineret RGB-farve:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
-        <translation>Udvendig bredde &lt;b&gt;b&lt;/b&gt;:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>Rød</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
-        <translation>Udvendige farve:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>Grøn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
-        <translation type="unfinished">Liniebredde:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
-        <translation type="unfinished">Liniefarve:</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation>Skrivebord</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
-        <translation>flad</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation type="unfinished">Professionel udskrivning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
-        <translation>rund</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished">Navn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
-        <translation>firkant</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
-        <source>Area color:</source>
-        <translation type="unfinished">Områdefarve:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
-        <translation>Koordinater:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation>Kurvestart</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation>[Midtpunkt]</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
-        <translation>Ukendt</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
-        <translation>Punktsymbol</translation>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
+        <translation>-ingen-</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
-        <translation>Udskrivning</translation>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
-        <translation>Der opstod en fejl under behandlingen.</translation>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation>Gennemsigtighed</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation type="unfinished">Staffagefarve</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>Ny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation>Slet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation>Dupliker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation>Flyt op</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation>Flyt ned</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation type="unfinished">Dobbeltklik på en farveværdi for at åbne en dialogboks.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation type="unfinished">Bekræftelse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation>Kortet indeholder symboler med denne farve. Sletning vil fjerne farven fra disse objekter! Sikker?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation> (Dupliker)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation>Dobbeltklik for at definere farven</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation>Klik for at vælge navnet og klik igen for at redigere det.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt kortet, udskriftsområdet eller områdets grænser. </translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation type="unfinished">&amp;Antal dele:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdet. </translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation>-Privat liniesymbol-</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt kortet. </translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation>- Privat områdesymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdets grænse. </translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation type="unfinished">Rediger privat symbol...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
-        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdets grænser. </translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation>Kombinationindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation>Skift fra offentlig til privat symbol</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation type="unfinished">Anvend det gamle symbol som skabelon for det private symbol?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation>Symbol %1:</translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
-        <translation>Vis skabeloner</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished">Konfigurer gitter</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation type="unfinished">Vis gitter</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
-        <translation>Sideretning:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
+        <translation type="unfinished">Fastgør til gitter</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
-        <translation>Printer:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
+        <translation>Vælg...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
-        <translation>Stående</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
+        <translation>Alle linier</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
-        <translation>Liggende</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
+        <translation>Horisontale linier</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
-        <translation>Sideformat:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
+        <translation>Vertikale linier</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
-        <translation>Kopier:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
+        <translation>Justering</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
-        <translation>Venstre:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
+        <translation type="unfinished">Juster med magnetiske nordpol</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
-        <translation>Top:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
-        <translation>Bredde:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
-        <translation type="unfinished">Højde:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
+        <translation type="unfinished">Yderligere rotation (mod uret):</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
-        <translation>Forhåndsvisning…</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
-        <translation>Enkelt side</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
-        <translation>Brugerdefineret område</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
+        <translation>meter i terræn</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
-        <translation>Kortområde:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
+        <translation>millimeter på kort</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
-        <translation>Centrer udskriftsområde</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
+        <translation type="unfinished">Horisontal afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation type="unfinished">Vertikal afstand</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation>Horisontal forskydning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation>Vertikal forskydning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation>Enhed:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation>Liniefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation>Vis:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation type="unfinished">Vælg gitter stregfarve</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
+    <message>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
+        <translation>&lt;b&gt;Klik eller træk&lt;/b&gt;: Begynd at tegne hullet. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Error</source>
+        <translation>Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutoutTool</name>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Klip hele kortet. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
+        <translation>Kunne ikke åbne filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation>Filen er ikke en DXF-fil.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation>Bogstav:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation>Højde:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation type="unfinished">Antal punkter pr. sti:</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation>Rotationsindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation type="unfinished">Juster punkter med retningen af linje</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation>Yderligere rotationsvinkel (mod uret):</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation>Fra centrum</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation>&lt;b&gt;Klik&lt;/b&gt;: begynd en cirkel eller ellipse. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Tegn en cirkel. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation>&lt;b&gt;Klik&lt;/b&gt;: Afslut cirklen. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Tegn en ellipse. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation type="unfinished">&lt;b&gt;Træk&lt;/b&gt;: Tegn en sti. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation>&lt;b&gt;%1+Klik&lt;/b&gt;: Fastgør eller føj til eksisterende objekter. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1 +Klik&lt;/b&gt;: Fastgør til eksisterende objekter. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fortryd sidste punkt. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation type="unfinished">Luk</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>Vinkel</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation>Fortryd</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation>Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation>&lt;b&gt;Længde:&lt;/b&gt; %1 m </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation>&lt;b&gt;%1+Træk&lt;/b&gt;: Følg eksisterende objekter. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>Vinkel</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation>Nulstil</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation>&lt;b&gt;Klik&lt;/b&gt;: Opret et punktobjekt.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Nulstil rotation.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation type="unfinished">Fastgør linie</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation>Fortryd</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation>Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fastgør til foregående linier. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Annuller redigering. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Fastgør</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fastgør til eksisterende objekter. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished">Kliktolerance:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished">Fastgør afstand (%1):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation>Redigeringsværktøj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation>Rektangelværktøj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation>Kunne ikke oprette ny fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
-        <translation type="unfinished">Advarsel</translation>
+        <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished">Generelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation>Programmet skal genstartes, før sprogændringen træder i kraft!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation>Åben oversættelse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation>Oversættelsesfiler (*.qm)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation>Den valgte fil er ikke en gyldig oversættelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation>%1 x %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished">Primær skærmopløsning i pixel:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished">Primær skærmstørrelsen i tommer (diagonal):</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation>UTM</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation>UTM koordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation>UTM Zone (nummer nord/syd)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation>Gauss-Krueger, datum: Potsdam</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation>Gauss-Krueger koordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation>Zonenummer (1-119)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished">af EPSG kode</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation>EPSG @code@ koordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation>Lokale koordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation>EPSG kode</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished">Brugerdefineret PROJ.4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation>Specifikation</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished">Ugyldig gitterskalafaktor: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation>Lokal</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation>Status:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation>Geografiske koordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation>Vis referencepunkt i:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation>gyldig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation>- lokal -</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation>Referencepunkt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished">X</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished">Y</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation>Ø</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation>Ø</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation>Geografiske koordinater:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation>Lokale koordinater:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation>Indlæser...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation>låst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation type="unfinished">Om %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished">Hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished">Vis Dagens tip</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished">Liniebredde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished">Liniefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished">flad</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished">rund</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished">firkant</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation>ingen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation>4</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation>Startsymbol</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation>Slutsymbol</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation>Aktiver kantlinjer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation>Kantbredde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation>Kantfarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation>&amp;Ny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation>Opret et nyt kort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Åbne...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation>Åbne en eksisterende fil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation>Åben &amp;seneste</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Gem</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation>Gem &amp;som...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation>Indstillinger...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation>Luk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation>Luk filen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">&amp;Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation>Afslut programmet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation>&amp;Fil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished">Generelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished">Åbn &amp;manualen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation>Vis hjælp for programmet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation>&amp;Om %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation>Vis oplysninger om programmet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation>Om &amp;Qt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation>Vis oplysninger om Qt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5881,7 +2870,3019 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished">Importer...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished">Fortryd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation>Skriv tekst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished">Dupliker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation>Klip objekt</translation>
+    </message>
+    <message>
+        <source>Rotate object(s)</source>
+        <translation type="vanished">Roter objekter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation>Aktiver GPS-visning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation>Aktiver GPS afstandsringe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished">Angiv midlertidig markør på GPS-position</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished">Ryd midlertidige GPS markører</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation>Aktiver kompas visning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation>Juster kort mod nord</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation>Tilføj nye del...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation>Omdøb aktuelle del...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation>Fjern aktuelle del</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation>Flet alle dele</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation>Importer...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Rediger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation>&amp;Vis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation>Værk&amp;tøj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation>Sy&amp;mboler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation>&amp;Kort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation>&amp;Skabeloner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation>Tegning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation>Redigering i gang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation>Kortet er gemt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation>Vis gitter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation>Konfigurer gitter...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation>Skjul alle skabeloner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation>Erstat symbolsæt...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation>Roter kort...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation>Roter hele kortet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation>Genåbn skabelon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation>Tegn rektangler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation>Tegn frihånd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation>Slet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation>Roter mønster</translation>
+    </message>
+    <message>
+        <source>Scale object(s)</source>
+        <translation type="vanished">Skaler objekter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation>Kortkoordinater</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation>Breddegrad/Længdegrad (Dec)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation>Breddegrad/Længdegrad (DMS)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation>Vis koordinater som...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation>Ctrl+Shift+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation type="unfinished">Ø</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished">Ctrl+R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation type="unfinished">N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation>Vælg alle</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation>Vælg intet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation>Vis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation>Vælg skabelon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation>Redigering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation>Avanceret redigering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation>Vælg symbol</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation>Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation>Brugerdefineret zoomfaktor</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation>Zoomfaktor:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation>Symboler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation>Farver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation>Skaler alle symboler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation>Kortnoter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation>Skabeloner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation type="unfinished">mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="obsolete">Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished">libocad returnerede %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished">Kunne ikke allokere bufferen.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation>libocad returnerede %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation>OCAD filer af version %1 understøttes ikke!</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation>
+            <numerusform>%n farveseparation blev sprunget over, årsag: import deaktiveret.</numerusform>
+            <numerusform>%n farveseparationer blev sprunget over, årsag: import deaktiveret.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation>Kan ikke importere symbol &quot;%3&quot; (%1. %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation>OCAD import lag</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation>Objekt kan ikke indlæses</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation>Kan ikke importere rektangelobjekt</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation>Tekstsymbol ikke importeret: kunne ikke bestemme sti (npts =%1): % 2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation>Forsøger at importere et tekstobjekt med ukendt koordinatformat</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation>Farve-id blev ikke fundet: %1, ignorerer farven</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation>Kunne ikke indlæse koordinatreferencesystem &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation>Kan ikke importere symbol %1.%2 &quot;%3&quot;: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation>Ikke understøttet type &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation>Kan ikke importere skabelon: &quot;%1&quot; er en ikke understøttet skabelontype.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation>Ikke understøttet liniestil &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation>Symbolet kan ikke gemmes som et OCD-symbol igen.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation>Brugerdefineret tegnafstand kan være forkert.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation>Ignorerer brugerdefinerede ordmellemrum (%1%).</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation>Ignorerer brugerdefinerede indrykninger (%1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation>Objekt kan ikke indlæses</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation>Kan ikke importere rektangelobjekt</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation>Tekstsymbol ikke importeret: kunne ikke bestemme sti (npts =%1): % 2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation>Forsøger at importere et tekstobjekt med ukendt koordinatformat</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation>Ugyldige data.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation>OCD-filer af version %1 understøttes ikke!</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished">Farve-id blev ikke fundet: %1, ignorerer farven</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished">Punkt</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished">Linie</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished">Område</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation>Vælg skabelon til at tegne på</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation>Tegn</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation>Farvevalg</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flytter kortet. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation>Elementer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation>Punkt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation>Linie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation>Område</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation>Centrer alle elementer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation>Aktuelle element</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation>Diameter &lt;b&gt;a&lt;/b&gt;:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation>Indvendig farve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation>Udvendig bredde &lt;b&gt;b&lt;/b&gt;:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation>Udvendige farve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished">Liniebredde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished">Liniefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation>flad</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation>rund</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation>firkant</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished">Områdefarve:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation>Koordinater:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation>Kurvestart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation>[Midtpunkt]</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation>Ukendt</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation>Punktsymbol</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation>Udskrivning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation>Der opstod en fejl under behandlingen.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt kortet, udskriftsområdet eller områdets grænser. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdet. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt kortet. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdets grænse. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation>&lt;b&gt;Træk&lt;/b&gt;: Flyt udskriftsområdets grænser. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation>Vis skabeloner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished">Vis gitter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation>Sideretning:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation>Printer:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation>Stående</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation>Liggende</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation>Sideformat:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation>Kopier:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation>Venstre:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation>Top:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation>Bredde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished">Højde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation>Forhåndsvisning…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation>Enkelt side</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation>Brugerdefineret område</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation>Kortområde:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation>Centrer udskriftsområde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished">Ukendt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5889,672 +5890,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished">Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished">&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished">Lokal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished">Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished">gyldig</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished">-ingen-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished">Generelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished">Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished">Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished">Område</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished">Dupliker</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished">Slet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished">Vælg alle</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished">Bekræftelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6562,58 +6563,58 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">Flyt op</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">Flyt ned</translation>
     </message>
@@ -6622,7 +6623,7 @@ to jump over the lazy dog
         <translation type="obsolete">Hjælp</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6630,625 +6631,625 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished">Hjælp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished">Ny</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished">Slet</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished">Hjælp</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished">Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuller</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished">Gennemsigtighed</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished">Luk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished">Dupliker</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished">Flyt op</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished">Flyt ned</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished">Hjælp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinatsystem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished">Én koordinere enhed er lig med:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7256,436 +7257,436 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished">Justering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished">Linjeafstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished">Bredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished">Liniebredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished">Liniefarve:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished">Bekræftelse</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Ukendt fejl</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_de.ts
+++ b/translations/OpenOrienteering_de.ts
@@ -2,249 +2,262 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Orientierungslaufkarte</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Programm zum Zeichnen von Orientierungslaufkarten</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Über %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Dieses Programm ist freie Software: Sie können es weitergeben oder modifizieren unter den Bedingungen der &lt;a %1&gt;GNU General Public License (GPL), Version&amp;nbsp;3&lt;/a&gt;, wie von der Free Software Foundation veröffentlicht.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Die Veröffentlichung dieses Programms erfolgt in der Hoffnung, daß es Ihnen von Nutzen sein wird, aber OHNE IRGENDEINE GARANTIE (soweit ausschließbar), sogar ohne die implizite Garantie der MARKTREIFE oder der VERWENDBARKEIT FÜR EINEN BESTIMMTEN ZWECK. &lt;a %1&gt;Details&lt;/a&gt; finden Sie in der GNU General Public License, Version&amp;nbsp;3.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Alles über Lizenz, Urheberhinweise, Bedingungen und Haftungsablehnungen&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Die OpenOrienteering-Entwickler in alphabetischer Reihenfolge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(Projektstarter)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Ein freies Programm zum Zeichnen von Orientierungslaufkarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Dank für Beiträge an:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Zuletzt benutzte Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Tipp des Tages anzeigen</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Weitere Elemente anzeigen</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Mindestgröße:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Füllungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Linienfüllung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Füllmuster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Einzellinie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Parallele Linien</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Linienabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Einzelreihe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Musterabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Musterversatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Reihenversatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Parallele Reihen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Reihenabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Drehung der Füllung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>objektweise einstellbar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Zeichnen von Elementen  am Rand</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Elemente am Rand beschneiden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Elemente zeichnen wenn das Zentrum innerhalb der Begrenzung liegt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Elemente zeichnen wenn irgendein Punkt innerhalb der Begrenzung liegt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Elemente zeichnen wenn alle Punkte innerhalb der Begrenzung liegen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Flächeneinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Füllmuster %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Linienfüllung %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Keine Füllung ausgewählt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Flächenfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Linienversatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Linienfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Linienbreite:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automatisch gespeicherte Datei</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n Byte</numerusform>
@@ -252,249 +265,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Vom Benutzer gespeicherte Datei</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Dateiwiederherstellung</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Datei %1 wurde nicht ordnungsgemäß geschlossen. Im Augenblick gibt es zwei Versionen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Speichern Sie die aktive Datei, um den Versionskonflikt zu lösen.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Kartenfarbe bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definiert eine Schmuckfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mischung aus Schmuckfarben (Raster und Überdruck):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout: löscht darunterliegende Farben</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Angepasste Prozessfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Schwarz</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- unbenannt -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Aus Schmuckfarben berechnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Aus RGB-Farbe berechnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Aus CMYK-Farbe berechnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Angepasste RGB-Farbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Rot</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Grün</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Blau</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Professioneller Druck</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- keine -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Deckkraft</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Schmuckfarbe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Nach oben schieben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Nach unten schieben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Doppelklick auf einen Farbeintrag öffnet den Farbdialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Die Karte enthält Symbole mit dieser Farbe. Diese Symbole würden die Farbe verlieren. Wollen Sie das wirklich?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (Kopie)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translatorcomment>Remove initial space from tr.</translatorcomment>
         <translation> (Kopie)</translation>
@@ -508,303 +521,303 @@
         <translation type="vanished">Bitte geben Sie einen Prozentsatz von 0% bis 100% ein!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Doppelklick, um die Farbe festzulegen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klick, um den Namen auszuwählen. Zum Bearbeiten erneut klicken.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>A&amp;nzahl der Teile:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Privates Liniensymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Privates Flächensymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Privates Symbol bearbeiten ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translatorcomment>Replace original with &quot;Composition&quot;</translatorcomment>
         <translation>Zusammensetzung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Von öffentlichem zu privatem Symbol ändern</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Das alte Symbol als Vorlage für das private Symbol nehmen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbol %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Gitter konfigurieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Gitter anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translatorcomment>Improve original (unclear!)</translatorcomment>
         <translation>Einrasten am Gitter aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Wählen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Alle Linien</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Horizontale Linien</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Vertikale Linien</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Ausrichtung</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Nach magnetisch Nord ausrichten</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Nach Gitternord ausrichten</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Nach geographisch Nord ausrichten</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Zusätzliche Drehung (gegen Uhrzeigersinn):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Positionierung</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>Meter im Gelände</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>Millimeter auf Karte</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Horizontaler Abstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Vertikaler Abstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horizontaler Versatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikaler Versatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Einheit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Linienfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translatorcomment>Add explanation to tr()</translatorcomment>
         <translation>Anzeige:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Gitterlinienfarbe wählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Ursprung bei: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Ursprung der Papierkoordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>Ursprung der projizierten Koordinaten</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klicken oder Ziehen&lt;/b&gt;: Zeichnen des Lochs beginnen. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Die Schnittlinie muss am Flächenrand enden!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Anfang und Ende der Schnittlinie befinden sich an verschiedenen Teilen des Objekts!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Anfang und Ende der Schnittlinie befinden sich an derselben Position!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klicken&lt;/b&gt;: Linie teilen. &lt;b&gt;Ziehen&lt;/b&gt;: Linienstück entfernen. &lt;b&gt;Klicken oder Ziehen&lt;/b&gt; am Flächenrand: Schnittlinie beginnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Das Auftrennen von Löchern in Flächenobjekten ist noch nicht unterstützt!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Auf gesamter Karte wegschneiden. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klick oder Ziehen&lt;/b&gt;: Zu beschneidende Objekte auswählen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ausgewählte Objekte beschneiden. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Konnte Datei nicht öffnen.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Die Datei ist nicht im DXF-Format.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Schriftgröße bestimmen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Buchstabe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -818,261 +831,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Punkte entlang eines Pfads verteilen</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Anzahl der Punkte:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Punkte auch an den Pfad enden plazieren</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Drehung einstellen</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Drehung der Punkte am Pfad ausrichten</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Zusätzliche Drehung (gegen Uhrzeigersinn):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Vom Mittelpunkt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klicken&lt;/b&gt;: Kreis oder Ellipse beginnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Einen Kreis zeichnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>%1 gedrückt halten, um vom Mittelpunkt zu beginnen.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klicken&lt;/b&gt;: Kreis fertigstellen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Eine Ellipse zeichnen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Einen Pfad zeichnen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Strichelungspunkte aktiv.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt;: An bestehenden Objekten einrasten oder weiterzeichnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt;: Richtung von bestehenden Objekten übernehmen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Richtung und Länge des Segments. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt;: An bestehenden Objekten einrasten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Eingeschränkte Winkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Letzten Punkt entfernen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Abschließen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Strichelung</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Länge:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Gerade Linie beginnen. &lt;b&gt;Ziehen&lt;/b&gt;: Kurve beginnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Ziehen&lt;/b&gt;: Bestehenden Objekten folgen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Gerade Line zeichnen. &lt;b&gt;Ziehen&lt;/b&gt;: Kurve zeichnen. &lt;b&gt;Rechts- oder Doppelklick&lt;/b&gt;: Pfad fertigstellen. &lt;b&gt;%1&lt;/b&gt;: Pfad schließen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Karte berühren, um Mittelung abzuschließen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klicken&lt;/b&gt;: Plazieren des Objekts abschließen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Winkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Eingeschränkte Winkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Punktobjekt erstellen.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Objekt erstellen und Ausrichtung festlegen.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Drehung zurücksetzen.</translation>
     </message>
@@ -1082,518 +1095,518 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Abschließen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Linienraster</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Strichelung</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klick oder Ziehen&lt;/b&gt;: Rechteck beginnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: An vorherigen Linien einrasten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Eckpunkt setzen. &lt;b&gt;Rechts- oder Doppelklick&lt;/b&gt;: Rechteck fertigstellen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Bearbeitung abschließen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Bearbeitung abbrechen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Einfach verankerten Text erstellen. &lt;b&gt;Ziehen&lt;/b&gt;: Textrahmen erstellen. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Kurve umschalten</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Freie Bewegung. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt; auf Segment: Zwischen gerader Linie und Kurve umschalten. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Einrasten</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punkt / Winkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Strichelung umschalten</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Bearbeitung abschließen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Anfasspunkte in gegenüberliegenden Positionen halten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt; auf Punkt: Diesen löschen; auf Pfad: Strichelungspunkt einfügen; mit &lt;b&gt;%2&lt;/b&gt;: Normalen Punkt einfügen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt; auf Punkt: Diesen löschen; auf Pfad: Punkt einfügen; mit &lt;b&gt;%2&lt;/b&gt;: Strichelungspunkt einfügen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klick&lt;/b&gt; auf Punkt: Zwischen normalem und Strichelungspunkt umschalten. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinatenversatz:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Entfernung:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Eingeschränkte Winkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: An bestehenden Objekten einrasten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Einzelnes Objekt auswählen. &lt;b&gt;Ziehen&lt;/b&gt;: Bereich auswählen. &lt;b&gt;%1+Klick&lt;/b&gt;: Auswahl umkehren. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ausgewählte Objekte löschen. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Hohe Darstellungsqualität (Antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing verbessert die Kartendarstellung, verlangsamt aber den Bildaufbau</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Hohe Text-Darstellungsqualität (Antialiasing), langsam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klicktoleranz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Einrastdistanz (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Schrittweite bei eingeschränkten Winkeln (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Symbolgröße:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Automatisch das zugehörige Symbol auswählen, wenn ein Objekt ausgewählt wird</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Vom Mauszeiger aus herauszoomen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Zeichentools: beim Abschließen mit Rechtsklick auch letzten Punkt setzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Vorlagen: Einstellungen von geschlossenen Vorlagen speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Bearbeitungstool:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Alte Form beibehalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Äußere Kurven-Handles zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Äußere Kurven-Handles behalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Aktion beim Löschen eines Kurvenpunkts mit %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Rechteckstool:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Radius des Hilfskreuzes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Breite von Linien mit dem Hilfskreuz darstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Kann Datei nicht erstellen: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Speichern in diesem Format (%1) wird nicht unterstützt</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Die Kartenfläche ist groß. Die Anwendung des Füllen-Werkzeugs kann sehr langsam sein. Möchten Sie dennoch fortfahren?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Die angeklickte Fläche wird nicht von Linien oder Flächen begrenzt. Füllen nicht möglich.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Die angeklickte Stelle ist nicht leer. Füllen nicht möglich.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Konnte das Füllungsobjekt nicht erstellen.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Fläche mit aktivem Symbol füllen. Die Fläche muss von Linien oder Flächen begrenzt sein, andere Symbole werden nicht berücksichtigt. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS ist in den Geräteeinstellungen deaktiviert. Einstellungen jetzt öffnen?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Import mit GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Erscheinungsbild</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Sprache:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Bildschirm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixel pro Zoll:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Programmstart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Speichern von Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Kompatibilität mit Mapper %1 erhalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Rückgängig-/Wiederholen-Schritte speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Informationen für automatische Wiederherstellung speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Wiederherstellungsinformation speichern alle:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Datei-Import und Export</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>7-Bit-Kodierung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Weitere...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Neuen OCD-Import auch für Dateien der Version 8 benutzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Hinweis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Das Programm muss neu gestartet werden, um die eingestellte Sprache zu verwenden!</translation>
     </message>
@@ -1602,48 +1615,48 @@
         <translation type="vanished">Übersetzungsdatei benutzen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translatorcomment>-datei hinzugefügt</translatorcomment>
         <translation>Übersetzungsdatei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Übersetzungsdateien (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Die gewählte Datei ist keine gültige Übersetzung.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Auflösung des Hauptbildschirms in Pixeln:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Größe (Diagonale) des Hauptbildschirms in Zoll:</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM-Koordinaten</translation>
     </message>
@@ -1652,80 +1665,80 @@
         <translation type="vanished">UTM-Zone (Zahl Nord/Süd, z.B. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM-Zone (Zahl Nord/Süd)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krüger, Datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krüger-Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Zonennummer (1 bis 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>mit EPSG-Code</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG-@code@-Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Lokale Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG Code</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>PROJ.4-Spezifikation</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Spezifikation</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Angabe des Kartenmaßstabs ist ungültig oder fehlt.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Ungültiger Maßstabsfaktor: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Unbekannte Sprache der Koordinatenreferenzsystems-Angabe: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Geographisches Koordinatenreferenzsystem nicht unterstützt: %1</translation>
     </message>
@@ -1734,7 +1747,7 @@
         <translation type="vanished">Nur Maßstab</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
@@ -1744,74 +1757,74 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georeferenzierung</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Abrufen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Deklination:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Projizierte Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translatorcomment>Maßstabsfaktor der Projektionsverzerrung</translatorcomment>
         <translation>Maßstabsfaktor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Geographische Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Referenzpunkt anzeigen in:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>gültig</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Deklination online abrufen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Karten-Koordinatenbezugssystem</translation>
     </message>
@@ -1824,7 +1837,7 @@
         <translation type="vanished">- aus Proj.4-Spezifikation -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokal -</translation>
     </message>
@@ -1833,112 +1846,112 @@
         <translation type="vanished">Koordinatenbezugssystem-Spezifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Referenzpunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>Auf &amp;Karte auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Kartennord</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Koordinatenbezugssystem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Kartenkoordinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Geographische Koordinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Bei Änderungen des&lt;br/&gt;Koordinatenbezugssystems, behalte bei:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Nadelabweichung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Die magnetische Deklination des Referenzpunkts %1° %2° wird nun online von &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt; abgerufen. Wollen Sie fortfahren?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Deklinationsänderung</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Die Deklination wurde geändert. Wollen Sie auch den Karteninhalt entsprechend drehen?</translation>
     </message>
@@ -1947,149 +1960,149 @@
         <translation type="vanished">Projizierte Koordinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Lokale Koordinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Lade...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Konnte Daten nicht auswerten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Deklinationswert nicht gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Der Online-Abruf der Deklination ist fehlgeschlagen:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klick&lt;/b&gt;: Referenzpunkt setzen. Andere Maustaste zum Abbrechen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Referenzpunkt setzen. &lt;b&gt;Rechtsklick&lt;/b&gt;: Abbrechen.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Willkommen bei OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Aktivitäten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Neue Karte erstellen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Karte öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Über %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Zuletzt geöffnet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Zuletzt benutzte Datei bei Programmstart öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Liste leeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Tipp des Tages</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Tipp des Tages anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Vorheriger</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Nächster</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Über Mapper</translation>
     </message>
@@ -2098,12 +2111,12 @@
         <translation type="vanished">Über Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Dateiliste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Keine Kartendateien gefunden!&lt;br/&gt;&lt;br/&gt;Kopieren Sie Kartendateien in ein &apos;OOMapper&apos; genanntes Verzeichnis auf dem Gerät oder einer Speicherkarte.</translation>
     </message>
@@ -2113,19 +2126,19 @@
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Fehler beim Laden eines Symbols vom Typ %1 in Zeile %2 Spalte %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symbol-ID &apos;%1&apos; nicht eindeutig in Zeile %2 Spalte %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Fehler beim Laden eines Symbols vom Typ %1 in Zeile %2 Spalte %3: %4</translation>
     </message>
@@ -2134,38 +2147,38 @@
         <translation type="vanished">Fehler beim Laden eines Symbols.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Fehler beim Laden eines Objekts vom Typ %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Fehler beim Laden eines Objekts vom Typ %1 bei %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Kann Symbol für Objekt nicht finden bei %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Punktobjekt mit undefiniertem oder falschen Symbol bei %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Version 7/8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2174,48 +2187,48 @@
         <translation type="vanished">Konnte die Daten nicht auswerten.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Konnte die Koordinaten nicht auswerten.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>%1 Koordinaten erwartet, %2 gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Fehler beim Laden der Druckkonfiguration bei %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Fehler beim Laden der Rückgängig-/Wiederholen-Schritte bei %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Unbekannte Option: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Vektor-Geodaten</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Objekt ohne Symbol gefunden.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Ein irreguläres Objekt ausgelassen.</numerusform>
@@ -2223,36 +2236,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Fehler beim Nachbearbeiten der Symbole.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Die Vorlage &quot;%1&quot; wurde aus dem Verzeichnis der Karte geladen anstatt vom relativen Pfad zur Kartendatei, wo sie zuvor war.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Vorlage &apos;%1&apos; konnte nicht geladen werden, Grund: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Warnung beim Laden der Vorlage &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Mindestens eine Vorlage nicht gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klicken Sie die rot markierten Dateinamen unter Vorlagen -&gt; Vorlagen verwalten an, um die Datei(en) zu finden.</translation>
     </message>
@@ -2261,174 +2274,174 @@
         <translation type="vanished">Eine oder mehrere Vorlagen konnten nicht gefunden werden. Klicken Sie die rot markierten Dateinamen unter Vorlagen -&gt; Vorlagen verwalten an, um die Datei(en) zu finden..</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Diese Datei nutzt ein veraltetes Format. Die Unterstützung für dieses Format wird bald aus der Software entfernt. Um die Datei auch in Zukunft öffnen zu können, speichern Sie es bitte erneut.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Ungültige Version des Dateiformats.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Nicht unterstützte alte Version des Dateiformats. Bitte eine ältere Programmversion verwenden, um die Datei zu öffnen und neu zu speichern.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Nicht unterstützte neue Version des Dateiformats. Einige Kartenelemente werden von dieser Programmversion nicht geladen oder gespeichert. Bitte aktualisieren Sie das Programm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Das geographische Koordinatensystem dieser Datei war &quot;%1&quot;. Dieses Koordinatenbezugssystem wird nicht unterstützt. Es wird &quot;%2&quot; verwendet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Fehler beim Laden eines Symbols vom Typ %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Fehler beim Laden eines Symbols.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Fehler beim Laden von Rückgängig-Schritten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Fehler beim Lesen des Kartenteilzählers.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Fehler beim Laden des Kartenteils %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Kann Datei nicht lesen: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Dateiformat nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Nicht unterstützte neue Version des Dateiformats. Einige Kartenelemente werden von dieser Programmversion nicht geladen oder gespeichert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Import in diesem Format (%1) wird nicht unterstützt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Konnte &apos;%1&apos; nicht lesen: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Linieneigenschaften</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Linienbreite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Linienfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minimale Linienlänge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Linienende:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>flach</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translatorcomment>Context required: cap vs. join.</translatorcomment>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>quadratisch</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>spitz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Linienecken:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>spitz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>flach</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Länge des Linienendes:</translation>
     </message>
@@ -2438,208 +2451,208 @@
         <translation>gestrichelte Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Mindestens ein Mittelsymbol anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Mindestzahl von Mittelsymbolen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Mindestzahl von Mittelsymbolen geschlossener Pfade:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Länge eines Strichs:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Gestrichelte Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Länge der Unterbrechung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Strichen gruppieren:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>keine</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Unterbrechungslänge in Gruppen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Halbe Länge des ersten und letzten Strichs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Zwischensymbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translatorcomment>Must be improved.</translatorcomment>
         <translation>Mittelsymbole pro Stelle:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Abstand der Mittelsymbole:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Randlinien</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Verschiedene Ränder links und rechts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Linker Rand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Rechter Rand:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Anfangssymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Zwischensymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Endsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Strichelungssymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Randlinien</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Abstand zwischen den Symbolen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Abstand vom Linienende:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Strichelungssymbol am Linienanfang und -ende unterdrücken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Strichelungssymbol an Ecken skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Randbreite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Randfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translatorcomment>Re-check.</translatorcomment>
         <translation>Randverschiebung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Gestrichelter Rand</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Randstrichlänge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Randunterbrechungslänge:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2650,122 +2663,122 @@ File format not recognized.</source>
 Unbekanntes Dateiformat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Neu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Vor dem Öffnen einer neuen Datei muss die aktuelle Datei geschlossen werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Eine neue Karte erstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>Ö&amp;ffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Eine vorhandene Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Zu&amp;letzt bearbeitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Speichern &amp;unter...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Einstellungen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Diese Datei schließen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translatorcomment>Ausführlicher</translatorcomment>
         <translation>Die Anwendung beenden und alle Fenster schließen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translatorcomment>Kürzer</translatorcomment>
         <translation>&amp;Handbuch</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Die Dokumentation zu diesem Programm anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Über %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Informationen über Qt anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Wollen Sie die automatisch gespeicherte Version entfernen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Die Datei wurde geändert.
 Möchten Sie die Änderungen speichern?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2774,18 +2787,18 @@ Do you want to scale the symbols to the selected scale?</source>
 Sollen alle Symbole auf den gewählten Maßstab skaliert werden?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>%1 wird geöffnet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Absturz-Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Anscheinend ist %1 beim letzten Mal abgestürzt, als diese Datei geöffnet wurde:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Wirklich erneut versuchen, siezu öffnen?</translation>
     </message>
@@ -2798,92 +2811,93 @@ Sollen alle Symbole auf den gewählten Maßstab skaliert werden?</translation>
         <translation type="vanished">Es gibt eine Wiederherstellungsdatei von &lt;br /&gt;&lt;tt&gt;%1&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Diese Datei laden?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Automatisches Speichern...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Automatisches Speichern fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Alle Karten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Datei speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Datei konnte nicht gespeichert werden:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Beim Ermitteln des Dateiformat ist ein Problem aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Bitte melden Sie das als Programmfehler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Informationen über dieses Programm anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Ungespeicherte Datei</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Die Datei wurde verändert.
 Wollen Sie diese Änderungen verwerfen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Alle Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translatorcomment>Nicht zu übersetzen</translatorcomment>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2895,23 +2909,23 @@ Wählen Sie Nein, um ein anderes Dateiformat auszusuchen.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2920,7 +2934,7 @@ because saving as %2 (.%3) is not supported.</source>
 exportieren, weil das Speichern als %2 (.%3) nicht unterstützt wird.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2935,31 +2949,31 @@ exportieren, weil das Format unbekannt ist.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Beim Kartenexport sind Warnmeldungen aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Interner Fehler beim Speichern:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Beim Kartenimport sind Warnmeldungen aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2967,12 +2981,12 @@ for reading.</source>
 Datei kann nicht zum Lesen geöffnet werden.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Ungültiger Dateityp.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2983,7 +2997,7 @@ Datei kann nicht zum Lesen geöffnet werden.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -2992,17 +3006,17 @@ Datei kann nicht zum Lesen geöffnet werden.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nichts zu importieren.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Frage</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3011,23 +3025,23 @@ Rescale the imported data?</source>
 Importierte Daten auf Kartenmaßstab umrechnen?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Standardteil</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Neue Farbe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Symbolersetzung wurde abgebrochen.
@@ -3035,207 +3049,207 @@ Daten trotzdem importieren?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Passfarbe (alle gedruckten Echtfarben)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Koordinaten liegen außerhalb der Schranken.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Drucken...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Den letzten Schritt rückgängig machen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Den letzten Schritt wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>&amp;Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Hineinzoomen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Herauszoomen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Vollbildmodus umschalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Benutzerdefinierter Zoomfaktor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Symbolfenster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Symbolfenster anzeigen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Farben</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Farbfenster anzeigen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translatorcomment>Replace map file with either map or file</translatorcomment>
         <translation>Symbole mit denen aus einer anderen Datei ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Alle Symbole skalieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Die Größe aller Symbole ändern</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Maßstab ändern...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Den Kartenmaßstab ändern und alle Objekte und Symbole skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Kartennotizen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Vorlagen verwalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Vorlagenfenster anzeigen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Vorlage öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Ganze Karte anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Objekte bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Punktobjekte setzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Pfade zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Kreise und Ellipsen zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Text schreiben</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Symbol wechseln</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translatorcomment>Consider two separate actions or change text according to context</translatorcomment>
         <translation>Füllen / Rand erzeugen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Strichelung umkehren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Pfade verbinden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Objekt aufschneiden</translation>
     </message>
@@ -3244,67 +3258,67 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">Objekt(e) rotieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Längen und Flächen messen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Von Fläche wegschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Löcher der Flächen zusammenführen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Einstellungen zum Zeichnen auf Vorlagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Touch-Cursor aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>GPS-Anzeige aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>GPS-Entfernungsringe aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Punktobjekt an GPS-Position setzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Temporäre Markierung an GPS Position setzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Temporären Pfad an GPS-Position beginnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Temporäre Markierungen löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Kompass-Anzeige aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Karte nach Norden ausrichten</translation>
     </message>
@@ -3313,190 +3327,190 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">Vorlagen-Sichtbarkeit umschalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Kartenteil hinzufügen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Aktives Teil umbenennen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Aktives Teil entfernen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Alle Teile zusammenfügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Sy&amp;mbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>K&amp;arte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Vorlagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translatorcomment>To be checked</translatorcomment>
         <translation>Auf Vorlage zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Karte wird momentan bearbeitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Die Karte wird momentan bearbeitet. Bitte schließen sie den Bearbeitungsschritt ab, bevor Sie speichern.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Karte gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Gitter anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Gitter konfigurieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Flächen schraffieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Mittellinienansicht</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Alle Vorlagen verstecken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Symbolsatz ersetzen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferenzierung...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Karte drehen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Die komplette Karte drehen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Vorlage wieder öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Anmerkungseditor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Anmerkungseditor anzeigen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Rechtecke zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Freihändig zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Begrenzte Flächen ausfüllen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Loch herausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Rundes Loch herausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Rechteckiges Loch herausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Muster drehen</translation>
     </message>
@@ -3505,222 +3519,222 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">Objekte skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Flächen verschmelzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Schnittfläche berechnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>XOr-Operation für Flächen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Ausschnitt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Wegschneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Punkte entlang eines Pfads verteilen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Kartenkoordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Projizierte Koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Länge/Breite (dezimal)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Länge/Breite (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Koordinaten anzeigen als...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Loch schneiden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>NN</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Nichts auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Auswahl umkehren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Symbolsatz-ID...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Symbolsatz-ID bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>CRT-Datei laden...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Neue Symbole per Querverweis-Tabelle zuweisen</translation>
     </message>
@@ -3733,83 +3747,83 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">Selektion nach Anmerkungen zeigen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translatorcomment>... in die Zwischenablage</translatorcomment>
         <translation>Position kopieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translatorcomment>\todo Update English version</translatorcomment>
         <translation>Kopiert die Koordinaten der Position in die Zwischenablage.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Kartenteile</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Vorlage auswählen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Fortgeschrittene Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Symbol auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Obere Leiste verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Obere Leiste einblenden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Drucken/Exportieren ist in dieser Programmversion nicht verfügbar!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Keine Rückgängig-Schritte verfügbar.</translation>
     </message>
@@ -3819,8 +3833,8 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">%1 Objekt(e) ausgeschnitten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Es ist ein interner Fehler aufgetreten. Tut uns leid!</translation>
     </message>
@@ -3829,7 +3843,7 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">%1 Objekt(e) kopiert</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>In der Zwischenablage befinden sich keine einfügbaren Objekte!</translation>
     </message>
@@ -3838,68 +3852,68 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">%1 Objekt(e) eingefügt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Benutzerdefinierter Zoomfactor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Zoomfaktor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Farben</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Symbolsatz-ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Symbolsatz-ID bearbeiten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Alle Symbole skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Skalieren auf Prozentwert :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Kartennotizen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translatorcomment>FIXME: Ersetzen durch ButtonBox.</translatorcomment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Vorlagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Anmerkungseditor</translation>
     </message>
@@ -3908,7 +3922,7 @@ Daten trotzdem importieren?</translation>
         <translation type="vanished">Selektion nach Anmerkungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3918,7 +3932,7 @@ Symbol
 gewählt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3928,43 +3942,43 @@ Symbole
 gewählt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Punktobjekte auf der Karte platzieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Wählen Sie ein Punktsymbol, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translatorcomment>More information</translatorcomment>
         <translation>Eckige oder gebogene Linien durch Klicken oder Ziehen zeichnen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translatorcomment>Distinction between line and combined symbol probably not relevant here.</translatorcomment>
         <translation>Wählen Sie ein Linien oder Flächensymbol, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Kreise und Ellipsen zeichnen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Pfade freihändig zeichnen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Begrenzte Flächen ausfüllen.</translation>
     </message>
@@ -3973,109 +3987,109 @@ gewählt</translation>
         <translation type="vanished">Ausgewählte Objekte löschen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Die Richtung von Flächenmustern oder von Punktobjekten setzen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Wählen Sie ein Flächenobjekt mit drehbarem Füllmuster oder ein drehbares Punktobjekt, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Resultierendes Symbol: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Wenigstens zwei Flächen- oder Linienobjekte auswählen, um dieses Werkzeug zu aktivieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Überlappende Objekte zusammenfügen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Alle Teile entfernen, die nicht das erste ausgewählte Objekt überlappen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Alle überlappten Teile des ersten ausgewählten Objekts entfernen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Alle Teile entfernen, die das erste ausgewählte Objekt überlappen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Löcher in den Flächen zusammenfügen, oder Löcher mit dem Objektrand zusammenführen (Ausschneiden).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Ein Flächenobjekt mit Löchern auswählen, um dieses Werkzeug zu aktivieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Einen Ausschnitt einiger Objekte oder der ganzen Karte erstellen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Wählen Sie einen geschlossenen Pfad as Schnittform, um dieses Tool zu aktivieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Einige Objekte oder alles in einem begrenzten Bereich wegschneiden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Erstellt gleichmäßig verteilte Punktobjekte entlang eines bestehenden Pfadobjekts</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Wenigstens ein Pfadobjekt sowie ein Punktsymbol auswählen, um dieses Tool zu aktivieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Zusammenfügen der Löcher fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Temporäre Markierungen löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Wollen Sie wirklich alle temporären Markierungen löschen? Das kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Dieses Teil zusammenfügen mit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Ausgewählte Objekte verschieben zu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Name des Kartenteils eingeben:</translation>
     </message>
@@ -4084,88 +4098,88 @@ gewählt</translation>
         <translation type="vanished">Wollen Sie Kartenteil &quot;%1&quot; mit allen seinen Objekten entfernen? Das kann nicht rückgangig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Kartenteile zusammenfügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Wollen Sie alle Objekte von Kartenteil &quot;%1&quot; nach &quot;%2&quot; verschieben und &quot;%1&quot; entfernen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Wollen Sie alle Objekte nach Kartenteil &quot;%1&quot; verschieben und alle anderen Teile entfernen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Die ausgewählte Kartendatei konnte nicht geladen und importiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Rechtecke zeichnen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>B&amp;ild</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Rückgängig/Wiederholen - Schritte löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Alle Rückgängig/Wiederholen - Schritte löschen, um die Dateigröße der Karte zu reduzieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Verschieben</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Überdruck-Simulation</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Linien bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>In Kurven umwandeln</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Pfad vereinfachen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exportieren als...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Text auf der Karte platzieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Wählen Sie ein Textsymbol, um dieses Werkzeug verwenden zu können.</translation>
     </message>
@@ -4174,26 +4188,26 @@ gewählt</translation>
         <translation type="vanished">Die ausgewählten Objekte duplizieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Wählen Sie wenigstens ein Objekt, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Die Ausrichtung der Symbole an Linienobjekten ändern.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Wählen Sie wenigstens ein Linienobjekt, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Pfade an benachbarten Endpunkten verbinden.</translation>
     </message>
@@ -4202,17 +4216,17 @@ gewählt</translation>
         <translation type="vanished">Gewählte Objekte in kleinere Teile zerschneiden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Wählen Sie wenigstens ein Linien- oder Flächenobjekt, um dieses Werkzeug verwenden zu können.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Ein Loch in das ausgewählte Flächenobjekt schneiden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Wählen Sie ein einzelnes Flächensymbol, um dieses Werkzeug verwenden zu können.</translation>
     </message>
@@ -4225,18 +4239,18 @@ gewählt</translation>
         <translation type="vanished">Die ausgewählten Objekte skalieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Pfade, die aus geraden Segmenten bestehen, in glatte Bezierkurven umwandeln.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Wählen Sie ein Pfadobjekt aus, um dieses Tool zu aktivieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Die Punktanzahl in Pfadobjekten reduzieren, während ihre Form möglichst beibehalten wird.</translation>
     </message>
@@ -4245,8 +4259,8 @@ gewählt</translation>
         <translation type="vanished">Den ausgewählten Objekten das ausgewählte Symbol zuweisen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Wählen Sie wenigstens ein Objekt sowie ein geeignetes alternatives Symbol, dieses Werkzeug verwenden zu können.</translation>
     </message>
@@ -4259,7 +4273,7 @@ gewählt</translation>
         <translation type="vanished">%1 Objekt(e) dupliziert</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Objektauswahl</translation>
     </message>
@@ -4268,83 +4282,83 @@ gewählt</translation>
         <translation type="vanished">Es wurden keine Objekte ausgewählt, weil es keine Objekte mit dem ausgewählten Symbol gibt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Messen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Verschmelzen fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Berechnung der Schnittfläche fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Subtraktion fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOr-Operation fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Wollen Sie Kartenteil &quot;%1&quot; und alle seine Objekte entfernen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Zum Kartenteil &apos;%1&apos; gewechselt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Auf einer Vorlage freihändig Zeichnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translatorcomment>First part duplicated. Check punctuation.</translatorcomment>
         <translation>Auf einer Vorlage freihändig Zeichnen. Erstellen oder laden Sie eine Vorlage auf die gezeichnet werden kann, um dieses Werkzeug zu verwenden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>%1, GPX, OSM oder DFX - Datei importieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importierbare Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Alle Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Die ausgewählte Datei konnte nicht importiert werden: unbekanntes Dateiformat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Objekte rotieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Objekte skalieren</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4353,7 +4367,7 @@ gewählt</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Ein Objekt kopiert</numerusform>
@@ -4361,7 +4375,7 @@ gewählt</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Ein Objekt eingefügt</numerusform>
@@ -4369,42 +4383,42 @@ gewählt</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Löscht die ausgewählten Objekte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Die ausgewählten Objekte duplizieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Die ausgewählten Objekten drehen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Die ausgewählten Objekte skalieren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Gewählte Objekte in kleinere Teile zerschneiden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Den ausgewählten Objekten das ausgewählte Symbol zuweisen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Ausgewählte Linienobjekte ausfüllen oder eine Randlinie um ausgewählte Flächen erstellen.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Ein Objekt dupliziert</numerusform>
@@ -4412,178 +4426,178 @@ gewählt</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Es wurden keine Objekte ausgewählt, weil es keine Objekte mit dem ausgewählten Symbol gibt.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Abbrechen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Mehr: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Mehr: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Mehr: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Suchen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>&amp;Nächstes suchen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Objekte suchen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Nächstes suchen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>&amp;Alle suchen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Abfrageeditor</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Verarbeite Separationen von Seite %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Verarbeite Seite %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Abgeschlossen</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Karte -</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Textquelle:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Karte (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>undefinierte Sprache</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Übersetzung (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Vor dem Bearbeiten wird der gespeicherte Text mit der aktuellen Übersetzung ersetzt. Möchten Sie fortfahren?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Nach dem Verändern des gespeicherten Texts wird möglicherweise die Übersetzung nicht mehr gefunden. Möchten Sie fortfahren?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4597,7 +4611,7 @@ Wählen Sie dazu im Menü
 Symbole &gt; Farben.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4612,7 +4626,7 @@ in die Symbolleiste und wählen Sie
 &quot;Neues Symbol&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4625,7 +4639,7 @@ Um eine Vorlage zu laden, wählen Sie
 Vorlagen -&gt; Vorlage öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Hinweis: Mit der mittleren Taste kann die Karte gezogen werden.
@@ -4633,131 +4647,131 @@ Zoomen ist mit dem Mausrad möglich.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Länge des Umrisses:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Fläche:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Kein Objekt ausgewählt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 Objekte ausgewählt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Das ausgewählte Objekt hat keine Ausdehnung.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Dieses Objekt ist zu klein.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Die Mindestgröße ist %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Hinweis: die Länge des Umrisses und die Fläche sind nur korrekt, wenn es keine Selbst-Überschneidungen gibt und Löcher als solche verwendet werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Diese Linie ist zu kurz.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Die Mindestlänge ist %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NativeFileImport</name>
+    <name>OpenOrienteering::NativeFileImport</name>
     <message>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation type="vanished">Diese Datei nutzt ein veraltetes Format. Die Unterstützung für dieses Format wird bald aus der Software entfernt. Um die Datei auch in Zukunft öffnen zu können, speichern Sie es bitte erneut.</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Neue Karte erstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Maßstab und Symbolsatz der neuen Karte wählen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translatorcomment>Check spaces.</translatorcomment>
         <translation>Maßstab:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Symbolsätze:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Nur zum Maßstab passende Symbolsätze zeigen</translation>
     </message>
@@ -4766,140 +4780,140 @@ Zoomen ist mit dem Mausrad möglich.</translation>
         <translation type="vanished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Leerer Symbolsatz</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Symbolsatz von Datei laden...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Alle Symbolsatz-Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Alle Dateien</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Die Karte enthält mehr als 256 Farben, was von ocd-Version 8 nicht unterstützt wird.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad-Fehler %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Passfarbe wird als reguläre Farbe exportiert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Kann den Versatz eines Füllmusters für ein Flächenobjekt nicht exportieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Kann Vorlage nicht exportieren: der Dateityp von &quot;%1&quot; wird noch nicht unterstützt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Die Koordinaten wurden angepasst, um in die OCAD-8-Zeichenfläche zu passen (-2 m…2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Einige Koordinaten bleiben außerhalb der OCAD-8-Zeichenfläche. Sie könnten in OCAD nicht erreichbar sein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Im Liniensymbol &quot;%1&quot; kann die Kombination der Linienenden/ecken nicht repräsentiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Im Liniensymbol &quot;%1&quot; wird die Gruppierung der Strichelungen verworfen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Im Liniensymbol &quot;%1&quot; wird die Anzahl der Striche in einer Gruppe auf 2 reduziert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Im Liniensymbol &quot;%1&quot; können die Ränder nicht korrekt exportiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Im Flächensymbol &quot;%1&quot; wird ein Füllmuster verworfen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Im Flächensymbol &quot;%1&quot; wird ein Punktmuster mit gegeneinander versetzten Reihen angenommen. Dies könnte stimmen, aber auch falsch sein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Im Textsymbol &quot;%1&quot; ist der Zeichenabstand geändert. Dies wird von diesem Programm und OCAD verschieden interpretiert</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Im Textsymbol &quot;%1&quot; wird das Unterstreichen verworfen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Im Textsymbol &quot;%1&quot; wird das Kerning verworfen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Zeichenkette verkürzt (Abbruchstelle mit drei &apos;|&apos; markiert): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Kann Puffer nicht allokieren.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad-Fehler %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD-Dateien der Version %1 werden nicht unterstützt!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>Eine Farbseparation wurde ignoriert, Grund: Import deaktiviert.</numerusform>
@@ -4907,334 +4921,334 @@ Zoomen ist mit dem Mausrad möglich.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Konnte Echtfarbendefinitionen nicht laden, Fehler: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Farbe &quot;Registration black&quot; (Passfarbe) wurde als spezielle Farbe importiert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Kann Symbol &quot;%3&quot; (%1.%2) nicht importieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD-Import-Ebene</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Im gestrichelten Liniensymbol %1 sind die Längen für die spitzen Enden am Anfang und Ende verschieden (%2 and %3). Verwende %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Die Länge des Endstücks des gestrichelten Liniensymbols %1 kann nicht korrekt importiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Die Länge der Endunterbrechung des gestrichelten Liniensymbols %1 kann nicht korrekt importiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Im gestrichelten Liniensymbol %1 sind die Haupt- und Endlänge verschieden (%2 and %3). Verwende %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Im gestrichelten Liniensymbol %1 sind die Unterbrüche D und E verschieden (%2 and %3). Verwende %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Liniensymbol %1: Strichelungssymbol am Linienanfang und -ende werden unterdrückt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Ignoriere Ausrichtung bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Ignoriere Höhe (%2) bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Vom Original abweichende Zeichenabstände bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Ignoriere Wordabstand (%2%) bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Ignoriere Enrückung (%2/%3) bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Ignoriere Textrahmen (Modus %2) bei Textsymbol %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Kann Objekt nicht laden</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Kann Rechtecksobjekt nicht importieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Textsymbol nicht importiert: Konnte Pfad nicht ermitteln (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Kann Vorlage nicht importieren: Hintegrund &quot;%1&quot; scheint kein Rasterbild zu sein</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Versuch, ein Textobjekt mit unbekanntem Koordinatenformat zu importieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Farb-ID nicht gefunden: %1, ignoriere diese Farbe</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>ist</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>ist nicht</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>enthält</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Suche</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>und</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>oder</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>ungültig</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Bei Liniensymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Bei Textsymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Das Koordinatenreferenzsystem &apos;%1&apos; konnte nicht geladen werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Echtfarbeninformation verworfen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Kann Symbol %1.%2 &quot;%3&quot; nicht importieren: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Nicht unterstützter Typ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Kann Vorlage nicht importieren: &quot;%1&quot; ist kein unterstützer Vorlagentyp.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Nicht unterstützter Linienstil &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Unterschiedliche Längen für die spitzen Enden am Anfang (%1 mm) und Ende (%2 mm) sind nicht unterstützt. Benutze %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Das Strichelungsmuster konnte nicht korrekt importiert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Die Länge des Endstücks des Strichelungsmusters (%1 mm) kann nicht korrekt importiert werden. Benutze %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Die Länge des Endunterbrechung des Strichelungsmusters (%1 mm) kann nicht korrekt importiert werden. Benutze %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Rahmenlinienstil &apos;%1&apos; ist nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Ignoriere zusätzliches Punktsymbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Strichelungssymbol am Linienanfang und -ende wird unterdrückt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Diese Symbol kann nicht wieder als ordentliches OCD-Symbol gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Bündige Ausrichtung wird nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Vertikale Ausrichtung &apos;%1&apos; wird nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ignoriere benutzerdefinierte Schriftstärke (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Benutzerdefinierter Zeichenabstand kann fehlerhaft sein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ignoriere benutzerdefinierten Wortabstand (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ignoriere benutzerdefinierte Einrückung (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ignoriere Textrahmen (Art %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Linientextsymbole werden noch nicht unterstützt. Symbol wird als verborgen markiert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Kodierung &apos;%1&apos; ist nicht verfügbar. Prüfen Sie die Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>Bei Flächensymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Kann Objekt nicht laden</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Kann Rechtecksobjekt nicht importieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Textsymbol nicht importiert: Konnte Pfad nicht ermitteln (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Versuch, ein Textobjekt mit unbekanntem Koordinatenformat zu importieren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Ungültige Daten.</translation>
     </message>
@@ -5243,59 +5257,59 @@ Zoomen ist mit dem Mausrad möglich.</translation>
         <translation type="vanished">Ungetestete Importfunktion für Dateiformat OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD-Dateien der Version %1 werden nicht unterstützt!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Farb-ID nicht gefunden: %1, ignoriere diese Farbe</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Kann Bezugssystem &quot;%1&quot; für GDAL nicht einrichten: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Violett</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Fläche</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Konnte Ebene &apos;%1&apos; nicht laden.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Konnte ein Objekt nicht laden, Grund: %1</numerusform>
@@ -5303,461 +5317,448 @@ Zoomen ist mit dem Mausrad möglich.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Leere Geometrie.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Koordinatentransformation kann nicht bestimmt werden: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Koordinatentransformation fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Unbekannter oder nicht unterstützter Geometrietyp.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Nicht genug Koordinaten.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Dieser räumliche Bezug kann nicht verwendet werden:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>Die Geodaten haben keinen geeigneten räumlichen Bezug.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Orientierungslaufkarte</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Programm zum Zeichnen von Orientierungslaufkarten</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Vorlage auswählen, auf die gezeichnet wird</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Zeichnen</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klick und Ziehen&lt;/b&gt;: Zeichnen. &lt;b&gt;Rechtsklick und Ziehen&lt;/b&gt;: Löschen. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Farbauswahl</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Karte verschieben. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Koordinate setzen. &lt;b&gt;%1+Klick&lt;/b&gt;: Gewählte Koordinate ändern. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Immer nach Norden ausrichten (nicht drehbar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elemente</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Fläche</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Alle Elemente zentrieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Aktuelles Element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Durchmesser &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Innere Farbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Randbreite &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Randfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Linienbreite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Linienfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Linienende:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>flach</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>quadratisch</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Linienverbindung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>spitz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>flach</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Geschlossene Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Flächenfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Kurvenanfang</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Zentriert ausrichten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Innerer Punkt]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Punktsymbol</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Bei der Verarbeitung ist ein Fehler aufgetreten.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Karte, Druckbereich oder Bereichsränder verschieben. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Druckbereich verschieben. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Karte verschieben. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Rand des Druckbereichs verschieben. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Ränder des Druckbereichs verschieben. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Vorlagen ausgeben</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Gitter anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Seitenausrichtung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Drucker:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Hochformat</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Querformat</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Seitenformat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopien:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Oben:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektor-
 grafik</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Raster-
 grafik</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Farbsepa-
 rationen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Vorschau...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Einzelne Seite</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Benutzerdefinierter Bereich</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Kartenfläche:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Druckbereich zentrieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Überlappung zwischen Seiten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
@@ -5770,158 +5771,158 @@ rationen</translation>
         <translation type="vanished">Farbseparationen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Auflösung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>In anderem Maßstab drucken:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Vorlagen können anders erscheinen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Überdruck-Simulation</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exportieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF-Export</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Bildexport</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Als PDF speichern</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Unter Android nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Druckvorschauerzeugung</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Eine spezielle Ansicht ist aktiviert. Sind Sie sicher, dass Sie die Karte so drucken / exportieren wollen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Karte exportieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translatorcomment>Check original.</translatorcomment>
         <translation>Bild konnte nicht gespeichert werden. Pfad nicht vorhanden oder Berechtigungen unzureichend.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Erfolgreich nach %1 exportiert</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Druckfortschritt</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Das Bild konnte nicht erstellt werden. Nicht genügend Arbeitsspeicher.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Abgebrochen.</translation>
@@ -5931,216 +5932,216 @@ rationen</translation>
         <translation type="vanished">Drucken</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Der Druckauftrag konnte nicht abgebrochen werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Druckauftrag erfolgreich erzeugt</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Der Kartenbereich ist leer. Ausgabe abgebrochen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Geräteabhängiges CMYK (experimentell)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Farbmodus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Die Vorschau konnte nicht erstellt werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Fehler beim Vorbereiten des PDF-Exports.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Der PDF-Export konnte nicht abgeschlossen werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Fehler beim Vorbereiten des Druckens.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Beim Drucken ist ein Fehler aufgetreten.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Koordinatenbezugssystem:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Vorlage wieder öffnen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Ziehen Sie Einträge aus der linken Liste an die gewünschte Stelle in der rechten Liste, um sie wieder zu laden.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Geschlossene Vorlagen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Liste leeren</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktive Vorlagen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Karte -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Symbolsatz ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Legen Sie fest, wie die Symbole ersetzt werden sollen, und welche.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Alle neuen Symbol importieren, auch wenn sie nicht als Ersatz benutzt werden</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Ursprüngliche Symbole löschen, die nach der Ersetzung ungenutzt sind</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Farben löschen, die nach der Ersetzung ungenutzt sind</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Symbolzuordnung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Verborgen-/Geschützt-Status des alten Symbolsatz erhalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Ersatzsymbole über Symbolnummer zuordnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Symbolsatz-ID bearbeiten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Ersatz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Nach Symbolname zuordnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Neue Symbole zuweisen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Muster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Ersetzungen löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>CRT-Datei öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>CRT-Datei speichern...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Symbol-Zuordnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT-Datei</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Es gibt mehrere Ersetzungen für das Symbol %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6151,7 +6152,7 @@ rationen</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6162,281 +6163,281 @@ rationen</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Die Querverweis-Tabelle wurde geändert.
 Sollen die Änderungen gesichert werden?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Keines -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Kartendatei wählen, aus der die Symbole geladen werden sollen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Kann Kartendatei nicht laden; Abbruch.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Der gewählte Symbolsatz hat einen Maßstab von 1:%1, der Kartenmaßstab ist jedoch 1:%2. Wollen Sie wirklich diesen Symbolsatz wählen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>CRT-Datei konnte nicht geladen werden. Abbruch.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Karte drehen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Winkel (gegen Uhrzeigersinn):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Drehungsparameter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Drehen um:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Ursprung des Karten-Koordinatensystems</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Referenzpunkt der Georeferenzierung</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Anderer Punkt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Referenzpunkt für Georeferenzierung anpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Deklination in Georeferenzierung anpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Nicht-georeferenzierte Vorlagen drehen</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Winkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Eingeschränkte Winkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Richtung von Flächenmustern oder Punktobjekten festlegen. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Drehung:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Eingeschränkte Winkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Rotationspunkt festlegen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Die ausgewählten Objekte drehen. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Kartenmaßstab ändern</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Skalierungs-Parameter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Neuer Maßstab:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Skalierungszentrum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Ursprung des Karten-Koordinatensystems</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Referenzpunkt der Georeferenzierung</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Anderer Punkt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Symbole skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Objektpositionen skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Referenzpunkt für Georeferenzierung anpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Nicht-georeferenzierte Vorlagen skalieren</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translatorcomment>TODO: Check proper % escaping.</translatorcomment>
         <translation>&lt;b&gt;Skalierung:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Skalierungszentrums festlegen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Die ausgewählten Objekte skalieren. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Koordinatenbezugssystem wählen</translation>
     </message>
@@ -6445,17 +6446,17 @@ Sollen die Änderungen gesichert werden?</translation>
         <translation type="vanished">Gleiches wie das der Karte</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Gleiches wie das der Karte</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Geographische Koordinaten (WGS 84)</translation>
     </message>
@@ -6476,176 +6477,176 @@ Sollen die Änderungen gesichert werden?</translation>
         <translation type="vanished">Koordinatenbezugssystem-Spezifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>gültig</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; befindet sich an einem normalen Speicherort.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; befindet sich im App-Speicher. Die Dateien werden gelöscht, wenn die App deinstalliert wird.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; ist nicht schreibbar. Änderungen können nicht gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; ist kein gültiger Speicherort.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- kein -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Keines -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nummer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Beschreibung:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Hilfssymbol (in fertiger Karte nicht sichtbar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Um die Beschreibung eines Symbols anzuzeigen, F1 drücken während der Tooltip sichtbar ist</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Neues Symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Fläche</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Zusammengesetzt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skalieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
@@ -6658,7 +6659,7 @@ Sollen die Änderungen gesichert werden?</translation>
         <translation type="vanished">Ausgewählte Objekte ausfüllen / Rand erzeugen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Symbole auswählen</translation>
     </message>
@@ -6667,203 +6668,203 @@ Sollen die Änderungen gesichert werden?</translation>
         <translation type="vanished">Symbole skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Es ist ein interner Fehler aufgetreten!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>In der Zwischenablage befinden sich keine einfügbaren Objekte!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Alle Objekte mit diesem Symbol auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Alle Objekte mit diesem Symbol zur Auswahl hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Alle Objekte mit diesem Symbol von der Auswahl entfernen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Alle Objekte mit diesem Symbol verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Objekte mit diesem Symbol schützen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Alle Objekte mit den ausgewählten Symbolen zur Auswahl hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Alle Objekte mit den ausgewählten Symbolen von der Auswahl entfernen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Objekte mit den ausgewählten Symbolen verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Objekte mit den ausgewählten Symbolen schützen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Alle auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Ungenutzte auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Auswahl umkehren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Symbole sortieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Nach Nummer sortieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Nach vorwiegender Farbe sortieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Nach Priorität der vorwiegenden Farbe sortieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skalieren auf Prozentwert:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Die Karte enthält Objekte mit dem Symbol &quot;%1&quot;. Beim Löschen des Symbols werden diese Objekte aus der Karte und dem Protokoll entfernt. Wollen Sie das wirklich?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Alle Objekte mit den ausgewählten Symbolen auswählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Drag and drop aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Symbol der ausgewählten Objekte austauschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Ausgewählte Objekte ausfüllen / Rand erzeugen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Symbole skalieren</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Symboleinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Vorlage:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Vorlage:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translatorcomment>Standardize &quot;(none)&quot; vs &quot;- none -&quot;</translatorcomment>
         <translation>(keine)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Vorlage zentrieren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>Umriss im Ursprung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Schwerpunkt im Ursprung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Hintergrundfarbe wählen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6875,58 +6876,58 @@ verwahrlosten Taxi quer durch Bayern
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- unbenannt -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Keine Beschreibung!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Verknüpfung</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Schlüssel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Vergleich</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Zeile hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Zeile löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Nach oben schieben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Nach unten schieben</translation>
     </message>
@@ -6939,7 +6940,7 @@ verwahrlosten Taxi quer durch Bayern
         <translation type="vanished">Hilfe</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>Ein Objekt ausgewählt</numerusform>
@@ -6947,70 +6948,70 @@ verwahrlosten Taxi quer durch Bayern
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Ungültige Abfrage</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Schlüssel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Schlüssel vorhanden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Der Schlüssel &quot;%1&quot; existiert bereits und darf nicht zweimal verwendet werden.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Vorlagendatei wiederfinden</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Datei existiert nicht.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Passt das Dateiformat zu dieser Vorlagenart?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Nicht genügend freier Arbeitsspeicher.</translation>
     </message>
@@ -7020,134 +7021,134 @@ verwahrlosten Taxi quer durch Bayern
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Vorlagen einrichten</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Anpassung konnte nicht berechnet werden!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Position des Passpunkts auf der Vorlage festlegen. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Position des Passpunkts auf der Karte festlegen. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klick&lt;/b&gt;: Passpunkt löschen. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt;: Passpunkt verschieben. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Passpunkte:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Verschieben</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Vorlagen-X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Vorlagen-Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Karten-X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Karten-Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Passpunkte anwenden</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Anwenden &amp;&amp; alle löschen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Alle löschen</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Nicht genügend freier Arbeitsspeicher (Bildgröße: %1x%2 Pixel)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7155,120 +7156,120 @@ If you do not intend to draw on this template however, that is no problem.</sour
 Speichern im GIF-Format wird nicht unterstützt. Zeichnungen auf solchen Vorlagen können nicht gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Wählen Sie das Koordinatenbezugssystem der Koordinaten in der Weltdatei</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>%1 öffnen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Bildgröße:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Geben Sie an, wie das Bild positioniert oder skaliert werden soll:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Weltdatei</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nicht georeferenziert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferenziert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Meter pro Bildpunkt:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Gescannt mit</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Vorlagenmaßstab: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Deckkraft</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Dateiname</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Zeichnung</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Öffnen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georeferenziert: %1</translation>
     </message>
@@ -7277,79 +7278,79 @@ Speichern im GIF-Format wird nicht unterstützt. Zeichnungen auf solchen Vorlage
         <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Nach oben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Nach unten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Frei verschieben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Ausrichten...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translatorcomment>FIXME: Update original string</translatorcomment>
         <translation>Karte, Bild-, DXF-, GPX- oder OSM-Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Positionierung...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Vorlage hinzufügen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importieren und entfernen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Vorlagendateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Alle Dateien</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7358,227 +7359,227 @@ Speichern im GIF-Format wird nicht unterstützt. Zeichnungen auf solchen Vorlage
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Dateiformat nicht erkannt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Konnte Vorlage nicht laden. Existiert die Datei und ist sie in Ordnung?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Geben Sie eine ganze Zahl ein, um eine Gruppe festzulegen, oder lassen Sie das Feld frei, um die Gruppierung dieser Vorlage aufzuheben!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Nicht skalieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Skalieren nach Kartenmaßstabsverhältnis (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Skalieren nach aktueller Vorlagenausrichtung (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Vorlagenimport</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Wie sollen die Symbole der importierten Vorlage skaliert werden?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Die Vorlage wird in der Überdruck-Simulation nicht sichtbar sein. In normale Ansicht wechseln?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Karte -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Ziehen&lt;/b&gt; zum Verschieben der aktuellen Vorlage</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Positionierung</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Maßstab:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Maßstab:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Skalierung und Positionierung des Tracks</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinatensystem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Real</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Karte</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Eine Koordinateneinheit entspricht:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Track an gegebenen Koordinaten positionieren</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Track in der Mitte der Kartenansicht positionieren</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Diese Vorlage muss mit GDAL/OGR geladen werden.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Wählen Sie das Koordinatenbezugssystem der Koordinaten des Tracks</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Pfad öffnen ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Pfad georeferenziert oder nicht-georeferenziert öffnen?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Positioniert den Pfad mithilfe der Georeferenzierung der Karte.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translatorcomment>Add explanation for &quot;these&quot;.</translatorcomment>
         <translation>Diese ist nicht nicht konfiguriert, daher werden die Einstellungen dazu als nächster Schritt angezeigt.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferenziert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Nicht georeferenziert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projiziert den Pfad mithilfe einer orthographischen Projektion mit Zentrum am Mittelpunkt der Pfadkoordinaten. Ermöglicht die Anpassung der Transformation, und die Georeferenzierung der Karte mithilfe der angepassten Pfadposition zu setzen.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Leere Aufzeichnung, nichts zum Importieren vorhanden!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Frage</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Sollen Wegpunkte als Punkte eines Linienobjekts importiert werden?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Probleme beim Import</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>Ein Pfadobjekt konnte nicht importiert werden (Grund: fehlende Koordinaten).</numerusform>
@@ -7586,12 +7587,12 @@ Speichern im GIF-Format wird nicht unterstützt. Zeichnungen auf solchen Vorlage
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Fehler beim Lesen</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7600,39 +7601,39 @@ Speichern im GIF-Format wird nicht unterstützt. Zeichnungen auf solchen Vorlage
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Keine OSM-Datei.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Die OSM-Datei hat Version %1.
 Die kleinste unterstütze Version ist %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Die OSM-Datei hat Version %1.
 Die höchste unterstütze Version ist %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Probleme</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 Knoten konnten nicht korrekt verarbeitet werden.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Externer Verweis: %1</translation>
@@ -7643,80 +7644,80 @@ Die höchste unterstütze Version ist %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Ausrichtung</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Zentriert</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Oben</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Grundlinie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Unten</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Texteinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Schriftart:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Schriftgröße:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
@@ -7725,272 +7726,272 @@ Die höchste unterstütze Version ist %2.</translation>
         <translation type="vanished">Größe bestimmen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Schriftfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>fett</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>kursiv</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translatorcomment>or &quot;underline&quot;/&quot;unterstreichen&quot;</translatorcomment>
         <translation>unterstrichen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Schriftstil:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Zeilenabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Absatzabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Zeichenabstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kerning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Piktogrammtext:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Freistellung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Einstellungen für OCD-Kompatibilität</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Linienfreistellung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Schattenfreistellung</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Links/Rechts-Versatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Oben/Unten-Versatz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCD-Kompatibilität</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>aktiviert</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Linienbreite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Linienfarbe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Position:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linie unter dem Absatz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Abstand zur Grundlinie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Benutzerdefinierte Tabulatorpositionen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Tabulator hinzufügen</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Berechnen</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translatorcomment>Original diskutabel</translatorcomment>
         <translation>Rückgängig nicht möglich, weil der letze gespeicherte Schritt ungültig geworden ist (z.B. nachdem das Symbol des Objekts gelöscht wurde).</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Dieser Rückgängig-Schritt führt zu einem Zustand vor dem Zeitpunkt des Ladens der Datei. Sind Sie sicher?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Wiederherstellen nicht möglich, weil der erste Wiederherstellungsschritt ungültig geworden ist (z.B. nach dem Löschen des notwendigen Symbols).</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Die Hilfedateien konnten nicht gefunden werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Das Handbuchprogramm (&quot;Qt Assistant&quot;) konnte nicht gefunden werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Das Handbuchprogramm (&quot;Qt Assistant&quot;) konnte nicht gestartet werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Mehr...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Ältere Versionen von Mapper unterstützen nicht mehrere Kartenteile. Um die Datei im Kompatibilitätsmodus zu speichern, müssen Sie erst alle Kartenteile zusammenfügen.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Element nicht unterstützt: %1 (Zeile %2 Spalte %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>unbekannt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Teile der Datei können von dieser Version von Mapper nicht gelesen werden. Benötigte Mindestversion: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Fehler in Zeile %1 Spalte %2: %3</translation>
     </message>
@@ -7999,49 +8000,49 @@ Die höchste unterstütze Version ist %2.</translation>
         <translation type="vanished">Die Kartennotizen konnten nicht gelesen werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Einige ungültige Zeichen mussten entfernt werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Nicht unterstützte oder ungültige Georeferenzierungsspezifikation &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Knockout-Attribut der Farbe &apos;%1&apos; konnte nicht gesetzt werden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>%1 Farben erwartet, %2 gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Schmuckfarbe %1 bei der Verarbeitung von %2 (%3) nicht gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>%1 Symbole erwartet, %2 gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>%1 Kartenteile erwartet, %2 gefunden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Einige Koordinaten waren außerhalb des druckbaren Bereichs. Der Karteninhalt wurde korrigiert.</translation>
     </message>

--- a/translations/OpenOrienteering_en.ts
+++ b/translations/OpenOrienteering_en.ts
@@ -2,10 +2,10 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en">
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -14,9 +14,9 @@
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Dropped one irregular object.</numerusform>
@@ -25,9 +25,9 @@
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -36,7 +36,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Copied one object</numerusform>
@@ -44,7 +44,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Pasted one object</numerusform>
@@ -52,7 +52,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Duplicated one object</numerusform>
@@ -61,9 +61,9 @@
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>One color separation was skipped, reason: Import disabled.</numerusform>
@@ -72,13 +72,13 @@
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Unable to load one object, reason: %1</numerusform>
@@ -87,9 +87,9 @@
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>One object selected</numerusform>
@@ -98,9 +98,9 @@
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>One path object could not be imported (reason: missing coordinates).</numerusform>

--- a/translations/OpenOrienteering_eo.ts
+++ b/translations/OpenOrienteering_eo.ts
@@ -2,5171 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="eo">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation>Pri %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation>&lt;a %1&gt;Ĉion pri permesiloj, kopirajtaj avizoj, kondiĉoj kaj malgarantioj.&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation>La OpenOrienteering programistoj laŭ alfabeta ordo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation>(iniciatoro de projekto)</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation>Libera programaro por desegni orientiĝajn mapojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation>Ĉi tiu verko estas libera programo: vi povas ĝin pludistribui kaj/aŭ modifi je la kondiĉoj de la &lt;a %1&gt;GNUa Ĝenerala Publika Permesilo (GPL), la versio&amp;nbsp;3&lt;/a&gt;, eldonita de Free Software Foundation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation>Ni distribuas ĉi tiun programon esperante ke ĝi estos utila, tamen SEN IA AJN GARANTIO; i.a. sen la implica garantio pri SURMERKATIGEBLO aŭ TAŬGECO POR IU KONKRETA CELO. &lt;a %1&gt;Pliajn detalojn&lt;/a&gt; vidu en la GNUa Ĝenerala Publika Permesilo (GPL), la versio&amp;nbsp;3.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation>Por kontribuoj, danke al:</translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation>Malfermi plej antaŭ nelonge uzita dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation>Montri helpilojn</translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation>Montri restantajn punktojn</translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation>Minimuma grandeco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation>Plenigo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation>Linia plenigo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation>Plenigo per modelo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation>Sola linio</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation>Paralelaj linioj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation>Linipaŝo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation>Sola vico</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation>Modela intervalo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation>Modela deŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation>Vica deŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation>Paralelaj vicoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation>Intervica distanco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation>Pleniga rotacio</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation>Angulo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation>alĝustigebla per objekto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation>Desegni elementojn, se la centro estas interne de la limo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation>Desegni elementojn, se iu ajn punkto estas interne de la limo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation>Desegni elementojn, se ĉiuj punktoj estas interne de la limo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation>Agordoj de areo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation>Plenigo per modelo %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation>Linia plenigo %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation>Neniu plenigo estas elektita</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation>Koloro de areo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation>Linia deŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation>Linikoloro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation>Linia larĝo:</translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation>Aŭtokonservita dosiero</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation>
-            <numerusform>%n bajto</numerusform>
-            <numerusform>%n bajtoj</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation>Dosiero estas konservita por la uzanto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation>Riparado de dosiero</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation>Dosiero %1 ne estis fermita ĝuste. Ĉi-momente ekzistas du versioj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation>Konservi la aktivan dosieron por forigi la konfliktantajn versiojn.</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation>Redakti koloron de mapo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation>Redakti</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation>Difini spot-koloron:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation>Mikso de spot-koloroj (ekranoj kaj surpreso):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation>Kalkuli el spot-koloroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation>Kalkuli el RVB-koloro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation>Propra procezkoloro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation>Cejana</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation>Magenta</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation>Flava</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation>Nigra</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation>Kalkuli el CMFN-koloro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation>Propra RGB-koloro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>Ruĝa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>Verda</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>Blua</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation>Labortablo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation>Profesia presado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation>Nomo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation>- nenomita -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation>Averto</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation>- nenio -</translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>Nomo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation>Opakeco</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation>Spot-koloro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation>K.o.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>Nova</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation>Forigi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation>Duobligi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation>Movi Supren</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation>Movi Malsupren</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation>Helpo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation>Duoble alklaki kolorvaloron por malfermi dialogon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation>Konfirmo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation>La mapo enhavas simbolojn kun tiu koloro. Ĝia forigo kondukas al forigo de la koloro el tiuj simboloj. Ĉu vi vere volas fari tion?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation>%1 (duoblaĵo)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation> (Duoblaĵo)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation>Duoble alklaki por difini koloron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation>Alklaki por elekti nomon kaj alklaki denove por redakti.</translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation>&amp;Nombro de partoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation>- Privata linia simbolo -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation>- Privata area simbolo -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation>Redakti privatan simbolon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation>Agordoj de kombinaĵo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation>Ŝanĝi el publika al privata simbolo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation>Preni la malnovan simbolon kiel ŝablono por la privata simbolo?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation>Simbolo %1:</translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation>Konfiguri reton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation>Montri reton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation>Kapti per krado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation>Elekti…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation>Ĉiu linioj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation>Horizontalaj linioj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation>Vertikalaj linioj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation>Alkadrigo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation>Ĝisrandigi kun magneta nordo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation>Ĝisrandigi kun krada nordo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation>Ĝisrandigi kun vera nordo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation>Kroma turno (maldekstrume):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation>Enpoziciigo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation>metroj sur tereno</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation>milimetroj sur la mapo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation>Horizontala interspaco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation>Vertikala interspaco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation>Horizontala deŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation>Vertikala deŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation>Unuo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation>Linikoloro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation>Vidigi:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation>Elekti kradlinikoloron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation>Origino ĉe: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation>&lt;b&gt;Klaki aŭ treni&lt;/b&gt;: Komenci desegni truon. </translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation>La dividolinio devas finiĝi ĉe limo de la areo!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation>Komenco kaj fino de la dividolinio estas sur diversaj partoj de la objekto!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation>Komenco kaj fino de la dividolinio estas sur sama pozicio!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt; sur linio: Dividi ĝin en du. &lt;b&gt;Treni&lt;/b&gt; laŭlonge linio: Forigi ĉi tiun linioparton. &lt;b&gt;Klaki aŭ treni&lt;/b&gt; ĉe limo de la areo: Komenci dividolinion. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Eltondi la tutan mapon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation>&lt;b&gt;%1+Klaki aŭ treni&lt;/b&gt;: Elekti objektojn por eltondi. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Eltondi la elektitajn objektojn. </translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation>Ne povis malfermi la dosieron.</translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation>La dosiero ne estas DXF dosiero.</translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation>Litero:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation>Alteco:</translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation>Distribui punktojn egalmezure laŭlonge de la vojo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation>Nombro da punktoj per vojo:</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation>Agordoj de turno</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation>Ĝisrandigi punktojn al direkto de linio</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation>Kroma turnangulo (maldekstrume):</translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation>El centro</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Startigi cirklon aŭ elipson. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni cirklon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation>Reteni %1 por komenci la desegnadon el la centro.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Fini la cirklon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni elipson. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni vojon. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation>&lt;b&gt;Uzi strekpunktojn.&lt;/b&gt; </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Kapti aŭ postglui al ekzistantaj objektoj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Elekti direkton el ekzistantaj objektoj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Azimuto kaj longo de segmento. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Kapti per ekzistantaj objektoj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Malfari lastan punkton. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation>Finiŝo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation>Fermi</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>Angulo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation>Informo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>Streko</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation>Malfari</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation>Ĉesigi</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation>&lt;b&gt;Longo:&lt;/b&gt; %1 m </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Komenci rektan linion. &lt;b&gt;Treni&lt;/b&gt;: Komenci kurbon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation>&lt;b&gt;%1+Treni&lt;/b&gt;: Daŭrigi ekzistantajn objektojn. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Desegni rektan linion. &lt;b&gt;Treni&lt;/b&gt;: Desegni kurbon. &lt;b&gt;Dekstre aŭ duoble alklaki&lt;/b&gt;: Fini la vojon. &lt;b&gt;%1&lt;/b&gt;: Fermi la vojon. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation>Tuŝi la mapon por fini mezumadon</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Fini starigon de la objekto. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>Angulo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation>Reagordi</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation>&lt;b&gt;Angulo:&lt;/b&gt; %1° </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Krei punkta objekto.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Krei objekton kaj agordi ĝian orientiĝon.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Reagordi rotacion.</translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation>Finiŝo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation>Linia kapto</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>Streko</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation>Malfari</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation>Ĉesigi</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation>&lt;b&gt;Klaki aŭ treni&lt;/b&gt;: Komenci desegni rektangulon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Kapti al antaŭaj linioj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Starigi angulan punkton. &lt;b&gt;Dekstre aŭ duoble alklaki&lt;/b&gt;: Fini la rektangulon. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fini la redaktadon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Rezigni redakton. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Krei tekstan objekton kun unuopa ankro. &lt;b&gt;Treni&lt;/b&gt;: Krei tekstujon. </translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation>Baskuligi kurbon</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Libera movo. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur segmento: Baskuligi inter rekta kaj malrekta. </translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>Kapti</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation>Punkto / Angulo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation>Baskuligi strekon</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fini la redaktadon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto: Forigi ĝin; sur vojo: Aldoni novan strekpunkton; kun &lt;b&gt;%2&lt;/b&gt;: Aldoni normalan punkton. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto: Forigi ĝin; sur vojo: Aldoni novan punkton; kun &lt;b&gt;%2&lt;/b&gt;: Aldoni strekpunkton. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto por ŝalti inter streka kaj normala punkto. </translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation>&lt;b&gt;Koordinata deŝovo:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distanco:&lt;/b&gt; %3 m </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Kapti al ekzistantaj objektoj. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Elekti unuopan objekton. &lt;b&gt;Treni&lt;/b&gt;: Elekti plurajn objektojn. &lt;b&gt;%1+Klaki&lt;/b&gt;: Baskuligi elektaĵon. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Forigi elektitajn objektojn. </translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation>Alta kvalita vidigo de mapo (glatigo)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation>Alta kvalita vidigo de teksto sur la mapo (glatigo), malrapida</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation>Klaka tolero:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation>Kapta distanco (%1):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation>Grandeco de la bildsimbolo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation>Ŝablonoj: konservi agordojn de fermitaj ŝablonoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation>Redaktilo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation>Reteni praformon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation>Reagordi eksterajn tenilojn de kurbo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation>Konservi eksterajn tenilojn de kurbo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation>Ortangulilo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation>Radiuso de helpa kruco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation>Redaktilo</translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation>Ne povis krei novan dosieron: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation>Formato (%1) ne subtenas eksporton</translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation>Averto</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation>La mapa areo estas granda. Uzo de la plenigilo povas esti tre malrapida. Ĉu vi volas uzi ĝin ĉiuokaze?</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation>La elektita areo ne estas limigita per linioj aŭ areoj, ne povas plenigi ĉi tiun areon.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation>Fiaskis krei la plenigan objekton.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation>GPS estas malvalidigita en la aparataj agordoj. Ĉu malfermi agordojn nun?</translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation>Jes</translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation>Ne</translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation>Importi kun GDAL/OGR:</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation>DXF</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation>GPX</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation>OSM</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation>Agordo</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation>Parametro</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation>Valoro</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation>GDAL/OGR</translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation>Aspekto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation>Lingvo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation>Ekrano</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation>Bilderoj en colo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation>Programa starto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation>Konservo de dosieroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation>Reteni kongruecon kun Mapper %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation>Konservi informon por aŭtomata riparado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation>Intervalo de konservado:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation>min</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation>Dosiera importo kaj eksporto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation>8-bita signaro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation>Pli…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation>Konservi malfaran/refaran historion</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation>Defaŭlto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation>Uzi la novan OCD-importilon ankaŭ por dosierversio 8</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation>Ĝenerala</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation>Rimarko</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation>La programo devas esti rekomencita por la lingva ŝanĝo efektiviĝos!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation>Malfermi tradukon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation>Tradukaj dosieroj (*.qm)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation>La elektita dosiero ne estas valida tradukdosiero.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation>%1 x %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation>Ĉefa ekrandistingivo en bilderoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation>Ĉefa ekrangrando en coloj (diagonalo):</translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation>UTM</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation>UTM koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation>UTM-zono (numero N/S)</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation>Gauss-Krueger, datumo: Potsdamo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation>Gauss-Krueger koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation>Numero de zono (1-119)</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation>per EPSG kodo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation>EPSG @code@ koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation>Lokaj koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation>EPSG kodo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation>Propra PROJ.4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation>Specifo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation>Specifo de mapa skalo estas nevalida aŭ mankas.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation>Nevalida krada skalfaktoro: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation>Nekonata CRS-specifa lingvo: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation>Nesubtenata specifo de geografia CRS: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation>Loka</translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation>Mapa georeferencado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation>Elserĉi...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation>Deklinacio:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation>Projekciaj koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation>Stato:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation>Geografiaj koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation>Montri referencan punkton en:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation>valida</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation>Reta serĉo por deklinacio</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation>Koordinatsistemo de mapo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation>- loka -</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation>Krada skalfaktoro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation>Referenca punkto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation>&amp;Elekti sur mapo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation>(Datumo: WGS84)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation>Mapa nordo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation>&amp;Koordinatsistemo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation>Mapaj koordinatoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation>Geografiaj koordinatoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation>Ŝanĝinte CRS, konservi:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation>Deklinacia ŝanĝo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation>La deklinacio estis ŝanĝita. Ĉu vi volas ankaŭ turni enhavon de la mapo?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation>Lokaj koordinatoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation>Ŝargo…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation>ŝlosita</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation>Ne povis analizi datumon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation>Deklinacia valoro ne trovita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation>Eraro dum la reta serĉo de deklinacio:
-%1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation>%1 °</translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Agordi referencan punkton. &lt;b&gt;Dekstre alklaki&lt;/b&gt;: Rezigni.</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation>Bonvenon en OpenOrienteering Mapper!</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation>Aktivecoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation>Krei novan mapon …</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation>Malfermi mapon …</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation>Agordoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation>Pri %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation>Helpo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation>Eliri</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation>Lastaj mapoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation>Malfermi plej antaŭ nelonge uzita dosieron startigante</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation>Vakigi liston</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation>Konsilo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation>Montri konsilojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation>Antaŭa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation>Sekva</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation>Ekzemploj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation>Pri Mapper</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation>Dosierlisto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation>Neniu dosiero trovita!&lt;br/&gt;&lt;br/&gt; Kopii mapodosierojn al supra dosierujo &apos;OOMapper&apos; sur la aparato aŭ memorkarto.</translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation>Eraro dum ŝarĝo de simbolo de tipo %1 ĉe linio %2 kolumno %3.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation>Simbola ID &apos;%1&apos; ne estas unika ĉe linio %2 kolumno %3.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation>Eraro dum ŝarĝo de simbolo de tipo %1 ĉe linio %2 kolumno %3: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation>Eraro dum ŝarĝo de objekto de tipo %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation>Eraro dum ŝarĝo de objekto de tipo %1 ĉe %2:%3: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation>Ne eblas trovi simbolon por objekto ĉe %1:%2.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation>Punktobjekto kun nedefinita aŭ malvera simbolo ĉe %1:%2.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation>OpenOrienteering Mapper</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation>OCAD Versioj 7, 8</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation>OCAD</translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation>Ne povis analizi la koordinatojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation>Atendita %1 koordinatoj, %2 estis trovita.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation>Eraro dum ŝarĝo de presagordo ĉe %1:%2: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation>Eraro dum ŝarĝo de la malfari/refari paŝoj ĉe %1:%2: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation>Tia opcio ne ekzistas: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation>Geospaca vektoraj datumoj</translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation>Trovita objekto sen simbolo.</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation>
-            <numerusform>Forĵetita %n neregula objekto.</numerusform>
-            <numerusform>Forĵetitaj %n neregulaj objektoj.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation>Eraro dum postprilaborado de simbolo.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation>Fiaskis ŝargi ŝablonon &apos;%1&apos;, kialo: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation>Avertoj dum ŝarĝo de ŝablono &apos;%1&apos;:
-%2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation>Almenaŭ unu ŝablona dosiero ne povis esti trovita.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation>Nevalida versio de dosierformo.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation>Nesubtenata malnova versio de dosierformo. Bonvolu uzi pli malnovan programversion por ŝargi kaj ĝisdatigi la dosieron.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation>La geografia koordinatsistemo de la mapo estis &quot;%1&quot;. Ĉi tiu CRS estas nesubtenata. &quot;%2&quot; estas uzata.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation>Eraro dum ŝarĝo de simbolo kun tipo %2.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation>Eraro dum ŝarĝo de simbolo.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation>Eraro dum ŝarĝo de malfaraj paŝoj.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation>Eraro dum lego de nombro de mapopartoj.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation>Eraro dum ŝarĝo de mapoparto %2.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation>Ne povis legi dosieron: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation>Nesubtenata dosierformo.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation>Formo (%1) ne subtenas importon</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation>Ne povis legi &apos;%1&apos;: %2</translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation>Agordoj de linio</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation>Linia larĝo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation>Linikoloro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation>Minimuma longo de linio:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation>Linia fino:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation>plata</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation>ronda</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation>kvadrata</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation>akuta</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation>Kuniĝo de linioj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation>bevelo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation>Montri almenaŭ unun mezsimbolon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation>Minimuma kvanto de mezaj simboloj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation>Streka longo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation>Interspaco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation>Grupigo de strekoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation>nenio</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation>2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation>3</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation>4</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation>Mezaj simboloj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation>Limoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation>Maldekstra limo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation>Dekstra limo:</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation>Komenca simbolo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation>Meza simbolo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation>Fina simbolo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation>Ŝalti limajn liniojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation>Distanco inter la punktoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation>Larĝo de limo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation>Koloro de limo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation>Bordera ŝovo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation>&amp;Nova</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation>Krei novan mapon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;Malfermi…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation>Malfermi ekzistantan dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation>Malfermi &amp;lastan</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation>&amp;Konservi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation>Kon&amp;servi kiel…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation>Ctrl+Shift+S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation>Agordoj…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation>Fermi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation>Fermi la dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation>Eli&amp;ri</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation>Eliri la aplikaĵon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation>&amp;Dosiero</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation>Ĝenerala</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation>Malfermi &amp;Manlibron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation>Montri helpdosieron por la aplikaĵo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation>&amp;Pri %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation>Montri informon pri la aplikaĵo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation>Pri &amp;Qt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation>Montri informon pri Qt</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation>&amp;Helpo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation>Ĉu vi volas forigi la aŭtokonservitan version?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation>La dosiero estis modifita.
-Ĉu vi volas konservi viajn ŝanĝojn?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation>Nekonservita dosiero</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation>Averto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation>Kraŝaverto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation>Ŝajnas ke %1 kraŝis la lastan fojon, kiam ĉi tiu dosiero estis malfermita:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Ĉu vere reprovi malfermi ĝin?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation>Aŭtokonservado…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation>Aŭtokonservado fiaskis!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation>Ĉiuj mapoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation>Ĉiuj dosieroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation>Malfermi dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation>Vi devas fermi la aktualan dosieron antaŭ vi povas malfermi alian.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation>Malfermo de %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation>Ne povas malfermi dosieron:
-%1
-
-Dosierformo ne rekonita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation>La dosiero estis modifita.
-Ĉu vi volas forĵeti viajn ŝanĝojn?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation>&amp;%1 %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation>Ĉi tiu mapo estas konservata kiel &quot;%1&quot;-dosiero. Informo povas esti perdita.
-
-Premu Jes por konservi en ĉi tiu dosierformo.
-Premu Ne por elekti malsaman dosierformon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation>Konservi dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation>Dosiero ne povis esti konservita:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation>Tie estis problemo de determinado de la dosierformo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation>Bonvolu raporti tion kiel cimon.</translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation>Ne povas eksporti la mapon kiel
-&quot;%1&quot;
-ĉar konservado kiel %2 (.%3) estas nesubtenata.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation>Ne povas eksporti la mapon kiel
-&quot;%1&quot;
-ĉar la dosierformo estas nekonata.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation>Averto</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation>Eksportado de la mapo kaŭzis avertojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation>Interna eraro dum konservado:
-%1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation>Mapa importo generis avertojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation>Ne povas malfermi dosieron:
-%1
-por legado.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation>Nevalida dosiertipo.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation>Ne povas malfermi dosieron:
-%1
-
-%2</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation>Ne povas konservi dosieron
-%1:
-%2</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation>Nenio por importi.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation>Demando</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation>defaŭlta parto</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation>Nova koloro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation>Importi…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation>Malfari</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation>Malfari la lastan paŝon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation>Refari</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation>Refari la lastan paŝon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation>&amp;Eltondi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation>&amp;Kopii</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation>&amp;Alglui</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation>Zomi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation>Malzomi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation>Baskuligi tutekranan reĝimon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation>Simbola fenestro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation>Montri/Kaŝi la simbolan fenestron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation>Kolora fenestro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation>Montri/Kaŝi la koloran fenestron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation>Skali ĉiujn simbolojn…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation>Ŝanĝi mapan skalon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation>Mapaj notoj…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation>Montri/Kaŝi la ŝablonan fenestron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation>Malfermi ŝablonon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation>Montri tutan mapon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation>Redakti objektojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation>Desegni vojojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation>Desegni cirklojn kaj elipsojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation>Skribi tekston</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation>Duobligi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation>Ŝanĝi simbolon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation>Plenigi / Krei limon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation>Konekti vojojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation>Eltondi objekton</translation>
-    </message>
-    <message>
-        <source>Rotate object(s)</source>
-        <translation type="vanished">Turni objektojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation>Mezuri longojn kaj areojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation>Ŝalti tuŝkursoron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation>Ŝalti GPS-vidigon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation>Vakigi provizorajn GPS-markojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation>Ŝalti vidigon de kompaso</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation>Aldoni novan parton…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation>Renomi aktualan parton…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation>Forigi aktualan parton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation>Kunfandi ĉiujn partojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation>Importi…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation>&amp;Redakti</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation>&amp;Vido</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation>&amp;Iloj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation>&amp;Simboloj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation>&amp;Mapo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation>Ŝa&amp;blonoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation>Desegnado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation>Desegni sur la ŝablono</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation>Redaktado en progreso</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation>Mapo estis konservita</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation>Montri reton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation>Konfiguri reton…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation>Haĉitaj areoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation>Kaŝi ĉiujn ŝablonojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation>Anstataŭigi simbolaron…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation>Georeferencado…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation>Turni mapon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation>Turni la tutan mapon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation>Remalfermi ŝablonon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation>Etikeda redaktilo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation>Montri/Kaŝi la etikedan redaktilan fenestron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation>Desegni rektangulojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation>Forigi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation>Eltondi rondan truon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation>Eltondi rektangulan truon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation>Turni modelon</translation>
-    </message>
-    <message>
-        <source>Scale object(s)</source>
-        <translation type="vanished">Skali objektojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation>Sekci areojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation>Malinkluziva aŭo de areoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation>Eltondi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation>Ĉirkaŭtranĉi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation>Mapaj koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation>Projekciaj koordinatoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation>Latitudo/Longitudo (Dec)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation>Latitudo/Longitudo (° ′ ″)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation>Vidigi koordinatojn kiel…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation>Eltondi truon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation>Ctrl+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation>Ctrl+Shift+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation>Ctrl+I</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation>S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation>P</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation>O</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation>Ctrl+R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation>T</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation>Ctrl+G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation>Ctrl+F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation>Ctrl+D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation>C</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation>R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation>Z</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation>K</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation>U</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation>Ctrl+M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation>Elekti ĉiujn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation>Elekti nenion</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation>Inversigi elektaĵon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation>ID de simbolaro…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation>Redakti ID de simbolaro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation>Ŝargi CRT-dosieron…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation>Kopii pozicion</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation>Kopii pozicion al tondujo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation>Vido</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation>Mapopartoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation>Elekti ŝablonon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation>Redaktado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation>Speciala redaktado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation>Elekti simbolon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation>Kaŝi supran breton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation>Montri supran breton</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation>Preso / eksporto ne estas disponebla en ĉi tiu programversio!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cut %1 object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="vanished">Eltondi %1 objekto(j)n</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation>Interna eraro okazis, pardonu!</translation>
-    </message>
-    <message>
-        <source>Copied %1 object(s)</source>
-        <translation type="vanished">Kopiita %1 objekto(j)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pasted %1 object(s)</source>
-        <translation type="vanished">Algluita %1 objekto(j)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation>Zoma faktoro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation>Simboloj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation>Koloroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation>ID de simbolaro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation>Redakti ID de simbolaro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation>Skali ĉiujn simbolojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation>Skali en elcentoj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation>Mapaj notoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation>Rezigni</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation>Bone</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation>Ŝablonoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation>Etikeda Redaktilo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation>Neniu
-simbolo
-estis elektita</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation>Pluraj
-simboloj
-elektitaj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation>Desegni plurlaterajn kaj kurbajn liniojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation>Desegni cirklojn kaj elipsojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation>Desegni libermanan linion.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Deletes the selected object(s).</source>
-        <translation type="vanished">Forigi la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation>Rezultinta simbolo: %1 %2.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation>Kunfando de la truoj fiaskis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation>Vakigi provizorajn markojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation>Ĉu vi estas certa, ke vi volas forigi ĉiujn provizorajn GPS-markojn? Tio ne povas esti malfarita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation>Kunfandi ĉi tiun parton kun</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation>Movi elektitajn objektojn al</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation>Enigu nomon de la mapoparto:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation>Ŝanĝis al mapoparto &apos;%1&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation>Kunfandi mapopartojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation>Ĉu vi volas movi ĉiujn objektojn el mapoparto &quot;%1&quot; al &quot;%2&quot;, kaj forigi &quot;%1&quot;?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation>Ĉu vi volas movi ĉiujn objektojn al mapoparto &quot;%1&quot;, kaj forigi ĉiujn aliajn mapopartojn?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation>Ne povas importi la elektitan mapodosieron, ĉar ĝi ne povis esti ŝargita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation>Desegni rektangulojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation>Presi…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation>&amp;Bildo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation>&amp;PDF</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation>Vakigi malfaran / refaran historion</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation>Vakigi malfaran / refaran historion por redukti mapodosiergrandon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation>Movi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation>Redakti liniojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation>Konverti en kurbojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation>Simpligi vojon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation>&amp;Eksporti kiel…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation>Skribi tekston sur la mapo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Duplicate the selected object(s).</source>
-        <translation type="vanished">Duobligi la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Rotate the selected object(s).</source>
-        <translation type="vanished">Turni la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <source>Scale the selected object(s).</source>
-        <translation type="vanished">Skali elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fill the selected line(s) or create a border for the selected area(s).</source>
-        <translation type="vanished">Plenigi la elektitajn liniojn aŭ krei limon por la elektitaj areoj.</translation>
-    </message>
-    <message>
-        <source>%1 object(s) duplicated</source>
-        <translation type="vanished">%1 duobligita(j) objekto(j)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation>Objekta elekto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation>Mezurado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation>Unuiĝo fiaskis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation>Intersekco fiaskis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation>Diferenco fiaskis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation>XOr fiaskis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation>Ĉu vi volas forigi mapoparton &quot;%1&quot; kaj ĉiujn ĝiajn objektojn?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation>Importi %1, GPX, OSM aŭ DXF dosieron</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation>Importeblaj dosieroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation>Ĉiuj dosieroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation>Ne povas importi la elektitan dosieron, ĉar ĝia dosierformo estas nesubtenata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation>Turni objektojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation>Skali objektojn</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation>
-            <numerusform>Eltondita %n objekto</numerusform>
-            <numerusform>Eltondita %n objektoj</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation>
-            <numerusform>Kopiita %n objekto</numerusform>
-            <numerusform>Kopiita %n objektoj</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation>
-            <numerusform>Algluita %n objekto</numerusform>
-            <numerusform>Algluita %n objektoj</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation>Forigi la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation>Duobligi la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation>Turni la elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation>Skali elektitajn objektojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation>Plenigi la elektitajn liniojn aŭ krei limon por la elektitaj areoj.</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation>
-            <numerusform>Duobligita %n objekto</numerusform>
-            <numerusform>Duobligita %n objektoj</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Ĉesigi. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation>Pli: %1, %2</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation>Pli: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation>Pli: %1, %2, %3</translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation>&amp;Trovi…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation>Trovi &amp;sekvan</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation>Trovi objektojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation>&amp;Trovi sekvan</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation>Trovi ĉi&amp;ujn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation>Informpeta redaktilo</translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation>- Mapo -</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation>Traktado de disiĝoj de paĝo %1…</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation>Traktado de paĝo %1…</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation>Rezignita</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation>Finigita</translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation>Teksta fonto:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation>Mapo (%1)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation>nedefinita lingvo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation>%1x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation>Eraro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation>Ĉio estas preta por desegnado!
-
-Komencu desegni aŭ ŝargu bazmapon.
-Por ŝargi bazmapon, klaku
-Ŝablonoj -&gt; Malfermi ŝablonon…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation>Longo de rando:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation>Longo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation>Areo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation>Neniu objekto estis elektita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation>%1 objektoj estis elektita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation>Elektita objekto ne estas vojo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation>m²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation>Tiu objekto estas tro malgranda.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation>La minimuma areo estas %1 %2.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation>Tiu linio estas tro mallonga.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation>La minimuma longo estas %1 %2.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation>Krei novan mapon</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation>Elekti la skalon kaj aron de simboloj por la nova mapo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation>Skalo:  1 : </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation>Aroj de simboloj:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Rezigni</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation>Krei</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation>Malplena simbolaro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation>Ŝargi simbolaron el dosiero…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation>Ĉiuj simbolaraj dosieroj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation>Ĉiuj dosieroj</translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation>La mapo enhavas pli ol 256 koloroj, ke estas nesubtenata de OCD-versio 8.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation>libocad redonis %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation>Ne eblas eksporti ŝablonon: dosiertipo &quot;%1&quot; ankoraŭ ne estas subtenata</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation>Ne povis asigni bufron.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation>libocad redonis %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation>Versio %1 de OCAD-dosieroj ne estas subtenata!</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation>Ne povis ŝargi la spot-koloran difinon, eraro: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation>Ne eblas importi simbolon &quot;%3&quot; (%1.%2)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation>Ne eblas ŝarĝi objekton</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation>Ne eblas importi ortangulan objekton</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation>Kolora id ne trovita: %1, malatentas tiun koloron</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation>estas</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation>ne estas</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation>enhavas</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation>Serĉi</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation>Teksto</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation>kaj</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation>aŭ</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation>Simbolo</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation>nevalida</translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation>En linia simbolo %1 &apos;%2&apos;: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation>En teksta simbolo %1 &apos;%2&apos;: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation>Ne povis ŝargi la koordinatsistemon &apos;%1&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation>Spot-koloron informo estis malatentita.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation>Ne eblas importi simbolon %1.%2 &quot;%3&quot;: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation>Nesubtenata tipo &quot;%1&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation>Ne eblas importi ŝablonon: &quot;%1&quot; estas nesubtenata tipo de ŝablono.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation>Nesubtenata linia stilo &apos;%1&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation>Vertikala ĝisrandigo &apos;%1&apos; estas nesubtenata.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation>Kodoprezento &apos;%1&apos; ne estas disponebla. Kontrolu la agordojn.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation>En area simbolo %1 &apos;%2&apos;: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation>Ne eblas ŝarĝi objekton</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation>Ne eblas importi ortangulan objekton</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation>Nevalidaj datumoj.</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation>Versio %1 de OCD-dosieroj ne estas subtenata!</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation>Kolora id ne trovita: %1, malatentas tiun koloron</translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation>Purpura</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation>Punkto</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation>Linio</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation>Areo</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation>Teksto</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation>Ne eblas ŝarĝi tavolon %1.</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation>
-            <numerusform>Ne eblas ŝarĝi %n objekton, kaŭzo: %1</numerusform>
-            <numerusform>Ne eblas ŝarĝi %n objektojn, kaŭzo: %1</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation>Malplena geometrio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation>Geometria tipo estas nekonata aŭ nesubtenata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation>Ne sufiĉas koordinatoj.</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5180,770 +15,2871 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
-        <translation>Elekti ŝablonon por desegni sur ĝin</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
+        <translation>Pri %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
-        <translation>Rezigni</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
+        <translation>&lt;a %1&gt;Ĉion pri permesiloj, kopirajtaj avizoj, kondiĉoj kaj malgarantioj.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation>Desegni</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
-        <translation>&lt;b&gt;Klaki kaj treni&lt;/b&gt;: Desegni. &lt;b&gt;Dekstre klaki kaj treni&lt;/b&gt;: Viŝi. </translation>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation>La OpenOrienteering programistoj laŭ alfabeta ordo:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
-        <translation>Kolorelekto</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation>(iniciatoro de projekto)</translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la mapon. </translation>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
+        <translation>Libera programaro por desegni orientiĝajn mapojn</translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
-        <translation>%</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
+        <translation>Ĉi tiu verko estas libera programo: vi povas ĝin pludistribui kaj/aŭ modifi je la kondiĉoj de la &lt;a %1&gt;GNUa Ĝenerala Publika Permesilo (GPL), la versio&amp;nbsp;3&lt;/a&gt;, eldonita de Free Software Foundation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation>Ni distribuas ĉi tiun programon esperante ke ĝi estos utila, tamen SEN IA AJN GARANTIO; i.a. sen la implica garantio pri SURMERKATIGEBLO aŭ TAŬGECO POR IU KONKRETA CELO. &lt;a %1&gt;Pliajn detalojn&lt;/a&gt; vidu en la GNUa Ĝenerala Publika Permesilo (GPL), la versio&amp;nbsp;3.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
+        <translation>Por kontribuoj, danke al:</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
-        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Aldoni koordinaton. &lt;b&gt;%1+Klaki&lt;/b&gt;: Ŝanĝi la elektitan koordinaton. </translation>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
+        <translation>Malfermi plej antaŭ nelonge uzita dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation>Montri helpilojn</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation>Montri restantajn punktojn</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
-        <translation>Elementoj</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
+        <translation>Minimuma grandeco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
-        <translation>Punkto</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
+        <translation>Plenigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
-        <translation>Linio</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
+        <translation>Linia plenigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
-        <translation>Areo</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
+        <translation>Plenigo per modelo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation>Centrigi ĉiujn elementojn</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation>Aktuala elemento</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation>Diametro &lt;b&gt;a&lt;/b&gt;:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
-        <translation>Interna koloro:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
+        <translation>Sola linio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
-        <translation>Ekstera larĝo &lt;b&gt;b&lt;/b&gt;:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
+        <translation>Paralelaj linioj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
-        <translation>Ekstera koloro:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
+        <translation>Linipaŝo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
-        <translation>Linia larĝo:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
+        <translation>Sola vico</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
-        <translation>Linikoloro:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
+        <translation>Modela intervalo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
-        <translation>Linia fino:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
+        <translation>Modela deŝovo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
-        <translation>plata</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
+        <translation>Vica deŝovo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
-        <translation>ronda</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
+        <translation>Paralelaj vicoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
-        <translation>kvadrata</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
+        <translation>Intervica distanco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
-        <translation>Kuniĝo de linioj:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
+        <translation>Pleniga rotacio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
+        <translation>Angulo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
+        <translation>alĝustigebla per objekto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
-        <translation>bevelo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation>Desegni elementojn, se la centro estas interne de la limo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation>Desegni elementojn, se iu ajn punkto estas interne de la limo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation>Desegni elementojn, se ĉiuj punktoj estas interne de la limo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation>Agordoj de areo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation>Plenigo per modelo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation>Linia plenigo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation>Neniu plenigo estas elektita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Koloro de areo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
-        <translation>Koordinatoj:</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
+        <translation>Linia deŝovo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
-        <translation>X</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
+        <translation>Linikoloro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation>Kurba komenco</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation>[Mezo]</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
-        <translation>Nekonata</translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
+        <translation>Linia larĝo:</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
-        <translation>Punktosimbolo</translation>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation>Aŭtokonservita dosiero</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation>
+            <numerusform>%n bajto</numerusform>
+            <numerusform>%n bajtoj</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation>Dosiero estas konservita por la uzanto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation>Riparado de dosiero</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation>Dosiero %1 ne estis fermita ĝuste. Ĉi-momente ekzistas du versioj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
+        <translation>Konservi la aktivan dosieron por forigi la konfliktantajn versiojn.</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
-        <translation>Presado</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
+        <translation>Redakti koloron de mapo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
-        <translation>Eraro okazis dum traktado.</translation>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation>Redakti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation>Difini spot-koloron:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation>Mikso de spot-koloroj (ekranoj kaj surpreso):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation>Kalkuli el spot-koloroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation>Kalkuli el RVB-koloro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation>Propra procezkoloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation>Cejana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation>Magenta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation>Flava</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation>Nigra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation>Kalkuli el CMFN-koloro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation>Propra RGB-koloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>Ruĝa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>Verda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>Blua</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation>Labortablo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation>Profesia presado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation>- nenomita -</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la presareon. </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la mapon. </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
+        <translation>- nenio -</translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
-        <translation>Montri ŝablonojn</translation>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation>Opakeco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation>Spot-koloro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation>K.o.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>Nova</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation>Forigi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation>Duobligi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation>Movi Supren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation>Movi Malsupren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Helpo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation>Duoble alklaki kolorvaloron por malfermi dialogon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation>Konfirmo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation>La mapo enhavas simbolojn kun tiu koloro. Ĝia forigo kondukas al forigo de la koloro el tiuj simboloj. Ĉu vi vere volas fari tion?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation>%1 (duoblaĵo)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation> (Duoblaĵo)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation>Duoble alklaki por difini koloron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation>Alklaki por elekti nomon kaj alklaki denove por redakti.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation>&amp;Nombro de partoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation>- Privata linia simbolo -</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation>- Privata area simbolo -</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation>Redakti privatan simbolon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation>Agordoj de kombinaĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation>Ŝanĝi el publika al privata simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation>Preni la malnovan simbolon kiel ŝablono por la privata simbolo?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation>Simbolo %1:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation>Konfiguri reton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Montri reton</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
-        <translation>Orientiĝo de paĝo:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
+        <translation>Kapti per krado</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
-        <translation>Presilo:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
+        <translation>Elekti…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
-        <translation>Vertikala</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
+        <translation>Ĉiu linioj</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
-        <translation>Horizontala</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
+        <translation>Horizontalaj linioj</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
-        <translation>Paĝa formato:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
+        <translation>Vertikalaj linioj</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
-        <translation>Kopioj:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
+        <translation>Alkadrigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
-        <translation>Maldekstra:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
+        <translation>Ĝisrandigi kun magneta nordo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
-        <translation>Desupre:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
+        <translation>Ĝisrandigi kun krada nordo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
-        <translation>Larĝo:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
+        <translation>Ĝisrandigi kun vera nordo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
-        <translation>Alteco:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
+        <translation>Kroma turno (maldekstrume):</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
-        <translation>Antaŭrigardo…</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
-        <translation>Unuopa paĝo</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
+        <translation>Enpoziciigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
-        <translation>Propra areo</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
+        <translation>metroj sur tereno</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
-        <translation>Areo de mapo:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
+        <translation>milimetroj sur la mapo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
-        <translation>Centrigi presareon</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
+        <translation>Horizontala interspaco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation>Vertikala interspaco:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation>Horizontala deŝovo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation>Vertikala deŝovo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation>Unuo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation>Linikoloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation>Vidigi:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation>Elekti kradlinikoloron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
-        <translation>Atributoj</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
+        <translation>Origino ĉe: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
-        <translation>Paĝa surmeteco:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
-        <translation>Agordaĵoj</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
-        <translation>Distingivo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
-        <translation>Presi en alia skalo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
-        <translation>Ŝablona aspekto povas nuanciĝi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
-        <translation>Defaŭlto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
-        <translation>Aparata CMYK (eksperimente)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
-        <translation>Kolora reĝimo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
-        <translation>Presi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
-        <translation>Eksporti…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
-        <translation>PDF eksporto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
-        <translation>Bildoeksporto</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
-        <translation>Konservi al PDF</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
-        <translation>dpi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
-        <translation>Nesubtenata sur Androjdo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
-        <translation>Fiaskis pretigi antaŭrigardon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
-        <source>Warning</source>
-        <translation>Averto</translation>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
+        <translation>&lt;b&gt;Klaki aŭ treni&lt;/b&gt;: Komenci desegni truon. </translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation>PNG</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation>BMP</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation>TIFF</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation>JPEG</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation>Fiaskis pretigi PDF-eksporton.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation>PDF</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation>Eraro okazis dum presado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation>Eksporti mapon …</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation>Ĉiuj dosieroj (*.*)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation>Fiaskis pretigi presadon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation>Plenumo de presado</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
-        <translation>Vektora
-bildo</translation>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
+        <translation>La dividolinio devas finiĝi ĉe limo de la areo!</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
-        <translation>Rastruma
-bildo</translation>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
+        <translation>Komenco kaj fino de la dividolinio estas sur diversaj partoj de la objekto!</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
-        <translation>Kolor
-apartigoj</translation>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
+        <translation>Komenco kaj fino de la dividolinio estas sur sama pozicio!</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
-        <translation>Reĝimo:</translation>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt; sur linio: Dividi ĝin en du. &lt;b&gt;Treni&lt;/b&gt; laŭlonge linio: Forigi ĉi tiun linioparton. &lt;b&gt;Klaki aŭ treni&lt;/b&gt; ĉe limo de la areo: Komenci dividolinion. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation>Fiaskis pretigi bildon. Ne estas sufiĉe da memoro.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation>Fiaskis konservi la bildon. Ĉu la vojo ekzistas? Ĉu vi havas sufiĉaj rajtoj?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation>Sukcese eksportita al %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation>Fiaskis fini PDF-eksporton.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation>Rezignita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation>La presa tasko ne povis esti ĉesita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation>Sukcese kreita prestasko</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation>Nekonata</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
-        <translation>Mapa areo estas malplena. Eligo estas nuligita.</translation>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
-        <translation>Remalfermi ŝablonon</translation>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Eltondi la tutan mapon. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
+        <translation>&lt;b&gt;%1+Klaki aŭ treni&lt;/b&gt;: Elekti objektojn por eltondi. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Eltondi la elektitajn objektojn. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
+        <translation>Ne povis malfermi la dosieron.</translation>
+    </message>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation>La dosiero ne estas DXF dosiero.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation>Litero:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation>Alteco:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation>Distribui punktojn egalmezure laŭlonge de la vojo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation>Nombro da punktoj per vojo:</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
-        <translation>Fermitaj ŝablonoj:</translation>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation>Agordoj de turno</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation>Ĝisrandigi punktojn al direkto de linio</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation>Kroma turnangulo (maldekstrume):</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation>El centro</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Startigi cirklon aŭ elipson. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni cirklon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation>Reteni %1 por komenci la desegnadon el la centro.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Fini la cirklon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni elipson. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Desegni vojon. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation>&lt;b&gt;Uzi strekpunktojn.&lt;/b&gt; </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Kapti aŭ postglui al ekzistantaj objektoj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Elekti direkton el ekzistantaj objektoj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Azimuto kaj longo de segmento. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt;: Kapti per ekzistantaj objektoj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Malfari lastan punkton. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation>Finiŝo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>Angulo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation>Informo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>Streko</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation>Malfari</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation>Ĉesigi</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation>&lt;b&gt;Longo:&lt;/b&gt; %1 m </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Komenci rektan linion. &lt;b&gt;Treni&lt;/b&gt;: Komenci kurbon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation>&lt;b&gt;%1+Treni&lt;/b&gt;: Daŭrigi ekzistantajn objektojn. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Desegni rektan linion. &lt;b&gt;Treni&lt;/b&gt;: Desegni kurbon. &lt;b&gt;Dekstre aŭ duoble alklaki&lt;/b&gt;: Fini la vojon. &lt;b&gt;%1&lt;/b&gt;: Fermi la vojon. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation>Tuŝi la mapon por fini mezumadon</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Fini starigon de la objekto. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>Angulo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation>Reagordi</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation>&lt;b&gt;Angulo:&lt;/b&gt; %1° </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Krei punkta objekto.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Krei objekton kaj agordi ĝian orientiĝon.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Reagordi rotacion.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation>Finiŝo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation>Linia kapto</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>Streko</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation>Malfari</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation>Ĉesigi</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation>&lt;b&gt;Klaki aŭ treni&lt;/b&gt;: Komenci desegni rektangulon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Kapti al antaŭaj linioj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Starigi angulan punkton. &lt;b&gt;Dekstre aŭ duoble alklaki&lt;/b&gt;: Fini la rektangulon. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fini la redaktadon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Rezigni redakton. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Krei tekstan objekton kun unuopa ankro. &lt;b&gt;Treni&lt;/b&gt;: Krei tekstujon. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation>Baskuligi kurbon</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Libera movo. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur segmento: Baskuligi inter rekta kaj malrekta. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>Kapti</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation>Punkto / Angulo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation>Baskuligi strekon</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fini la redaktadon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto: Forigi ĝin; sur vojo: Aldoni novan strekpunkton; kun &lt;b&gt;%2&lt;/b&gt;: Aldoni normalan punkton. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto: Forigi ĝin; sur vojo: Aldoni novan punkton; kun &lt;b&gt;%2&lt;/b&gt;: Aldoni strekpunkton. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation>&lt;b&gt;%1+Klaki&lt;/b&gt; sur punkto por ŝalti inter streka kaj normala punkto. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation>&lt;b&gt;Koordinata deŝovo:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distanco:&lt;/b&gt; %3 m </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Kapti al ekzistantaj objektoj. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Elekti unuopan objekton. &lt;b&gt;Treni&lt;/b&gt;: Elekti plurajn objektojn. &lt;b&gt;%1+Klaki&lt;/b&gt;: Baskuligi elektaĵon. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Forigi elektitajn objektojn. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation>Alta kvalita vidigo de mapo (glatigo)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation>Alta kvalita vidigo de teksto sur la mapo (glatigo), malrapida</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation>Klaka tolero:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation>Kapta distanco (%1):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation>Grandeco de la bildsimbolo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation>Ŝablonoj: konservi agordojn de fermitaj ŝablonoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation>Redaktilo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation>Reteni praformon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation>Reagordi eksterajn tenilojn de kurbo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation>Konservi eksterajn tenilojn de kurbo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation>Ortangulilo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation>Radiuso de helpa kruco:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation>Redaktilo</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation>Ne povis krei novan dosieron: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation>Formato (%1) ne subtenas eksporton</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
+        <translation>La mapa areo estas granda. Uzo de la plenigilo povas esti tre malrapida. Ĉu vi volas uzi ĝin ĉiuokaze?</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation>La elektita areo ne estas limigita per linioj aŭ areoj, ne povas plenigi ĉi tiun areon.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
+        <translation>Fiaskis krei la plenigan objekton.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GPSDisplay</name>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
+        <translation>GPS estas malvalidigita en la aparataj agordoj. Ĉu malfermi agordojn nun?</translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
+        <translation>Jes</translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation>Ne</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
+        <translation>Importi kun GDAL/OGR:</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation>DXF</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation>GPX</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation>OSM</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation>Agordo</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation>Parametro</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation>Valoro</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation>GDAL/OGR</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation>Aspekto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation>Lingvo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation>Ekrano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation>Bilderoj en colo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation>Programa starto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation>Konservo de dosieroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation>Reteni kongruecon kun Mapper %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation>Konservi informon por aŭtomata riparado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation>Intervalo de konservado:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation>min</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation>Dosiera importo kaj eksporto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation>8-bita signaro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation>Pli…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation>Konservi malfaran/refaran historion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation>Defaŭlto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation>Uzi la novan OCD-importilon ankaŭ por dosierversio 8</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation>Ĝenerala</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation>Rimarko</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation>La programo devas esti rekomencita por la lingva ŝanĝo efektiviĝos!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation>Malfermi tradukon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation>Tradukaj dosieroj (*.qm)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation>La elektita dosiero ne estas valida tradukdosiero.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation>%1 x %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation>Ĉefa ekrandistingivo en bilderoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation>Ĉefa ekrangrando en coloj (diagonalo):</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation>UTM</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation>UTM koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation>UTM-zono (numero N/S)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation>Gauss-Krueger, datumo: Potsdamo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation>Gauss-Krueger koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation>Numero de zono (1-119)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation>per EPSG kodo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation>EPSG @code@ koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation>Lokaj koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation>EPSG kodo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation>Propra PROJ.4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation>Specifo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation>Specifo de mapa skalo estas nevalida aŭ mankas.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation>Nevalida krada skalfaktoro: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation>Nekonata CRS-specifa lingvo: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation>Nesubtenata specifo de geografia CRS: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation>Loka</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation>Mapa georeferencado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation>Elserĉi...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation>Deklinacio:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation>Projekciaj koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation>Stato:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation>Geografiaj koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation>Montri referencan punkton en:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation>valida</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation>Reta serĉo por deklinacio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation>Koordinatsistemo de mapo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation>- loka -</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation>Krada skalfaktoro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation>Referenca punkto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation>&amp;Elekti sur mapo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation>(Datumo: WGS84)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation>Mapa nordo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation>&amp;Koordinatsistemo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation>Mapaj koordinatoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation>Geografiaj koordinatoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation>Ŝanĝinte CRS, konservi:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation>Deklinacia ŝanĝo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation>La deklinacio estis ŝanĝita. Ĉu vi volas ankaŭ turni enhavon de la mapo?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation>Lokaj koordinatoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation>Ŝargo…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation>ŝlosita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation>Ne povis analizi datumon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation>Deklinacia valoro ne trovita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation>Eraro dum la reta serĉo de deklinacio:
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation>%1 °</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Agordi referencan punkton. &lt;b&gt;Dekstre alklaki&lt;/b&gt;: Rezigni.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation>Bonvenon en OpenOrienteering Mapper!</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation>Aktivecoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation>Krei novan mapon …</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation>Malfermi mapon …</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation>Agordoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation>Pri %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation>Helpo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation>Eliri</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation>Lastaj mapoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation>Malfermi plej antaŭ nelonge uzita dosieron startigante</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Vakigi liston</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
-        <translation>Aktivaj ŝablonoj:</translation>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
+        <translation>Konsilo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
-        <translation>- Mapo -</translation>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation>Montri konsilojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation>Antaŭa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
+        <translation>Sekva</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
-        <translation>Anstataŭigi simbolaron</translation>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
+        <translation>Ekzemploj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
+        <translation>Pri Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
+        <translation>Dosierlisto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation>Neniu dosiero trovita!&lt;br/&gt;&lt;br/&gt; Kopii mapodosierojn al supra dosierujo &apos;OOMapper&apos; sur la aparato aŭ memorkarto.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
+        <translation>Eraro dum ŝarĝo de simbolo de tipo %1 ĉe linio %2 kolumno %3.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
+        <translation>Simbola ID &apos;%1&apos; ne estas unika ĉe linio %2 kolumno %3.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
+        <translation>Eraro dum ŝarĝo de simbolo de tipo %1 ĉe linio %2 kolumno %3: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
+        <translation>Eraro dum ŝarĝo de objekto de tipo %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
+        <translation>Eraro dum ŝarĝo de objekto de tipo %1 ĉe %2:%3: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
+        <translation>Ne eblas trovi simbolon por objekto ĉe %1:%2.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
+        <translation>Punktobjekto kun nedefinita aŭ malvera simbolo ĉe %1:%2.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
+        <translation>OpenOrienteering Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
+        <translation>OCAD Versioj 7, 8</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
+        <translation>OCAD</translation>
+    </message>
+    <message>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
+        <translation>Ne povis analizi la koordinatojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
+        <translation>Atendita %1 koordinatoj, %2 estis trovita.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
+        <translation>Eraro dum ŝarĝo de presagordo ĉe %1:%2: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
+        <translation>Eraro dum ŝarĝo de la malfari/refari paŝoj ĉe %1:%2: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
+        <translation>Tia opcio ne ekzistas: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation>Geospaca vektoraj datumoj</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation>Trovita objekto sen simbolo.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation>
+            <numerusform>Forĵetita %n neregula objekto.</numerusform>
+            <numerusform>Forĵetitaj %n neregulaj objektoj.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
+        <translation>Eraro dum postprilaborado de simbolo.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation>Fiaskis ŝargi ŝablonon &apos;%1&apos;, kialo: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation>Avertoj dum ŝarĝo de ŝablono &apos;%1&apos;:
+%2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation>Almenaŭ unu ŝablona dosiero ne povis esti trovita.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation>Nevalida versio de dosierformo.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation>Nesubtenata malnova versio de dosierformo. Bonvolu uzi pli malnovan programversion por ŝargi kaj ĝisdatigi la dosieron.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
-        <translation>Simbolomapigo:</translation>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation>La geografia koordinatsistemo de la mapo estis &quot;%1&quot;. Ĉi tiu CRS estas nesubtenata. &quot;%2&quot; estas uzata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation>Eraro dum ŝarĝo de simbolo kun tipo %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation>Eraro dum ŝarĝo de simbolo.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation>Eraro dum ŝarĝo de malfaraj paŝoj.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation>Eraro dum lego de nombro de mapopartoj.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation>Eraro dum ŝarĝo de mapoparto %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation>Ne povis legi dosieron: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation>Nesubtenata dosierformo.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation>Formo (%1) ne subtenas importon</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation>Ne povis legi &apos;%1&apos;: %2</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation>Agordoj de linio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation>Linia larĝo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation>Linikoloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation>Minimuma longo de linio:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation>Linia fino:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation>plata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation>ronda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation>kvadrata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation>akuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation>Kuniĝo de linioj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
-        <translation>Origina</translation>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation>bevelo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
-        <translation>Redakti ID de simbolaro:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
-        <translation>Anstataŭigo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
-        <translation>Ŝablono</translation>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation>Montri almenaŭ unun mezsimbolon</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation>Minimuma kvanto de mezaj simboloj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
-        <translation>Malfermi CRT-dosieron…</translation>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation>Streka longo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
-        <translation>Konservi CRT-dosieron…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
-        <translation>CRT-dosiero</translation>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation>Interspaco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation>Grupigo de strekoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation>nenio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation>4</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation>Mezaj simboloj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation>Limoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation>Maldekstra limo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation>Dekstra limo:</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation>Komenca simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation>Meza simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation>Fina simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation>Ŝalti limajn liniojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation>Distanco inter la punktoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation>Larĝo de limo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation>Koloro de limo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation>Bordera ŝovo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation>&amp;Nova</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation>Krei novan mapon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Malfermi…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation>Malfermi ekzistantan dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation>Malfermi &amp;lastan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Konservi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation>Kon&amp;servi kiel…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation>Agordoj…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation>Fermi la dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation>Eli&amp;ri</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation>Eliri la aplikaĵon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation>&amp;Dosiero</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation>Ĝenerala</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation>Malfermi &amp;Manlibron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation>Montri helpdosieron por la aplikaĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation>&amp;Pri %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation>Montri informon pri la aplikaĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation>Pri &amp;Qt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation>Montri informon pri Qt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Helpo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation>Ĉu vi volas forigi la aŭtokonservitan version?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation>La dosiero estis modifita.
+Ĉu vi volas konservi viajn ŝanĝojn?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation>Nekonservita dosiero</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation>Kraŝaverto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation>Ŝajnas ke %1 kraŝis la lastan fojon, kiam ĉi tiu dosiero estis malfermita:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Ĉu vere reprovi malfermi ĝin?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation>Aŭtokonservado…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation>Aŭtokonservado fiaskis!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation>Ĉiuj mapoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation>Ĉiuj dosieroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation>Malfermi dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation>Vi devas fermi la aktualan dosieron antaŭ vi povas malfermi alian.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation>Malfermo de %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation>Ne povas malfermi dosieron:
+%1
+
+Dosierformo ne rekonita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation>La dosiero estis modifita.
+Ĉu vi volas forĵeti viajn ŝanĝojn?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation>&amp;%1 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation>Ĉi tiu mapo estas konservata kiel &quot;%1&quot;-dosiero. Informo povas esti perdita.
+
+Premu Jes por konservi en ĉi tiu dosierformo.
+Premu Ne por elekti malsaman dosierformon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation>Konservi dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation>Dosiero ne povis esti konservita:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation>Tie estis problemo de determinado de la dosierformo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation>Bonvolu raporti tion kiel cimon.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation>Ne povas eksporti la mapon kiel
+&quot;%1&quot;
+ĉar konservado kiel %2 (.%3) estas nesubtenata.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation>Ne povas eksporti la mapon kiel
+&quot;%1&quot;
+ĉar la dosierformo estas nekonata.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation>Eksportado de la mapo kaŭzis avertojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation>Interna eraro dum konservado:
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation>Mapa importo generis avertojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation>Ne povas malfermi dosieron:
+%1
+por legado.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation>Nevalida dosiertipo.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5954,7 +2890,3072 @@ apartigoj</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation>Ne povas konservi dosieron
+%1:
+%2</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation>Nenio por importi.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation>Demando</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation>defaŭlta parto</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation>Nova koloro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation>Importi…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation>Malfari</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation>Malfari la lastan paŝon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation>Refari</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation>Refari la lastan paŝon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation>&amp;Eltondi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation>&amp;Kopii</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Alglui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation>Zomi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation>Malzomi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation>Baskuligi tutekranan reĝimon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation>Simbola fenestro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation>Montri/Kaŝi la simbolan fenestron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation>Kolora fenestro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation>Montri/Kaŝi la koloran fenestron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation>Skali ĉiujn simbolojn…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation>Ŝanĝi mapan skalon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation>Mapaj notoj…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation>Montri/Kaŝi la ŝablonan fenestron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation>Malfermi ŝablonon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation>Montri tutan mapon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation>Redakti objektojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation>Desegni vojojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation>Desegni cirklojn kaj elipsojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation>Skribi tekston</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation>Duobligi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation>Ŝanĝi simbolon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation>Plenigi / Krei limon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation>Konekti vojojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation>Eltondi objekton</translation>
+    </message>
+    <message>
+        <source>Rotate object(s)</source>
+        <translation type="vanished">Turni objektojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation>Mezuri longojn kaj areojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation>Ŝalti tuŝkursoron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation>Ŝalti GPS-vidigon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation>Vakigi provizorajn GPS-markojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation>Ŝalti vidigon de kompaso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation>Aldoni novan parton…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation>Renomi aktualan parton…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation>Forigi aktualan parton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation>Kunfandi ĉiujn partojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation>Importi…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Redakti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation>&amp;Vido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation>&amp;Iloj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation>&amp;Simboloj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation>&amp;Mapo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation>Ŝa&amp;blonoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation>Desegnado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation>Desegni sur la ŝablono</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation>Redaktado en progreso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation>Mapo estis konservita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation>Montri reton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation>Konfiguri reton…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation>Haĉitaj areoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation>Kaŝi ĉiujn ŝablonojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation>Anstataŭigi simbolaron…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation>Georeferencado…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation>Turni mapon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation>Turni la tutan mapon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation>Remalfermi ŝablonon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation>Etikeda redaktilo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation>Montri/Kaŝi la etikedan redaktilan fenestron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation>Desegni rektangulojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation>Forigi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation>Eltondi rondan truon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation>Eltondi rektangulan truon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation>Turni modelon</translation>
+    </message>
+    <message>
+        <source>Scale object(s)</source>
+        <translation type="vanished">Skali objektojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation>Sekci areojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation>Malinkluziva aŭo de areoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation>Eltondi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation>Ĉirkaŭtranĉi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation>Mapaj koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation>Projekciaj koordinatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation>Latitudo/Longitudo (Dec)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation>Latitudo/Longitudo (° ′ ″)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation>Vidigi koordinatojn kiel…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation>Eltondi truon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation>Ctrl+Shift+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation>P</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation>O</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation>Ctrl+R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation>T</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation>D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation>C</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation>K</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation>H</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation>M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation>U</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation>Elekti ĉiujn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation>Elekti nenion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation>Inversigi elektaĵon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation>ID de simbolaro…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation>Redakti ID de simbolaro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation>Ŝargi CRT-dosieron…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation>Kopii pozicion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation>Kopii pozicion al tondujo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation>Vido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation>Mapopartoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation>Elekti ŝablonon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation>Redaktado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation>Speciala redaktado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation>Elekti simbolon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation>Kaŝi supran breton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation>Montri supran breton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation>Preso / eksporto ne estas disponebla en ĉi tiu programversio!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cut %1 object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="vanished">Eltondi %1 objekto(j)n</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation>Interna eraro okazis, pardonu!</translation>
+    </message>
+    <message>
+        <source>Copied %1 object(s)</source>
+        <translation type="vanished">Kopiita %1 objekto(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pasted %1 object(s)</source>
+        <translation type="vanished">Algluita %1 objekto(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation>Zoma faktoro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation>Simboloj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation>Koloroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation>ID de simbolaro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation>Redakti ID de simbolaro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation>Skali ĉiujn simbolojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation>Skali en elcentoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation>Mapaj notoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation>Rezigni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation>Bone</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation>Ŝablonoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation>Etikeda Redaktilo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation>Neniu
+simbolo
+estis elektita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation>Pluraj
+simboloj
+elektitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation>Desegni plurlaterajn kaj kurbajn liniojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation>Desegni cirklojn kaj elipsojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation>Desegni libermanan linion.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deletes the selected object(s).</source>
+        <translation type="vanished">Forigi la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation>Rezultinta simbolo: %1 %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation>Kunfando de la truoj fiaskis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation>Vakigi provizorajn markojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation>Ĉu vi estas certa, ke vi volas forigi ĉiujn provizorajn GPS-markojn? Tio ne povas esti malfarita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation>Kunfandi ĉi tiun parton kun</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation>Movi elektitajn objektojn al</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation>Enigu nomon de la mapoparto:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation>Ŝanĝis al mapoparto &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation>Kunfandi mapopartojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation>Ĉu vi volas movi ĉiujn objektojn el mapoparto &quot;%1&quot; al &quot;%2&quot;, kaj forigi &quot;%1&quot;?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation>Ĉu vi volas movi ĉiujn objektojn al mapoparto &quot;%1&quot;, kaj forigi ĉiujn aliajn mapopartojn?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation>Ne povas importi la elektitan mapodosieron, ĉar ĝi ne povis esti ŝargita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation>Desegni rektangulojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation>Presi…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation>&amp;Bildo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation>&amp;PDF</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation>Vakigi malfaran / refaran historion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation>Vakigi malfaran / refaran historion por redukti mapodosiergrandon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation>Movi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation>Redakti liniojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation>Konverti en kurbojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation>Simpligi vojon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation>&amp;Eksporti kiel…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation>Skribi tekston sur la mapo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Duplicate the selected object(s).</source>
+        <translation type="vanished">Duobligi la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate the selected object(s).</source>
+        <translation type="vanished">Turni la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <source>Scale the selected object(s).</source>
+        <translation type="vanished">Skali elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fill the selected line(s) or create a border for the selected area(s).</source>
+        <translation type="vanished">Plenigi la elektitajn liniojn aŭ krei limon por la elektitaj areoj.</translation>
+    </message>
+    <message>
+        <source>%1 object(s) duplicated</source>
+        <translation type="vanished">%1 duobligita(j) objekto(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation>Objekta elekto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation>Mezurado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation>Unuiĝo fiaskis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation>Intersekco fiaskis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation>Diferenco fiaskis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation>XOr fiaskis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation>Ĉu vi volas forigi mapoparton &quot;%1&quot; kaj ĉiujn ĝiajn objektojn?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation>Importi %1, GPX, OSM aŭ DXF dosieron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation>Importeblaj dosieroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation>Ĉiuj dosieroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation>Ne povas importi la elektitan dosieron, ĉar ĝia dosierformo estas nesubtenata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation>Turni objektojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation>Skali objektojn</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation>
+            <numerusform>Eltondita %n objekto</numerusform>
+            <numerusform>Eltondita %n objektoj</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation>
+            <numerusform>Kopiita %n objekto</numerusform>
+            <numerusform>Kopiita %n objektoj</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation>
+            <numerusform>Algluita %n objekto</numerusform>
+            <numerusform>Algluita %n objektoj</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation>Forigi la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation>Duobligi la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation>Turni la elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation>Skali elektitajn objektojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation>Plenigi la elektitajn liniojn aŭ krei limon por la elektitaj areoj.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation>
+            <numerusform>Duobligita %n objekto</numerusform>
+            <numerusform>Duobligita %n objektoj</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Ĉesigi. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation>Pli: %1, %2</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation>Pli: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation>Pli: %1, %2, %3</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation>&amp;Trovi…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation>Trovi &amp;sekvan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation>Trovi objektojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation>&amp;Trovi sekvan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation>Trovi ĉi&amp;ujn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation>Informpeta redaktilo</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation>- Mapo -</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation>Traktado de disiĝoj de paĝo %1…</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation>Traktado de paĝo %1…</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation>Rezignita</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation>Finigita</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation>Teksta fonto:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation>Mapo (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation>nedefinita lingvo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation>%1x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation>Ĉio estas preta por desegnado!
+
+Komencu desegni aŭ ŝargu bazmapon.
+Por ŝargi bazmapon, klaku
+Ŝablonoj -&gt; Malfermi ŝablonon…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation>Longo de rando:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation>Longo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation>Areo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation>Neniu objekto estis elektita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation>%1 objektoj estis elektita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation>Elektita objekto ne estas vojo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation>m²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation>Tiu objekto estas tro malgranda.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation>La minimuma areo estas %1 %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation>Tiu linio estas tro mallonga.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation>La minimuma longo estas %1 %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation>Krei novan mapon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation>Elekti la skalon kaj aron de simboloj por la nova mapo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation>Skalo:  1 : </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation>Aroj de simboloj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">Rezigni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation>Krei</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation>Malplena simbolaro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation>Ŝargi simbolaron el dosiero…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation>Ĉiuj simbolaraj dosieroj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation>Ĉiuj dosieroj</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation>La mapo enhavas pli ol 256 koloroj, ke estas nesubtenata de OCD-versio 8.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation>libocad redonis %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation>Ne eblas eksporti ŝablonon: dosiertipo &quot;%1&quot; ankoraŭ ne estas subtenata</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation>Ne povis asigni bufron.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation>libocad redonis %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation>Versio %1 de OCAD-dosieroj ne estas subtenata!</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation>Ne povis ŝargi la spot-koloran difinon, eraro: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation>Ne eblas importi simbolon &quot;%3&quot; (%1.%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation>Ne eblas ŝarĝi objekton</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation>Ne eblas importi ortangulan objekton</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation>Kolora id ne trovita: %1, malatentas tiun koloron</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation>estas</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation>ne estas</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation>enhavas</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation>Serĉi</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation>Teksto</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation>kaj</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation>aŭ</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation>Simbolo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation>nevalida</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation>En linia simbolo %1 &apos;%2&apos;: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation>En teksta simbolo %1 &apos;%2&apos;: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation>Ne povis ŝargi la koordinatsistemon &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation>Spot-koloron informo estis malatentita.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation>Ne eblas importi simbolon %1.%2 &quot;%3&quot;: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation>Nesubtenata tipo &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation>Ne eblas importi ŝablonon: &quot;%1&quot; estas nesubtenata tipo de ŝablono.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation>Nesubtenata linia stilo &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation>Vertikala ĝisrandigo &apos;%1&apos; estas nesubtenata.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation>Kodoprezento &apos;%1&apos; ne estas disponebla. Kontrolu la agordojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation>En area simbolo %1 &apos;%2&apos;: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation>Ne eblas ŝarĝi objekton</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation>Ne eblas importi ortangulan objekton</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation>Nevalidaj datumoj.</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation>Versio %1 de OCD-dosieroj ne estas subtenata!</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation>Kolora id ne trovita: %1, malatentas tiun koloron</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation>Purpura</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation>Punkto</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation>Linio</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation>Areo</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation>Teksto</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation>Ne eblas ŝarĝi tavolon %1.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation>
+            <numerusform>Ne eblas ŝarĝi %n objekton, kaŭzo: %1</numerusform>
+            <numerusform>Ne eblas ŝarĝi %n objektojn, kaŭzo: %1</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation>Malplena geometrio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation>Geometria tipo estas nekonata aŭ nesubtenata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation>Ne sufiĉas koordinatoj.</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation>Elekti ŝablonon por desegni sur ĝin</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation>Rezigni</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation>Desegni</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation>&lt;b&gt;Klaki kaj treni&lt;/b&gt;: Desegni. &lt;b&gt;Dekstre klaki kaj treni&lt;/b&gt;: Viŝi. </translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation>Kolorelekto</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la mapon. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation>&lt;b&gt;Klaki&lt;/b&gt;: Aldoni koordinaton. &lt;b&gt;%1+Klaki&lt;/b&gt;: Ŝanĝi la elektitan koordinaton. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation>Elementoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation>Punkto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation>Linio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation>Areo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation>Centrigi ĉiujn elementojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation>Aktuala elemento</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation>Diametro &lt;b&gt;a&lt;/b&gt;:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation>Interna koloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation>Ekstera larĝo &lt;b&gt;b&lt;/b&gt;:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation>Ekstera koloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation>Linia larĝo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation>Linikoloro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation>Linia fino:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation>plata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation>ronda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation>kvadrata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation>Kuniĝo de linioj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation>bevelo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation>Koloro de areo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation>Koordinatoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation>Kurba komenco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation>[Mezo]</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation>Nekonata</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation>Punktosimbolo</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation>Presado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation>Eraro okazis dum traktado.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la presareon. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi la mapon. </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation>Montri ŝablonojn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation>Montri reton</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation>Orientiĝo de paĝo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation>Presilo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation>Vertikala</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation>Horizontala</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation>Paĝa formato:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation>Kopioj:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation>Maldekstra:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation>Desupre:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation>Larĝo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation>Alteco:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation>Antaŭrigardo…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation>Unuopa paĝo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation>Propra areo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation>Areo de mapo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation>Centrigi presareon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation>Atributoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation>Paĝa surmeteco:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation>Agordaĵoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation>Distingivo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation>Presi en alia skalo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation>Ŝablona aspekto povas nuanciĝi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation>Defaŭlto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation>Aparata CMYK (eksperimente)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation>Kolora reĝimo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation>Presi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation>Eksporti…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation>PDF eksporto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation>Bildoeksporto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation>Konservi al PDF</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation>dpi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation>Nesubtenata sur Androjdo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation>Fiaskis pretigi antaŭrigardon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation>PNG</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation>BMP</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation>TIFF</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation>JPEG</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation>Fiaskis pretigi PDF-eksporton.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation>PDF</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation>Eraro okazis dum presado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation>Eksporti mapon …</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation>Ĉiuj dosieroj (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation>Fiaskis pretigi presadon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation>Plenumo de presado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation>Eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation>Vektora
+bildo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation>Rastruma
+bildo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation>Kolor
+apartigoj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation>Reĝimo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation>Fiaskis pretigi bildon. Ne estas sufiĉe da memoro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation>Fiaskis konservi la bildon. Ĉu la vojo ekzistas? Ĉu vi havas sufiĉaj rajtoj?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation>Sukcese eksportita al %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation>Fiaskis fini PDF-eksporton.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation>Rezignita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation>La presa tasko ne povis esti ĉesita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation>Sukcese kreita prestasko</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation>Nekonata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation>Mapa areo estas malplena. Eligo estas nuligita.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation>Remalfermi ŝablonon</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation>Fermitaj ŝablonoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation>Vakigi liston</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation>Aktivaj ŝablonoj:</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation>- Mapo -</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation>Anstataŭigi simbolaron</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation>Simbolomapigo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation>Origina</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation>Redakti ID de simbolaro:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation>Anstataŭigo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation>Ŝablono</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation>Malfermi CRT-dosieron…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation>Konservi CRT-dosieron…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation>CRT-dosiero</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation>Ne povas malfermi dosieron:
+%1
+
+%2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5965,467 +5966,467 @@ apartigoj</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Nenio -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Elekti mapodosieron por elŝargi simbolojn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Ne povas ŝargi mapodosieron, ĉesigado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Turni mapon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Angulo (maldekstrume):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Turnaj parametroj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Turni ĉirkaŭ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Alia punkto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Agordaĵoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Turni negeoreferencitajn ŝablonojn</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Angulo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Turno:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksaj anguloj. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Treni&lt;/b&gt;: Turni la elektitajn objektojn. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Ŝanĝi mapan skalon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Skaligaj parametroj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nova skalo:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Skaliga centro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Alia punkto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Agordaĵoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Skali grandojn de simboloj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skali poziciojn de mapaj objektoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skali negeoreferencitajn ŝablonojn</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skalado:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klaki&lt;/b&gt;: Agordi skalocentron. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Treni&lt;/b&gt;: Skali elektitajn objektojn. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Elekti koordinatsistemon</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Same kiel sur la mapo</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Loka</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Geografiaj koordinatoj (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Stato:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>valida</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; ne estas skribebla. Ŝanĝoj ne estas konservebla.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; estas nevalida memoraloko.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- nenio -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Nenio -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nombro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Redakti</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nomo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Priskribo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Helpa simbolo (ne estos montrita sur finita mapo)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Ĝenerala</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Priskribo</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nova simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Areo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Teksto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Kunigita</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Redakti</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duobligi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Forigi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skalo…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopii</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Alglui</translation>
     </message>
@@ -6438,12 +6439,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Plenigi / Krei limon por elektitaj objektoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Elekti simbolojn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Ŝalti &quot;ŝovi kaj demeti&quot;</translation>
     </message>
@@ -6452,197 +6453,197 @@ Do you want to save your changes?</source>
         <translation type="vanished">Skali simbolo(j)n</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Interna eraro okazis, pardonu!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Ne estas simboloj en tondejo, kiuj povas esti algluitaj!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Elekti ĉiujn objektojn kun tiu simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Elekti ĉiujn objektojn kun tiu simbolo al elekto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Forigi ĉiujn objektojn kun tiu simbolo el elekto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Kaŝi objektojn kun tiu simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Protekti objektojn kun tiu simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Aldoni ĉiujn objektojn kun elektitaj simboloj al elekto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Forigi ĉiujn objektojn kun elektitaj simboloj el elekto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Kaŝi objektojn kun elektitaj simboloj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Protekti objektojn kun elektitaj simboloj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Inversigi elektaĵon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Elekti ĉiujn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Elekti neuzatajn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Ordigi simbolojn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Ordigi laŭ numero</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Ordigi laŭ ĉefkoloro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Ordigi laŭ ĉefkolora prioritato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skali en elcentoj:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Elekti ĉiujn objektojn kun elektitaj simboloj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Ŝanĝi simbolon de elektitaj objektoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Plenigi / Krei limon por elektitaj objektoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Skali simbolojn</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Agordoj de simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Ŝablono:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Ŝablono:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(nenio)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Malfermi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centrigi ŝablonon…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>limiga kesto sur origino</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>masocentro sur origino</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Elekti fonan koloron</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6653,58 +6654,58 @@ manĝaĵo kun spicoj
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- nenomita -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Neniu priskribo!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Rilato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Ŝlosilo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Komparo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Valoro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Aldoni vicon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Forigi vicon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Movi Supren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Movi Malsupren</translation>
     </message>
@@ -6717,7 +6718,7 @@ manĝaĵo kun spicoj
         <translation type="vanished">Helpo</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n objekto estis elektita</numerusform>
@@ -6725,203 +6726,203 @@ manĝaĵo kun spicoj
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Nevalida informpeto</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Ŝlosilo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Valoro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Helpo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Ŝlosilo ekzistas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>La ŝlosilo &quot;%1&quot; jam ekzistas kaj devas ne esti uzata dufoje.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Serĉi la movitan ŝablonan dosieron</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Ĉiuj dosieroj (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Tia dosiero ne ekzistas.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Ĉu la dosierformo estas ĝusta por ĉi tiu tipo de ŝablono?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Ĝustigo de ŝablono</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Fiaskis kalkuli ĝustigon!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klaki&lt;/b&gt;: Forigi interpunktojn. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Treni&lt;/b&gt;: Movi interpunktojn. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Interpunktoj:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nova</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Movi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Forigi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Ŝablona X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Ŝablona Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Mapo X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Mapo Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Apliki interpunktojn</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Helpo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Apliki &amp;&amp; vakigi ĉiujn</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Vakigi ĉiujn</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Nesufiĉa libera memoro (bilda grandeco: %1x%2 bilderoj)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -6930,218 +6931,218 @@ Konservado de GIF-dosieroj estas nesubtenata. Tio signifas, ke desegnado sur ĉi
 Tamen se vi ne intencas desegni sur ĉi tiu ŝablono, tio ne estas problemo.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Malfermo de %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Bilda grandeco:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Precizigi kiel pozicii aŭ skali la bildon:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>World-dosiero</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nenia informo pri georeferencado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferencita</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metroj en bildero:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Skanita kun</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Ŝablona skalo:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Rezigni</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Malfermi</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Montri</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Opakeco</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Grupo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Dosiernomo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Skizo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Malfermi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georeferencita: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Fermi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duobligi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Aldoni ŝablonon…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Forigi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Movi Supren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Movi Malsupren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importi kaj forigi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Helpo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Movi permane</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Malfermi bildon, GPS trakon aŭ DXF dosieron</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Enpoziciigo…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Ŝablonaj dosieroj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Ĉiuj dosieroj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Ĝustigi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Bonvolu enigi validan entjeron por agordi grupon aŭ lasi la kampon malplena por malgrupigi la ŝablonon!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Ne skalu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7150,204 +7151,204 @@ Tamen se vi ne intencas desegni sur ĉi tiu ŝablono, tio ne estas problemo.</tr
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Dosierformo ne rekonita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Fiaskis ŝargi ŝablonon. Ĉu la dosiero ekzistas kaj ĉu tio estas valida?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Ŝablona importo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mapo -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Treni&lt;/b&gt; por movi la aktualan ŝablonon</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Enpoziciigo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Skalo:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Skalo:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Turnado:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Skalado kaj lokado de la trako</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinatsistemo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Reala</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Mapo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Unu unuo de koordinato egalas:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Pozicii trakon meze de la ekrano</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Malfermo de trako …</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Ŝargi la trakon en georeferencita aŭ negeoreferencita reĝimo?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Tiuj ĉi ankoraŭ ne estas agordita, tial ili estos montrita ĉe la sekva paŝo.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferencita</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Negeoreferencita</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>La vojo estas malplena, estas nenio por importi!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Demando</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Importaj problemoj</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7355,12 +7356,12 @@ Tamen se vi ne intencas desegni sur ĉi tiu ŝablono, tio ne estas problemo.</tr
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Eraro legante</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7369,39 +7370,39 @@ Tamen se vi ne intencas desegni sur ĉi tiu ŝablono, tio ne estas problemo.</tr
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Ne estas OSM-dosiero.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>La OSM-dosiero havas versio %1.
 Minimuma subtenata versio estas %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>La OSM-dosiero havas version %1.
 La maksimuma subtenata versio estas %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemoj</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 nodoj ne povis esti traktita ĝuste.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Ekstera ligilo: %1</translation>
@@ -7412,395 +7413,395 @@ La maksimuma subtenata versio estas %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Alkadrigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Maldekstro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Dekstro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Supra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Bazlinio</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Malsupra</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Tekstaj agordoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Tipara familio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Tipara grado:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Teksta koloro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>grasa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>kursiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>substrekita</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Teksta stilo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Interlinia distanco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Alineinterspaco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Interspaco:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kunŝovo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Teksto de la bildsimbolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Kadraĵo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD-kongruecaj agordoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Koloro de kadraĵo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Larĝo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Ombro</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Maldekstra/Dekstra Deŝovo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Supra/Malsupra Deŝovo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD-kongrueco</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>ŝaltita</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Linia larĝo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Linikoloro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Situo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linio sub alineoj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Distanco de bazlinio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Propraj tabaj pozicioj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Aldoni propran tabon</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Kalkuli</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Fiaskis serĉi la helpdosierojn.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Fiaskis trovi la helpofoliumilon (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Fiaskis lanĉi la helpofoliumilon (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Vidu pli…</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Malnovaj versioj de Mapper ne subtenas plurajn mapopartojn. Por konservi la mapon en kongrueca reĝimo, vi devas kunfandi ĉiujn mapopartojn antaŭe.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Nesubtenata elemento: %1 (linio %2 kolumno %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>nekonata</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Partoj de ĉi tiu dosiero ne estas legebla per tiu versio de Mapper. Minimuma postulata versio: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Eraro ĉe linio %1 kolumno %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Kelkaj nevalidaj simboloj devis esti forigita.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Nekonata eraro</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Nesubtenata aŭ nevalida specifo de georeferencado &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Atendata %1 koloroj, trovita %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Spot-koloro %1 ne trovita dum traktado de %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Atendata %1 simboloj, trovita %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Atendata %1 mapopartoj, trovita %2.</translation>
     </message>

--- a/translations/OpenOrienteering_es.ts
+++ b/translations/OpenOrienteering_es.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es_ES">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Mapa de orientación</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Aplicación para dibujar mapas de orientación</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Acerca de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Este programa es software libre: puede redistribuirlo y/o modificarlo bajo los términos de &lt;a %1&gt;GNU General Public License (GPL), versión&amp;nbsp;3&lt;/a&gt;, tal y como está publicada en la Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Este programa se distribuye con la esperanza de resultar útil, pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Ver la GNU General Public License (GPL), versión&amp;nbsp;3, para &lt;a %1&gt;más detalles&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Todo acerca de licencias, avisos de copyright, condiciones y renuncias de responsabilidad.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Los desarrolladores de OpenOrienteering en orden alfabético:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(iniciador del proyecto)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Software libre para dibujar mapas de orientación</translation>
@@ -54,7 +67,7 @@
         <translation type="vanished">Programadores en orden alfabético:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Gracias a las siguientes personas por su contribución:</translation>
     </message>
@@ -76,203 +89,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Abrir el archivo usado más recientemente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Mostrar consejo del día</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Mostrar los elementos restantes</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Tamaño mínimo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Relleno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Relleno de línea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Patrón de relleno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Línea simple</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Líneas paralelas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Espaciado de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Fila simple</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Intervalo de patrón:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Desplazamiento de patrón:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Desplazamiento de fila:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Filas paralelas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Espaciado de filas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Rotación de relleno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>Ajustable por objeto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Dibujo de objeto en el límite</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Cortar objetos en el límite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Dibujar objetos si el centro está dentro del límite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Dibujar objetos si algún punto esta dentro del límite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Dibujar objeto si todos los puntos están dentro del límite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Configuración de área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Patrón de relleno %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Relleno de línea %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>No se ha seleccionado relleno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Color de área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Desplazamiento de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Color de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Anchura de línea:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Archivo guardado automáticamente</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>% bytes</numerusform>
@@ -280,249 +293,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Archivo guardado por el usuario</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Recuperación de archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>El archivo %1 no se cerró correctamente. En este momento, hay dos versiones:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Guarde el archivo activo para eliminar la versión en conflicto.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Editar color del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Define un color spot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mezcla de colores spot (pantallas y sombreimpresiones):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Eliminación: borra colores más bajos</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Calcular desde colores spot</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Calcular desde color RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Proceso personalizado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cian</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Amarillo</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Negro</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Calcular desde color CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Color RGB personalizado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Escritorio</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Impresión profesional</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- sin nombre -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- ninguno -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Color spot</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Hacer doble-clic en un valor de color para abrir un diálogo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>El mapa contiene símbolos con este color. ¡Si lo borra eliminará el color de esos objetos! ¿Realmente desea hacerlo?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (duplicado)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Duplicar)</translation>
     </message>
@@ -535,300 +548,300 @@
         <translation type="vanished">¡Por favor, escriba un porcentaje de 0% a 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Hacer doble-clic para definir el color</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Clic para seleccionar el nombre y clic otra vez para editar.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Número de partes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Símbolo de línea privado -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Sub-símbolo -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Editar sub-símbolo…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Configuración de combinación</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Cambiar de símbolo público a privado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>¿Tomar el símbolo antiguo como plantilla para el símbolo privado?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Símbolo %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Configurar rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Mostrar rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Ajustar a la rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Elegir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Todas las líneas</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Líneas horizontales</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Líneas verticales</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Alineamiento</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Alinear con norte magnético</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Alinear con norte de rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Alinear con norte verdadero</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Rotación adicional (sentido contrario a las agujas del reloj):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Posicionamiento</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>Metros en el terreno</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>Milímetros en el mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Espaciado horizontal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Espaciado vertical:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Desplazamiento horizontal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Desplazamiento vertical:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Color de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Visualizar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Elegir color de línea de rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origen en: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Origen de coordenadas de papel</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>Origen de coordenadas de proyección</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Clic o arrastrar&lt;/b&gt;: Comenzar a dibujar el agujero. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>¡La línea de división debe terminar en el límite del área!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>¡El comienzo y el final de la línea de división están en diferentes partes del objeto!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>¡El comienzo y el final de la línea de división están en la misma posición!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt; en una línea: Dividir en dos. &lt;b&gt;Arrastre&lt;/b&gt; a lo largo de una línea: Eliminar esta parte de la línea. &lt;b&gt;Clic o arrastre&lt;/b&gt; en un límite de área: Comenzar una línea de división. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>¡La división de agujeros de objetos de área no está soportado todavía!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;:Recortar todo el mapa. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Clic o arrastrar&lt;/b&gt;: Seleccionar los objetos a recortar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Recortar los objetos seleccionados. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>No se pudo abrir el archivo.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>El archivo no es un archivo DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Determinar tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Letra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -842,268 +855,268 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Distribuir puntos uniformemente a lo largo del camino</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Número de puntos por camino:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Situar objetos también en los puntos finales de líneas</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Configuración de rotación</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Alinear puntos con la dirección de la línea</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>º</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Ángulo de rotación adicional (sentido contrario a las agujas del reloj):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translatorcomment>Dibujar un círculo comenzando por el centro</translatorcomment>
         <translation>Desde el centro</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Comenzar un círculo o elipse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Dibujar un círculo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Mantenga pulsado %1 para comenzar a dibujar desde el centro.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Terminar el círculo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Dibujar una elipse. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;:Dibujar un camino. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Puntos discontinuos activado.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: Adjuntar o añadir a objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: Elegir dirección de objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt; 1%1+%2&lt;/b&gt; 2: Ángulo y longitud del segmento. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: Adjuntar a objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ángulos fijos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Deshacer último punto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Finalizar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Ajustar a objetos existentes</translatorcomment>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translatorcomment>Usando ángulos restringidos</translatorcomment>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Dibujando puntos discontinuos</translatorcomment>
         <translation>Discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Longitud:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Comenzar una línea recta. &lt;b&gt;Arrastrar&lt;/b&gt;: Comenzar una curva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Arrastrar&lt;/b&gt;: Continuar objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Dibujar una línea recta. &lt;b&gt;Arrastrar&lt;/b&gt;: Dibujar una curva. &lt;b&gt;Botón derecho o doble-clic&lt;/b&gt;: Finalizar el camino. &lt;b&gt;%1&lt;/b&gt;: Cerrar el camino. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Tocar el mapa para finalizar el promedio</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;:Finalizar de configurar el objeto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Ajustar a objetos existentes</translatorcomment>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translatorcomment>Usando ángulos restringidos</translatorcomment>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translatorcomment>Resetear rotación</translatorcomment>
         <translation>Resetear</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Ángulo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ángulos fijos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Crear un objeto de tipo punto.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Crear un objeto y establecer su orientación.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Resetear rotación.</translation>
     </message>
@@ -1113,79 +1126,79 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Finalizar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Ajustar a objetos existentes</translatorcomment>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translatorcomment>Ajustar a líneas anteriores</translatorcomment>
         <translation>Ajuste de línea</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Dibujando puntos discontinuos</translatorcomment>
         <translation>Discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Clic o arrastar&lt;/b&gt;: Comenzar a dibujar un rectángulo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Anexar a líneas previas. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Poner un punto de esquina. &lt;b&gt;Botón derecho o doble-clic&lt;/b&gt;: Finalizar el rectángulo. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Acoplar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Finalizar la edición. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Cancelar edición. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Crear un objeto de texto con un anclaje simple. &lt;b&gt;Arrastrar&lt;/b&gt;: Crear una caja de texto. </translation>
     </message>
@@ -1195,135 +1208,135 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Ajustar a objetos existentes</translatorcomment>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translatorcomment>Conmutar entre segmento curvo y plano</translatorcomment>
         <translation>Conmutar curva</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Movimiento libre. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; en un segmento: Cambiar entre recta y curva. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Ajustar a objetos existentes</translatorcomment>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translatorcomment>Modificar puntos o usar ángulos restringidos</translatorcomment>
         <translation>Punto / Ángulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translatorcomment>Conmutar puntos discontinuos</translatorcomment>
         <translation>Conmutar discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;:Finalizar edición. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Mantener posiciones del gestor opuestas. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; en punto: Lo borra; en camino: Añadir un nuevo punto discontinuo; con &lt;b&gt;%2&lt;/b&gt;: Añadir un punto normal. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; en punto: Lo borra; en camino: Añadir un nuevo punto; con &lt;b&gt;%2&lt;/b&gt;: Añadir un  nuevo punto discontinuo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; en punto para cambiar entre punto discontinuo o normal. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Desplazamiento de coordenadas:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distancia:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ángulos fijos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Enfocar a objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Seleccionar un objeto. &lt;b&gt;Arrastrar&lt;/b&gt;: Seleccionar múltiples objetos. &lt;b&gt;%1+Clic&lt;/b&gt;: Cambiar selección. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Borrar objetos seleccionados. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Visualización de mapa en alta calidad (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing permite ver un mapa mucho mejor, pero también hace más lenta la visualización</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Visualización de texto en el mapa de alta calidad (antialiasing), lento</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolerancia de pulsación:</translation>
     </message>
@@ -1332,317 +1345,317 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>milímetros</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Distancia de coincidencia (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Paso del modo de ángulo fijo (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>º</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Tamaño del icono del símbolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Cuando se selecciona un objeto, también selecciona automáticamente su símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Alejarse del cursor cuando se hace un zoom hacia afuera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Herramientas de dibujo: establecer último punto al finalizar con clic en botón derecho</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Plantillas: mantener configuración de las plantillas cerradas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Herramienta de edición:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Mantener forma antigua</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Resetear gestores de curva exteriores</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Mantener gestores de curva exteriores</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Acción al borrar un punto de curva con %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Herramienta rectángulo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Radio de la cruz de ayuda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Vista previa de la anchura de las líneas con la cruz de ayuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>No se pudo crear el nuevo archivo: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>El formato (%1) no se puede exportar</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>El área del mapa es grande. El uso de la herramienta de relleno puede ser muy lento. ¿Quiere usarlo de todos modos?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>El área seleccionada no está limitada por líneas o áreas, no se puede rellenar este área.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>La posición seleccionada no está libre, no se puede usar la herramienta de relleno aquí.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Falló la creación del objeto de relleno.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Rellenar área con símbolo activo. El área a rellenar debe estar limitado por líneas o áreas, otros símbolos no se tienen en cuenta. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>El GPS está deshabilitado en la configuración del dispositivo. ¿Abrir configuración ahora?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>No</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importar con GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parámetro</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Apariencia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Idioma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Pantalla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Píxeles por pulgada:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Arranque del programa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Guardando archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Mantener compatibilidad con Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Guardar el historial de deshacer/rehacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Guardar información para recuperación automática</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervalo de grabación de información de recuperación:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translatorcomment>unidad minutos</translatorcomment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Importación y exportación de archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>Codificación de 8 bits:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Más...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Usar el nuevo importador de OCD también para archivos de la versión 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>¡El programa se tiene que reiniciar para que el cambio de idioma tenga efecto!</translation>
     </message>
@@ -1651,47 +1664,47 @@
         <translation type="vanished">Usar archivo de traducción...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Abrir traducción</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Archivos de traducción (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>El archivo seleccionado no es una traducción válida.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Resolución principal de pantalla en pixels:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Tamaño principal de pantalla en pulgadas (diagonal):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Coordenadas UTM</translation>
     </message>
@@ -1700,80 +1713,80 @@
         <translation type="vanished">Zona UTM (número norte/sur, por ej. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>Zona UTM (número norte/sur)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Coordenadas Gauss-Krueger</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Número de zona (1 a 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>Por código EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>Coordenadas de EPSG @code@</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Coordenadas locales</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Código EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>PROJ.4 personalizado</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Especificación</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>La especificación de escala de mapa no es válida o falta.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Factor de escala de rejilla no válido: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Idioma de especificación CRS desconocido: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Especificación CRS geográfica no soportada: %1</translation>
     </message>
@@ -1782,7 +1795,7 @@
         <translation type="vanished">Escala sólo</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
@@ -1792,73 +1805,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georreferenciación de mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Declinación:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Coordenadas de proyección</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Factor de escala de rejilla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Coordenadas geográficas</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Mostrar punto de referencia en:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>válido</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Buscar declinación online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Sistema de coordenadas de referencia del mapa</translation>
     </message>
@@ -1871,7 +1884,7 @@
         <translation type="vanished">- de la especificación Proj.4 -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- local -</translation>
     </message>
@@ -1880,113 +1893,113 @@
         <translation type="vanished">Especificación CRS:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Punto de referencia</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Picar en el mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>º</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Norte del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>Sistema de &amp;Coordenadas de referencia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Coordenadas del mapa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Coordenadas geográficas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Ante cambios de CRS, mantener:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translatorcomment>Grivation es &quot;grid variation&quot;, diferencia entre el norte de la rejilla y el norte magnético</translatorcomment>
         <translation>Variación de rejilla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>La declinación magnética del punto de referencia %1° %2° se va a buscar en &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. ¿Quiere continuar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Cambio de declinación</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>La declinación ha cambiado. ¿Quiere rotar el contenido del mapa de acuerdo a ese cambio?</translation>
     </message>
@@ -1995,66 +2008,66 @@
         <translation type="vanished">Coordenadas de proyección:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Coordenadas locales:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Cargando...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>bloqueado</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Imposible analizar los datos.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>El valor de declinación no se ha encontrado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>La búsqueda online de la declinación ha fallado:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 º</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Clic&lt;/b&gt;: Poner el punto de referencia. Otro botón para cancelar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Poner el punto de referencia. &lt;b&gt;Clic en botón derecho&lt;/b&gt;: Cancelar.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>¡Bienvenido a OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Activities</source>
         <translation type="vanished">Actividades</translation>
@@ -2118,91 +2131,91 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Actividades</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Crear un mapa nuevo...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Abrir mapa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translatorcomment>Como en Acerca de OpenOrienteering Mapper&apos;</translatorcomment>
         <translation>Acerca de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Mapas recientes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Abrir el archivo usado más recientemente al arrancar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Limpiar lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Consejo del día</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Mostrar consejo del día</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Ejemplos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Acerca de Mapper</translation>
     </message>
@@ -2211,12 +2224,12 @@
         <translation type="vanished">Acerca de Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Lista de archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>¡No se han encontrado archivos de mapas!&lt;br/&gt;&lt;br/&gt;Copie los archivos de mapas en una carpeta de primer nivel llamada &apos;OOMapper&apos; en el almacenamiento del dispositivo o en la tarjeta de memoria.</translation>
     </message>
@@ -2226,19 +2239,19 @@
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Error al cargar un símbolo del tipo %1 en la línea %2 columna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>ID del símbolo &apos;%1&apos; no es único en la línea %2 columna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Error al cargar un símbolo del tipo %1 en la línea %2 columna %3: %4</translation>
     </message>
@@ -2247,38 +2260,38 @@
         <translation type="vanished">Error cargando un símbolo.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Error cargando un objeto del tipo %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Error cargando un objeto de tipo %1 en %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Imposible encontrar símbolo para el objeto en %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Objeto de tipo punto con símbolo no definido o erróneo en %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versiones 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2287,48 +2300,48 @@
         <translation type="vanished">Imposible analizar los datos.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Imposible analizar las coordenadas.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Se esperaban %1 coordenadas, se encontraron %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Error al cargar la configuración de impresión en %1: %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Error al cargar los pasos de deshacer/rehacer en %1: %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>No existe la opción: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Datos vectoriales geoespaciales</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Se ha encontrado un objeto sin símbolo.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Eliminado %n objeto anómalo.</numerusform>
@@ -2336,36 +2349,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Error durante el post-proceso de símbolos.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>La plantilla &quot;%1&quot; se ha cargado desde el directorio del mapa en lugar de la ubicación relativa al archivo del mapa donde estaba anteriormente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Falló la carga de la plantilla &apos;%1&apos;, causa: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Avisos durante la carga de la plantilla &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Al menos un archivo de plantilla no se ha podido encontrar.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Haga clic sobre el nombre(s) de plantilla en rojo en la ventana Plantillas -&gt; Configuración de plantilla, para localizar el nombre del archivo de la plantilla.</translation>
     </message>
@@ -2374,173 +2387,173 @@
         <translation type="vanished">Al menos un archivo de plantilla no se ha encontrado. Haga clic en el nombre de plantilla en rojo en la ventana Plantillas -&gt; Configuración de plantilla, para localizar el nombre del archivo de plantilla.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Este archivo utiliza un formato obsoleto. Próximamente este formato no estará soportado en este programa. Para poder abrir el archivo en el futuro, guárdelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Versión no válida de formato de archivo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Versión antigua de formato de archivo no soportada. Por favor, utilice una versión más antigua del programa para cargar y actualizar el archivo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Versión moderna de formato de archivo no soportada. Algunas características del mapa no se podrán cargar o guardar con esta versión del programa. Considere una actualización.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>El sistema de coordenadas geográficas de referencia del mapa era &quot;%1&quot;. Este CRS no está soportado. Se usa &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Error cargando un símbolo de tipo %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Error cargando un símbolo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Error cargando los pasos para deshacer acciones.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Error leyendo el contador de partes del mapa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Error cargando parte del mapa %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>No se pudo leer el archivo: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Formato de archivo no soportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Versión moderna de formato de archivo no soportada. Algunas características del mapa no se podrán cargar o guardar con esta versión del programa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>El formato (%1) no se puede exportar</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>No se puede leer &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Configuración de línea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Anchura de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Color de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Longitud mínima de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Extremo de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>plano</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>redondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>cuadrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>punteado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Unión de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>inglete</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>biselado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Longitud del extremo:</translation>
     </message>
@@ -2550,334 +2563,335 @@
         <translation>La línea es discontínua</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Mostrar al menos un símbolo intermedio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Cuenta mínima de símbolo intermedio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Cuenta mínima de símbolo intermedio cuando está cerrado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Longitud de la discontinuidad:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Línea discontinua</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Longitud de ruptura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Discontinuidades agrupadas juntas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>ninguno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Longitud de ruptura en-grupo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Semilongitud de la primera y última discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Símbolos intermedios</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Símbolos intermedios por spot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Distancia de símbolo intermedio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Bordes</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Bordes diferentes en los extremos izquierdo y derecho</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Borde izquierdo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Borde derecho:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Símbolo de comienzo</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Símbolo intermedio</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Símbolo final</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Símbolo de discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Habilitar líneas de borde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Distancia entre spots:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Distancia desde el final de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Suprimir el símbolo de discontinuidad en los extremos inicial y final</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Escalar el símbolo de discontinuidad en las esquinas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Anchura de borde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Color de borde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Desplazamiento de borde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>El borde es discontinuo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Longitud de discontinuidad del borde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Longitud de ruptura del borde:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Crea un mapa nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Abrir un archivo existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Abrir &amp;reciente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Guardar &amp;como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+May+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Configuración...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Cerrar este archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Sale de la aplicación</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Abrir &amp;Manual</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Mostrar el archivo de ayuda de esta aplicación</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Acerca de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Muestra informacióón acerca de este programa</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Muestra información acerca de Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>Ay&amp;uda</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>¿Quiere eliminar la versión guardada automáticamente?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>El archivo se ha modificado.
 ¿Quiere guardar sus cambios?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Archivo no guardado</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2886,12 +2900,12 @@ Do you want to scale the symbols to the selected scale?</source>
 ¿Quiere cambiar la escala de los símbolos a la escala seleccionada?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Aviso de accidente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Parece que %1 ha fallado la última vez que se abrió este archivo:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;¿Realmente quiere intentar abrirlo de nuevo?</translation>
     </message>
@@ -2904,50 +2918,50 @@ Do you want to scale the symbols to the selected scale?</source>
         <translation type="vanished">Hay una versión guardada automáticamente de &lt;br /&gt;&lt;tt&gt;%1&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;¿Cargar esta versión?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Grabación automática...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>¡Falló la grabación automática!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Todos los mapas</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Todos los archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Debe cerrar el archivo actual para poder abrir otro distinto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Abriendo %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2958,19 +2972,19 @@ File format not recognized.</source>
 Formato de archivo no reconocido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>El archivo se ha modificado.
 ¿Quiere descartar sus cambios?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2981,44 +2995,44 @@ Pulse Sí para guardar en este formato.
 Pulse No para seleccionar un formato diferente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>El archivo no se ha podido guardar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Ha habido un problema tratando de averiguar el formato de archivo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Por favor, informe de esto como un error.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3027,7 +3041,7 @@ because saving as %2 (.%3) is not supported.</source>
 porque la grabación como %2 (.%3) no está soportada.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3042,31 +3056,31 @@ porque el formato es desconocido.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>La exportación del mapa generó avisos.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Error interno al grabar:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>La importación del mapa generó avisos.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3075,12 +3089,12 @@ for reading.</source>
 para lectura.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Tipo de archivo no válido.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3091,7 +3105,7 @@ para lectura.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3100,17 +3114,17 @@ para lectura.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nada que importar.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Pregunta</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3119,23 +3133,23 @@ Rescale the imported data?</source>
 ¿Reescalar los datos importados?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Parte por defecto</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nuevo color</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Se canceló el remplazo de símbolos.
@@ -3143,305 +3157,305 @@ Import the data anyway?</source>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Registro negro (todos los colores impresos)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Las coordenadas están fuera de los límites.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Deshace el último paso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Rehace el último paso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Cor&amp;tar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>C&amp;opiar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Pegar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Intercambiar a modo de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Establecer factor de zoom personalizado...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Ventana de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Muestra/Oculta la ventana de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Ventana de colores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Muestra/Oculta la ventana de colores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Reemplazar los símbolos con los de otro archivo de mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Escalar todos los símbolos...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Escala todo el conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Cambiar escala del mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Cambia la escala del mapa y ajusta los objetos del mapa y los tamaños de los símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Notas del mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Ventana de configuración de plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Muestra/Oculta la ventana de plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Abrir plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Mostrar todo el mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>No seleccionar nada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Invertir selección</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Nombre del conjunto de símbolos...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Editar el nombre del conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Cargar fichero CRT...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Asignar nuevos símbolos con tabla de referencia</translation>
     </message>
@@ -3454,57 +3468,57 @@ Import the data anyway?</source>
         <translation type="vanished">Mostrar/Ocultar la ventana de selección de pestañas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Editar objetos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Dibujar objetos de tipo punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Dibujar líneas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Dibujar círculos y elipses</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Escribir texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Cambiar símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Rellenar / Crear borde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Cambiar dirección de la discontinuidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Conectar caminos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Cortar objeto</translation>
     </message>
@@ -3513,67 +3527,67 @@ Import the data anyway?</source>
         <translation type="vanished">Rotar objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Medir longitudes y áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Cortar el interior desde el área</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Fusionar agujeros del área</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Configuración para pintar en plantilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Habilitar cursor táctil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Habilitar visualización de GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Habilitar círculos de distancia GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Situar objeto de tipo punto en la posición del GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Situar una marca temporal en la posición del GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Crear un camino temporal en la posición del GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Limpiar marcas temporales de GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Habilitar visualización de brújula</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Alinear mapa con el norte</translation>
     </message>
@@ -3582,189 +3596,189 @@ Import the data anyway?</source>
         <translation type="vanished">Conmutar visibilidad de plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Añadir nueva parte...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Renombrar parte actual...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Eliminar parte actual</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Fuscionar todas las partes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Herramientas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Sí&amp;mbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>M&amp;apa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Pintar sobre plantilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Edición en progreso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>El mapa se está editando actualmente. Por favor, finalice la operación de edición antes de grabar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Mapa guardado</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Mostrar rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Configurar rejilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Entramar áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Vista de línea de base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Ocultar todas las plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Reemplazar conjunto de símbolos...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georreferenciación...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Rotar mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Rota todo el mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Reabrir plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Editor de etiquetas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Mostrar/Ocultar la ventana del editor de etiquetas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Dibujar rectángulos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Dibujar a mano alzada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Rellenar áreas con límites</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Cortar agujero con forma libre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Cortar agujero redondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Cortar agujero rectangular</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Rotar patrón</translation>
     </message>
@@ -3773,12 +3787,12 @@ Import the data anyway?</source>
         <translation type="vanished">Escalar objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Unificar áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Intersecar áreas</translation>
     </message>
@@ -3787,52 +3801,52 @@ Import the data anyway?</source>
         <translation type="vanished">Diferencia de áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Operación XOr sobre áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Cortar el interior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Distribuir puntos a lo largo del camino</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Coordenadas de mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Coordenadas de proyección</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Latitud/Longitud (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Latitud/Longitud (GMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Ver coordenadas como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Cortar agujero</translation>
     </message>
@@ -3841,71 +3855,71 @@ Import the data anyway?</source>
         <translation type="vanished">Dummy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Partes del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Seleccionar plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Edición</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Edición avanzada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Seleccionar símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Ocultar barra superior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Mostrar barra superior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>¡Imprimir / Exportar no está disponible en esta versión del programa!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>No hay acciones disponibles para deshacer.</translation>
     </message>
@@ -3915,8 +3929,8 @@ Import the data anyway?</source>
         <translation type="vanished">Cortar %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>¡Ha ocurrido un error interno, lo sentimos!</translation>
     </message>
@@ -3925,7 +3939,7 @@ Import the data anyway?</source>
         <translation type="vanished">Copiado(s) %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>¡No hay objetos para pegar en el portapapeles!</translation>
     </message>
@@ -3934,67 +3948,67 @@ Import the data anyway?</source>
         <translation type="vanished">Pegado(s) %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Establecer factor de zoom personalizado</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Factor de zoom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Nombre del conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Editar el conjunto de símbolos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Escalar todos los símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Escalar según porcentaje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Notas del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Editor de etiquetas</translation>
     </message>
@@ -4003,7 +4017,7 @@ Import the data anyway?</source>
         <translation type="vanished">Selector de pestañas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4013,7 +4027,7 @@ símb.
 selecc</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4023,41 +4037,41 @@ símb.
 selecc</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Sitúa objetos de tipo punto en el mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Seleccione un símbolo de tipo punto para poder usar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Dibuja líneas poligonales y curvas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Seleccione una línea, área o símbolo combinado para poder usar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Dibuja círculos y elipses.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Dibujar caminos a mano alzada.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Rellenar áreas con límites.</translation>
     </message>
@@ -4066,109 +4080,109 @@ selecc</translation>
         <translation type="vanished">Borra los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Establece la dirección de patrones de relleno de áreas u objetos de tipo punto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Seleccione un objeto de tipo área con un patrón de relleno rotable o un objeto de tipo punto rotable para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Símbolo resultante: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Seleccione al menos dos objetos de área o camino para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Unificar objetos que se solapan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Eliminar todas las partes que no se solapen con el primer objeto seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Eliminar partes solapadas del primer objeto seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Eliminar todas las partes que se solapen con el primer objeto seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Fusionar agujeros de área juntos, o fusionar agujeros con el límite del objeto para cortar esta parte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Seleccionar un objeto de área con agujeros para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Crea un recorte de algunos objetos o de todo el mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Seleccione un objeto con camino cerrado como forma de recorte para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Corte interior a un área delimitada de algunos o todos los objetos en ella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Sitúa objetos de tipo punto espaciados de forma uniforme a lo largo de un objeto de camino existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Seleccione al menos un objeto de camino y un símbolo de punto para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Falló la fusión de agujeros.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Limpiar marcas temporales</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>¿Está seguro de que quiere borrar todas las marcas de GPS temporales? Esta acción no se puede deshacer.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Fusionar esta parte con</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Mover objetos seleccionados a</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Escriba el nombre de la parte del mapa:</translation>
     </message>
@@ -4177,103 +4191,103 @@ selecc</translation>
         <translation type="vanished">¿Quiere eliminar la parte de mapa &quot;%1&quot; y todos sus objetos? Esta acción no se puede deshacer.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Fusionar partes de mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>¿Quiere mover todos los objetos de la parte de mapa &quot;%1&quot; a &quot;%2&quot;, y eliminar &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>¿Quiere mover todos los objetos de la parte de mapa &quot;%1&quot;, y eliminar todas las otras partes de mapa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>No se puede importar el archivo de mapa seleccionado porque no se pudo cargar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Dibuja rectángulos.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Imprimir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Imagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Limpiar historial de deshacer / rehacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Limpiar el historial de deshacer / rehacer para reducir el tamaño del archivo del mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulación de sobreimpresión</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Editar líneas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Convertir a curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Simplificar camino</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Copiar la posición</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Copiar la posición al portapapeles.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exportar como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Escribe texto en el mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Seleccione un símbolo de texto para poder usar esta herramienta.</translation>
     </message>
@@ -4282,26 +4296,26 @@ selecc</translation>
         <translation type="vanished">Duplica los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Seleccione al menos un objeto para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Cambia la dirección de los símbolos en objetos lineales.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Seleccione al menos un objeto lineal para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Conecta puntos finales de líneas que están suficientemente juntas.</translation>
     </message>
@@ -4310,17 +4324,17 @@ selecc</translation>
         <translation type="vanished">Corta los objetos seleccionados en partes más pequeñas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Seleccione al menos un objeto lineal o de tipo área para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Corta un agujero en el objeto de área seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Seleccione un único objeto de tipo área para activar esta herramienta.</translation>
     </message>
@@ -4357,18 +4371,18 @@ selecc</translation>
         <translation type="vanished">Calcula las partes no superpuestas de áreas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Convierte líneas hechas con segmentos rectos en curvas bezier suavizadas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Seleccione un objeto lineal para activar esta herramienta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Reduce el número de puntos en objetos lineales intentando mantener su forma.</translation>
     </message>
@@ -4377,8 +4391,8 @@ selecc</translation>
         <translation type="vanished">Cambia el símbolo de los objetos seleccionados al símbolo seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Seleccione al menos un objeto y un símbolo diferente apropiado para activar esta herramienta.</translation>
     </message>
@@ -4391,7 +4405,7 @@ selecc</translation>
         <translation type="vanished">%1 objeto(s) duplicado(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Selección de objetos</translation>
     </message>
@@ -4400,82 +4414,82 @@ selecc</translation>
         <translation type="vanished">No se han seleccionado objetos porque no hay objetos que tengan el símbolo seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Medir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Falló la unificación.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Falló la intersección.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Falló la resta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Falló el XOr.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>¿Quiere eliminar la parte del mapa &quot;%1&quot; y todos sus objetos?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Cambiado a la parte del mapa &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Pintar a mano alzada sobre una plantilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Pintar a mano alzada sobre una plantilla. Cree o cargue una plantilla en la que se pueda dibujar para activar este botón</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importar %1, archivo GPX, OSM o DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Archivos importables</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Todos los archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>No se puede importar el archivo seleccionado porque su formato no está soportado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Rotar objetos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Escalar objetos</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4484,7 +4498,7 @@ selecc</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>%n objeto(s) cortado(s)</numerusform>
@@ -4492,7 +4506,7 @@ selecc</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>%n objeto(s) pegado(s)</numerusform>
@@ -4500,42 +4514,42 @@ selecc</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Elimina los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Duplicar los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Rotar los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Escalar los objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Cortar los objetos seleccionados en partes de menor tamaño.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Cambia el símbolo de los objetos seleccionados al nuevo símbolo seleccionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Rellenar las líneas seleccionadas o crear un borde para las áreas seleccionadas.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>%n objeto(s) duplicado(s)</numerusform>
@@ -4543,178 +4557,178 @@ selecc</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>No se seleccionó ningún objeto porque no hay ningún objeto con los símbolos seleccionados.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Abortar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Más: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Más: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Más: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Encontrar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Encontrar &amp;siguiente</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Encontrar objetos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Encontrar siguiente</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Encontrar &amp;todo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Procesando separaciones de la página %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Procesando la página %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Cancelado</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Finalizado</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Texto fuente:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Mapa (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>lenguaje no definido</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Traducción (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Antes de editar, el texto almacenado será remplazado con la traducción actual. ¿Desea continuar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Después de modificar el texto almacenado, es posible que la traducción no se pueda encontrar. ¿Desea continuar?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4729,7 +4743,7 @@ abrir el cuadro de diálogo de color y
 defina los colores allí.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4744,7 +4758,7 @@ y seleccione &quot;Símbolo nuevo&quot;
 para crear uno.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4757,7 +4771,7 @@ Para cargar un mapa base, haga clic en
 Plantillas -&gt; Abrir plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Consejo: Mantenga pulsado el botón central del ratón para arrastrar el mapa,
@@ -4765,123 +4779,123 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Longitud del perímetro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>No se han seleccionado objetos.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objetos seleccionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>El objeto seleccionado no es una línea.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Este objeto es muy pequeño.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>El área mínima es %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Nota: la longitud y área del perímetro son correctas sólo si no hay auto-intersecciones y los agujeros se usan como tales.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>La línea es demasiado corta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>La longitud mínima es %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Crear mapa nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Seleccione la escala y conjunto de símbolos para el nuevo mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Escala:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Conjuntos de símbolos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Mostrar sólo los conjuntos de símbolos con escala coincidente</translation>
     </message>
@@ -4890,140 +4904,140 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         <translation type="vanished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Crear</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Conjunto de símbolos vacío</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Cargar conjunto de símbolos desde un archivo...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Todos los archivos de conjuntos de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Todos los archivos</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>El mapa contiene más de 256 colores, lo cual no está soportado por ocd versión 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad devolvió %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Registro negro es exportado como un color regular.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Imposible exportar el desplazamiento de patrón de relleno para un objeto de tipo área</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Imposible exportar plantilla: el tipo de archivo &quot;%1&quot; no está soportado todavía</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>La coordenadas se ajustan para caber dentro del área de dibujo OCAD 8 (-2 m ... 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Algunas coordenadas permanecen fuera del área de dibujo OCAD 8. Puede que no sean alcanzables en OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>En símbolo de línea &quot;%1&quot;, no se puede representar la combinación tapar/unir.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>En símbolo de línea &quot;%1&quot;, descuidar la agrupación de discontinuidades.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>En símbolo de línea &quot;%1&quot;, el número de discontinuidades en un grupo se ha reducido a 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>En símbolo de línea &quot;%1&quot;, no se pueden exportar los bordes correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>En símbolo de área &quot;%1&quot;, saltarse un patrón de relleno.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>En símbolo de área &quot;%1&quot;, se asume un patrón de punto de &quot;filas desplazadas&quot;. Esto puede ser tanto correcto como incorrecto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>En símbolo de texto &quot;%1&quot;: se ha establecido un espaciado de carácter personalizado, su implementación no coincide con el comportamiento de OCAD todavía</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>En símbolo de texto &quot;%1&quot;: se ignora subrayado</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>En símbolo de texto &quot;%1&quot;: se ignora kerning</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Cadena truncada (el truncamiento se marca con 3 &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>No se ha podido reservar un buffer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad devolvió %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>¡Los archivos OCAD de la versión %1 no están soportados!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n separación de color fue omitida, motivo: importación deshabilitada.</numerusform>
@@ -5031,97 +5045,97 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>No se pudo cargar la definición de colores spot, error: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Color &quot;Registro negro&quot; se importa como un color especial.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Imposible importar el símbolo &quot;%3&quot; (&quot;%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Capa de importación OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>En el símbolo de línea discontinua %1, las longitudes de extremo punteado para el comienzo y el final son diferentes (%2 y %3). Se usa %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>En el símbolo de línea discontinua %1, la longitud del final no se puede importar correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>En el símbolo de línea discontinua %1, el espacio final no se puede importar correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>En el símbolo de línea discontinua %1, las longitudes principal y final son diferentes (%2 y %3). Se usa %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>En el símbolo de línea discontinua %1, los espacios D y E son diferentes (%2 y %3). Se usa %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Símbolo de línea %1: se suprime el símbolo de discontinuidad en los extremos de la línea.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Durante la importación del símbolo de texto %1: se ignora el alineamiento justificado</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Durante la importación del símbolo de texto %1: se ignora el peso personalizado (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Durante la importación del símbolo de texto %1: se ha establecido un espaciado de carácter personalizado, su implementación todavía no coincide con el comportamiento de OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Durante la importación del símbolo de texto %1: se ignora el espaciado de palabra personalizado (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Durante la importación del símbolo de texto %1: se ignora la sangría personalizada (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Durante la importación del símbolo de texto %1: se ignora el encuadre de texto (modo %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Imposible cargar objeto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>No se puede importar el objeto rectángulo</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>No se importa el símbolo de texto, al no conocer el path&apos; (npts=%1): %2</translation>
     </message>
@@ -5130,239 +5144,239 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         <translation type="obsolete">Imposible importar plantilla: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Imposible importar plantilla: el fondo &quot;%1&quot; no parece ser una imagen raster</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Intentando importar un objeto de texto con un formato de coordenadas desconocido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Id de color no encontrado: %1, se ignora este color</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>es</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>no es</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>contiene</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Texto</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>y</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>o</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Símbolo</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>inválido</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>En símbolo de línea %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>En símbolo de texto %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>No se pudo cargar el sistema de coordenadas de referencia &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Se ha ignorado la información de color spot.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Imposible importar símbolo %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Tipo no soportado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Imposible importar plantilla: &quot;%1&quot; no es un tipo de plantilla soportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Estilo de línea no soportado &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Longitudes diferentes para extremos puntiagudos a comienzo (%1 mm) y fin (%2 mm) no están soportadas. Se usa %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>El patrón de discontinuidad no se puede importar correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>La longitud final (%1 mm) del patrón de discontinuidad no se puede importar correctamente. Se usa %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>El espaciado final del patrón de discontinuidad (%1 mm) no se puede importar correctamente. Se usa %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Estilo de encuadre de línea no soportado &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Se omitió el símbolo de punto secundario.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Suprimiendo el símbolo de discontinuidad en los extremos de la línea.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Este símbolo no se puede guardar como un símbolo OCD correcto otra vez.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Alineamiento justificado no está soportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Alineamiento vertical &apos;%1&apos; no está soportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ignorando peso personsalizado (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>El espaciado de caracteres personalizado puede ser incorrecto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ignorando espaciado de palabras personalizado (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ignorando indentación personalizada (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ignorando encuadre de texto (modo %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Símbolos de texto en línea no están soportados todavía. Se marca el símbolo como oculto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>La codificación &apos;%1&apos; no está disponible. Compruebe la configuración.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>En el símbolo de área %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Imposible cargar objeto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Imposible importar objeto rectangular</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>No se importa el símbolo de texto, al no conocer el path&apos; (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Intentando importar un objeto de texto con un formato de coordenadas desconocido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Datos no válidos.</translation>
     </message>
@@ -5371,59 +5385,59 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         <translation type="vanished">Importador de archivos no testeado para el formato: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>¡Archivos OCD de versión %1 no están soportados!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Código de color no encontrado: %1, se ignora este color</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>No se puede establecer &quot;%1&quot; SRS para GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Púrpura</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Imposible cargar capa %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>No se puede cargar %n objeto, razón: %1</numerusform>
@@ -5431,438 +5445,425 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Geometría vacía.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>No se puede determinar la transformación de coordenadas: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Fallo al transformar las coordenadas.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Tipo de geometría desconocida o no soportada.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Coordenadas insuficientes.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>No se puede usar esta referencia espacial:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>La información geoespacial no tienen una referencia espacial apropiada.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Mapa de orientación</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Aplicación para dibujar mapas de orientación</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Seleccione la plantilla sobre la que va a dibujar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Dibujar</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Clic y arrastrar&lt;/b&gt;: Pintar. &lt;b&gt;Clic en botón derecho y arrastrar&lt;/b&gt;: Borrar. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Selección de color</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover el mapa. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Añadir una coordenada. &lt;b&gt;%1+Clic&lt;/b&gt;: Cambiar la coordenada seleccionada. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Siempre orientado al norte (no rotable)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centrar todos los elementos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Elemento actual</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diámetro &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Color interno:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Anchura externa &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Color externo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Anchura de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Color de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Extremo de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>plano</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>redondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>cuadrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Unión de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>inglete</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>biselado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Línea cerrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Color de área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Coordenadas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Comienzo de curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centrar por media de coordenadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Punto medio]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Símbolo de punto</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Imprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Error durante el procesamiento.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Arrastrar&lt;/b&gt;: Mover el área de impresión o sus bordes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;:Mover el mapa, el área de impresión o los bordes del área. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover el área de impresión. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover el mapa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover el borde del área de impresión. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover los bordes del área de impresión. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Exportar a PDF o PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Mostrar plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Mostrar rejilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientación de página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Impresora:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Vertical</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Apaisado</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Formato de página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Copias:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Izquierdo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Superior:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Vista previa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Página individual</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Área personalizada</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Área de mapa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centrar el área de impresión</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Superposición de página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
@@ -5875,226 +5876,226 @@ zoom usando la rueda del ratón, si dispone de esos elementos.</translation>
         <translation type="vanished">Separaciones de color</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Resolución:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Imprimir en una escala diferente:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>La apariencia de la plantilla puede variar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simular sobreimpresión</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>CMYK de dispositivo (experimental)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Modo de color:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exportar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Exportación a PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Exportación a Imagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Guardar como PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>ppp</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>No soportado en Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Falló la preparación de la vista previa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Progreso de la vista previa de impresión</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Está activado un modo de visualización no estándar. ¿Está seguro de imprimir / exportar el mapa de esta forma?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Falló la preparación de la exportación a PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Error durante la impresión.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Exportar mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Falló la preparación de la impresión.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Progreso de impresión</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Gráficos
 vectoriales</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Gráficos
 raster</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Separaciones
 de color</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Falló la preparación de la imagen. No hay memoria suficiente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Fallo al guardar la imagen. ¿Existe la ruta y tiene suficientes permisos?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Exportado con éxito en %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Falló la finalización de la exportación a PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Cancelado.</translation>
     </message>
@@ -6103,176 +6104,176 @@ de color</translation>
         <translation type="vanished">Imprimiendo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>El trabajo de impresión no se pudo parar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Trabajo de impresión creado con éxito</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>El área del mapa está vacía. Salida cancelada.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">Sistema de &amp;Coordenadas de referencia:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Reabrir plantilla</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Arrastre elementos de la lista de la izquierda al lugar deseado de la lista de la derecha para recargarlos.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Plantillas cerradas:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Limpiar lista</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Plantillas activas:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Reemplazar conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Configurar el modo en que los símbolos han de ser reemplazados, y cuáles.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importar todos los símbolos nuevos, incluso si no se han usado como reemplazo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Borrar símbolos originales que no se han usado después del reemplazo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Borrar colores no usados después del reemplazo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Mapeo de símbolos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Mantener los estados de los símbolos oculto / protegido del conjunto de símbolos antiguo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Emparejar símbolos a reemplazar por número de símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Editar el conjunto de símbolos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Reemplazo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Relacionar por nombre de símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Asignar nueva simbología</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Patrón</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Limpiar sustituciones</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Abrir archivo CRT...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Guardar archivo CRT...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Mapear símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>Archivo CRT</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Hay múltiples substitutos para el símbolo %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6283,7 +6284,7 @@ de color</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6294,280 +6295,280 @@ de color</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>La tabla de referencia ha sido modificada.
 ¿Quieres guardar los cambios?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Ninguno -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Seleccionar un archivo de mapa desde el que cargar los símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>No se puede cargar el archivo de mapa, cancelando.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>El conjunto de símbolos seleccionado tiene una escala de 1:%1, mientras que la escala del mapa es:%2. ¿Realmente quiere seleccionar ese conjunto?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>No se puede cargar el archivo CRT, cancelando.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Rotar mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Ángulo (sentido contrario a las agujas del reloj):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>º</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Configuración de rotación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotar alrededor de:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Origen del sistema de coordenadas del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Punto de referencia de la georreferenciación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Otro punto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajustar punto de referencia de la georreferenciación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Ajustar declinación de la georreferenciación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Rotar plantillas no georreferenciadas</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Ángulo:&lt;/b&gt; %1º </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ángulos fijos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Configurar la dirección de los patrones de relleno de áreas u objetos de tipo punto. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotación:&lt;/b&gt; %1º </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ángulos fijos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Configurar el centro de rotación. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Rotar los objetos seleccionados. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Cambiar escala del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Configuración de escalado</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Escala nueva:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Centro de escalado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Origen del sistema de coordenadas del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Punto de referencia de la georreferenciación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Otro punto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Escalar tamaños de símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Escalar posiciones de los objetos del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajustar punto de referencia de la georreferenciación</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Escalar plantillas no georreferenciadas</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Escalando:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Establecer el centro de escalado. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Escalar los objetos seleccionados. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Seleccionar sistema de coordenadas de referencia</translation>
     </message>
@@ -6576,17 +6577,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">El mismo que el del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>El mismo que el del mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Coordenadas geográficas (WGS84)</translation>
     </message>
@@ -6607,175 +6608,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">Especificación CRS:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>válido</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; está almacenado en una ubicación válida.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; está ubicado en el almacenamiento de la aplicación. Los archivos se eliminarán cuando la aplicación se desinstale.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>No se puede sobrescribir &apos;%1&apos;. Los cambios no se pueden guardar.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; no es una ruta de almacenamiento válida.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- ninguno -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Ninguno -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Número:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Descripción:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Símbolo de ayuda (no se muestra en el mapa final)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Para símbolos que tienen descripción, pulse F11 mientras la herramienta es visible para mostrarla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Símbolo nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Combinado</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Escalar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
@@ -6788,12 +6789,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Rellenar / Crear borde del (de los) objeto(s) seleccionado(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Seleccionar símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Habilitar arrastrar y soltar</translation>
     </message>
@@ -6802,108 +6803,108 @@ Do you want to save your changes?</source>
         <translation type="vanished">Escalar símbolo(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Ha ocurrido un error interno, ¡lo sentimos!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>¡No hay símbolos en el portapapeles que se puedan pegar!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Seleccionar todos los objetos con este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Añadir todos los objetos con este símbolo a la selección</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Eliminar de la selección todos los objetos con este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Ocultar objetos con este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Proteger objetos con este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Añadir todos los objetos de los símbolos seleccionados a la selección</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Eliminar de la selección todos los objetos de símbolos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Ocultar objetos de los símbolos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Proteger objetos de los símbolos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Invertir selección</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Seleccionar no usados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Ordenar símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Ordenar por número</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Ordenar por color primario</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Ordenar por prioridad de color primario</translation>
     </message>
@@ -6912,91 +6913,91 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Escalar símbolo %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Escalar a porcentaje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>El mapa contiene objetos con el símbolo &quot;%1&quot;. ¡Si los borra, eliminará esos objetos y limpiará el historial para deshacer cambios! ¿Realmente quiere hacerlo?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Seleccionar todos los objetos de los símbolos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Cambiar el símbolo de los objetos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Rellenar / Crear borde para los objetos seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Escalar símbolos</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Configuración de símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Plantilla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Plantilla:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(ninguno)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centrar plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>recuadro de límites en origen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>centro de gravedad en origen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Seleccionar color de fondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -7007,58 +7008,58 @@ para saltar sobre el perro perezoso
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- sin nombre -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>¡No hay descripción!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Relación</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Clave</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Comparación</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Añadir fila</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Eliminar fila</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
@@ -7071,7 +7072,7 @@ para saltar sobre el perro perezoso
         <translation type="vanished">Ayuda</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n objeto seleccionado</numerusform>
@@ -7079,77 +7080,77 @@ para saltar sobre el perro perezoso
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Consulta incorrecta</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Close</source>
         <translation type="obsolete">Cerrar</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Clave</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>La clave ya existe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>La clave &quot;%1&quot; todavía existe y no debe usarse dos veces.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Encontrar el archivo de plantilla movido</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>No existe el archivo.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>¿Es correcto el formato del archivo para este tipo de plantilla?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>No hay suficiente memoria libre.</translation>
     </message>
@@ -7159,134 +7160,134 @@ para saltar sobre el perro perezoso
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Ajuste de plantilla</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>¡Falló el cálculo del ajuste!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Establecer la posición del punto de ajuste en la plantilla. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Establecer la posición del punto de ajuste en el mapa. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: Borrar puntos de ajuste. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt;: Mover puntos de ajuste. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Puntos de ajuste:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Plantilla X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Plantilla Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Mapa X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Mapa Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Aplicar puntos de ajuste</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Aplicar y limpiar todo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Limpiar todo</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>No hay memoria libre suficiente (tamaño de imagen: %1x%2 pixels)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7295,98 +7296,98 @@ Guardar archivos GIF no está soportado. ¡Esto significa que los dibujos sobre 
 Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay problema.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Seleccionar el sistema de referencia de coordenadas para las coordenadas en el archivo mundial</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Abriendo %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Tamaño de imagen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Especifique cómo posicionar o escalar la imagen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Archivo mundial</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>No hay información de georreferencia</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metros por pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Escaneado con</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>ppp</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Escala de plantilla:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Grupo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nombre del archivo</translation>
     </message>
@@ -7395,19 +7396,19 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
         <translation type="obsolete">Crear...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Croquis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
@@ -7432,7 +7433,7 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
         <translation type="obsolete">no</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georreferenciado: %1</translation>
     </message>
@@ -7441,89 +7442,89 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
         <translation type="vanished">Borrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Añadir plantilla...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importar y eliminar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Mover manualmente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Abrir imagen, trayecto GPS o archivo DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Posicionamiento...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Archivos de plantillas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Todos los archivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Ajustar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Formato de archivo no reconocido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Falló la carga de la plantilla. ¿Existe el archivo y es válido?</translation>
     </message>
@@ -7532,23 +7533,23 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
         <translation type="obsolete">¡Por favor, escriba un número válido de 0 a 1, ó especifique un porcentaje de 0 a 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>¡Por favor, escriba un número entero válido para establecer un grupo o deje el campo vacío para desagrupar la plantilla!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>No escalar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Escalar por un ratio de escalado nominal de mapa (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7557,194 +7558,194 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Escalar por el escalado de la plantilla actual (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Importación de plantilla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>¿Cómo se tienen que escalar los símbolos del mapa importado?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>La plantilla no será visible en la simulación de sobreimpresión. ¿Cambiar a vista normal?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Arrastrar&lt;/b&gt; para mover la plantilla actual</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Posicionamiento</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Escala-X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Escala-Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Seguimiento de escalado y posicionamiento</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Sistema de coordenadas</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Real</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Una unidad de coordenada equivale:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Seguimiento de la posición en las coordenadas dadas</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Seguimiento de la posición en el centro de la vista</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Esta plantilla se debe cargar con GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Seleccione el sistema de coordenadas de referencia de las coordenadas del trayecto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Abriendo trayecto ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>¿Cargar el trayecto en modo georreferenciado o no georreferenciado?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Posiciona el trayecto de acuerdo a la configuración de georreferenciado del mapa.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Éstas no están configuradas todavía, así que serán mostradas en el siguiente paso.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>No georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Poyecta el trayecto usando una proyección ortográfica con centro en la coordenada media del trayecto. Permite el ajuste de la transformación y el establecimiento de la georreferencia del mapa usando la posición del trayecto ajustada.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>El camino está vacío, ¡no hay nada para importar!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Pregunta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>¿Deberían ser importados los puntos (waypoints) como una línea que vaya a través de todos los puntos?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problemas de importación</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n objeto de camino no se ha podido importar (razón: no hay coordenadas).</numerusform>
@@ -7752,7 +7753,7 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Error de lectura</translation>
     </message>
@@ -7765,7 +7766,7 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7774,39 +7775,39 @@ Sin embargo, si no pretende dibujar sobre esta plantilla, entonces no hay proble
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 No es un archivo OSM.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>El archivo OSM es versión %1.
 La mínima versión soportada es %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>El archivo OSM es versión %1.
 La máxima versión soportada es %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemas</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 nodos no se pudieron procesar correctamente.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Enlace externo: %1</translation>
@@ -7817,58 +7818,58 @@ La máxima versión soportada es %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Alineamiento</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Superior</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Línea base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Inferior</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Configuración de texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Familia de la fuente:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Tamaño de la fuente:</translation>
     </message>
@@ -7877,297 +7878,297 @@ La máxima versión soportada es %2.</translation>
         <translation type="vanished">Determinar tamaño...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Color del texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>negrita</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>itálica</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>subrayado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Estilo de texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Espaciado de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Espaciado de párrafo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Espaciado de carácter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kerning (espacio entre letras)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Texto de icono de símbolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Encuadrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Parámetros de compatibilidad OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Color de encuadrado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Encuadrado lineal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Encuadrado sombreado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Desplazamiento Izquierda/Derecha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Desplazamiento Superior/Inferior:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Compatibilidad OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>habilitado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Anchura de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Color de línea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Posición:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Línea bajo párrafos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Distancia desde la línea de base:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Posiciones de tabulador personalizadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Añadir tabulador personalizado</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Calcular</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>No se puede deshacer porque la última acción de deshacer no fue válida. Esto puede ocurrir, por ejemplo, si cambia el símbolo de un objeto a otro y luego borra el símbolo antiguo.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Si deshace este paso se irá más allá del punto donde el archivo fue cargado. ¿Está usted seguro?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>No se puede rehacer porque la primera acción de rehacer no fue válida. Esto puede ocurrir, por ejemplo, si borra el símbolo de un objeto que ha dibujado.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Falló la localización de los archivos de ayuda.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Falló la localización del visor de la ayuda (&quot;Asistente Qt&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Falló la ejecución del visor de la ayuda (&quot;Asistente Qt&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Ver más…</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Versiones anteriores de Mapper no soportan múltiples partes de mapa. Para guardar el mapa en un modo compatible, primero debe fusionar todas las partes del mapa.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elemento no soportado: %1 (línea %2 columna %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Algunas coordenadas estaban fuera de los límites de impresión. Se ha ajustado el contenido del mapa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Partes de este archivo no se pueden leer en esta versión de Mapper. Versión mínima requerida: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Error en línea %1 columna %2: %3</translation>
     </message>
@@ -8176,44 +8177,44 @@ La máxima versión soportada es %2.</translation>
         <translation type="vanished">Las notas del mapa no se pudieron leer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Deben eliminarse algunos caracteres no válidos.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Error desconocido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Especificación de georreferencia no soportada o inválida &apos;%1&apos;:%2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>No se pudo establecer la propiedad knockout del color &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Se esperaban %1 colores, se encontraron %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>El color spot %1 no se ha encontrado mientras se procesaba %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Se esperaban %1 símbolos, se encontraron %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Se esperaban %1 partes de mapa, se encontraron %2.</translation>
     </message>

--- a/translations/OpenOrienteering_et.ts
+++ b/translations/OpenOrienteering_et.ts
@@ -2,5092 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="et">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation>Kollane</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation>Must</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>Punane</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>Roheline</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>Sinine</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation>Nimi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation>Hoiatus</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>Nimi</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>Uus</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation type="unfinished">Hoiatus</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation>Ctrl+Shift+S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished">Hoiatus</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation type="unfinished">Hoiatus</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation>Ctrl+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation>Ctrl+Shift+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation>Ctrl+I</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation>Ctrl+R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation>Ctrl+G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation>Ctrl+F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation>Ctrl+D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation>Ctrl+M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation>%1x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation type="unfinished">mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation type="unfinished">mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5101,767 +15,2836 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
-        <translation type="unfinished">%</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PointSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PrintProgressDialog</name>
-    <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PrintTool</name>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PrintWidget</name>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
-        <translation type="unfinished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AutosaveDialog</name>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDialog</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation>Kollane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation>Must</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>Punane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>Roheline</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>Sinine</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation>Nimi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
+        <translation>Hoiatus</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDropDown</name>
+    <message>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorListWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>Nimi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>Uus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
+    <message>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutoutTool</name>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation type="unfinished">Hoiatus</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished">Hoiatus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5869,7 +2852,3025 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation type="unfinished">Hoiatus</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation>Ctrl+Shift+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation>Ctrl+R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation>%1x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation type="unfinished">mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation type="unfinished">mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished">Hoiatus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5877,672 +5878,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished">Hoiatus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Hoiatus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6550,63 +6551,63 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6614,625 +6615,625 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished">Uus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished">Hoiatus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n objekti ei saanud importida (põhjus: puuduvad koordinaadid).</numerusform>
@@ -7240,436 +7241,436 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_eu.ts
+++ b/translations/OpenOrienteering_eu.ts
@@ -2,5092 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="eu">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation>Lerro bakarra</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation type="unfinished">mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5101,767 +15,2854 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ActionGridBar</name>
+    <message>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
+        <translation>Lerro bakarra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GPSDisplay</name>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5869,7 +2870,3007 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation type="unfinished">mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5877,672 +5878,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6550,63 +6551,63 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6614,625 +6615,625 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7240,436 +7241,436 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Errore ezezaguna</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_fi.ts
+++ b/translations/OpenOrienteering_fi.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fi_FI">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Suunnistuskartta</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Ohjelma suunnistuskarttojen tekemiseen</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Tietoja %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Tämä on vapaa ohjelma; sitä on sallittu levittää edelleen ja muuttaa &lt;a %1&gt;GNU yleisen lisenssin (GPL-lisenssin) version&amp;nbsp;3&lt;/a&gt; ehtojen mukaan sellaisina kuin Free Software Foundation on ne julkaissut.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Tätä ohjelmaa levitetään siinä toivossa, että se olisi hyödyllinen, mutta ilman mitään takuuta; ilman edes hiljaista takuuta kaupallisesti hyväksyttävästä laadusta tai soveltuvuudesta tiettyyn tarkoitukseen. Katso GNU yleisestä lisenssistä (GPL-lisenssistä) versiosta&amp;nbsp;3, &lt;a %1&gt;lisää yksityiskohtia&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Tietoa lisensseistä, kopiosuojasta, ehdoista ja vastuuvapauslausekkeista.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>OpenOrienteering ohjelmiston kehittäjät aakkosellissa järjestyksessä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(projektin käynnistäjä)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Ilmainen ohjelma suunnistuskarttojen tekemiseen</translation>
@@ -50,7 +63,7 @@
         <translation type="vanished">Kehittäjät aakkosjärjestyksessä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Kiitos avustamisesta:</translation>
     </message>
@@ -60,203 +73,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Avaa viimeisin tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Näytä päivän vinkki</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Näytä jäljellä olevat kohteet</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minimikoko:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Täyttö</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Viivatäyttö</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Kuviotäyttö</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Yksittäinen viiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Samansuuntaiset viivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Viivojen väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Yksittäinen rivi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Kuvion väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Kuvion etäisyys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Rivin etäisyys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Samansuuntaiset rivit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Rivien väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Täytön kierto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Kulma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>muokattavissa erikseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Elementin piirtäminen reunalla</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Leikkaa elementit reunalla.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Piirtää elementit, jos keskipiste sijaitsee reunan sisäpuolella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Piirtää elementit, jos mikä tahansa piste sijaitsee reunan sisäpuolella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Piirtää elementit, jos kaikki pisteet sijaitsevat reunan sisäpuolella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Alueen asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Kuviotäyttö %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Viivatäyttö %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Täyttöä ei ole valittu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Alueen väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Viivan etäisyys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Viivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Viivan leveys:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automaattisesti tallennettu tiedosto</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -264,249 +277,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Tiedosto tallennettu käyttäjän toimesta</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Tiedoston palautus</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Tiedosto %1 ei suljettu oikein. Tällä hetkellä tiedostosta on 2 versiota:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Tallenna aktiivinen tiedosto poistaaksesi väärän version.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Muokkaa värejä</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Muokkaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Määrittelee spottivärin:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Spottivärien sekoitus (päällepainatus):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Aukotus: poistaa alle jäävän värin</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Laske spottiväristä</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Laske RGB-väristä</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Yksilöllisesti määritelty väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Syaani</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Keltainen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Musta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Laske CMYK-väristä</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Määritelty RGB-väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Punainen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Vihreä</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Sininen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Tulostus</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Erikoistulostus</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- nimeämätön -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- tyhjä -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Läpinäkyvyys</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Spottiväri</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>Altapoisto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Uusi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Monista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Tuplaklikkaus avaa värin muokkauksen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Vahvistus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Kartassa on symboleita tällä värillä. Sen poisto poistaa värin myös symboleilta! Haluatko todella tehdä niin?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (kaksoiskappale)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Kaksoiskappale)</translation>
     </message>
@@ -519,300 +532,300 @@
         <translation type="vanished">Aseta prosenttiluku välillä 0%-100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Tuplaklikkaa määritelläksesi värin</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klikkaus valitsee värin, toinen klikkaus avaa muokkauksen.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Osien lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Yksityinen viivasymboli -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Yksityinen aluesymboli -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Muokkaa yksityistä symbolia…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Yhdistelmän asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Muuta julkisesta yksityiseksi symboliksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Ota vanha symboli yksityisen symbolin malliksi?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symboli %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Ruudukon asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Näytä ruudukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Tartu ruudukkoon</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Valitse…</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Kaikki viivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Vaakaviivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Pystyviivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Suuntaus</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Suuntaa neulapohjoiseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Suuntaa karttapohjoiseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Suuntaa napapohjoiseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Lisäkierto (vastapäivään):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Asemointi</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>metrejä maastossa</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>millimetrejä kartalla</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Vaakaviivojen väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Pystyviivojen väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Vaakasiirto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Pystysiirto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Mittayksikkö:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Viivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Näytä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Valitse ruudukon viivan väri</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origo: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>paperikoordinaattien origossa</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>projektion origossa</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klikkaa tai vedä&lt;/b&gt;: Piirrä reikä. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Katkaisuviivan pitää päättyä alueen reunaviivalle!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Katkaisuviivan alku ja loppu ovat objektin eri osissa!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Katkaisuviivan alku ja loppu ovat samassa kohdassa!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;viivalle: Katkaise kahdeksi.&lt;b&gt;Vedä&lt;/b&gt;viivaa pitkin: Poista viivan tämä osa. &lt;b&gt;Klikkaa tai vedä&lt;/b&gt;alueen reunaviivalla: Aloita katkaisuviiva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Alueissa olevien reikien katkaisua ei vielä tueta!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Leikkaa koko kartta. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klikkaa tai vedä&lt;/b&gt;: Valitse leikattavat kohteet. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Leikkaa valitut kohteet. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Tiedostoa ei voitu avata.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Tiedosto ei ole DXF-tiedosto.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Määrittele fontin koko</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Kirjain:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -826,261 +839,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Korkeus:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Tee pisteitä tasaisesti viivalle</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Pisteitä viivalla:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Lisää kohteet myös viivan loppuun</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Kierron asetukset</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Suuntaa pisteet viivan suuntaisesti</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Ylimääräinen kierto (vastapäivään):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Keskuksesta</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aloita ympyrä tai ellipsi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Piirrä ympyrä. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Pidä näppäintä %1 pohjassa aloittaaksesi piirtämisen keskeltä.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Lopeta ympyrä. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Piirrä ellipsi. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Piirrä polku. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Käytä katkopisteitä&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt;: Tartu kohteeseen tai liitä loppuun. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt;: Ota suunta kohteesta. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Viivan atsimuutti ja pituus. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt;: Tartu kohteeseen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiinteät suunnat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kumoa viimeisin piste. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Loppu</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Kulma</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Tieto</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Ajatusviiva</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Keskeytä</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Pituus:&lt;/b&gt;%1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aloita suora viiva. &lt;b&gt;Vedä&lt;/b&gt;: Aloita kaariviiva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Vedä&lt;/b&gt;: Seuraa kohteita. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Piirrä suora viiva. &lt;b&gt;Vedä&lt;/b&gt;: Piirrä käyräviiva. &lt;b&gt;Hiiren oikea tai tuplaklikkaus&lt;/b&gt;: Lopeta viiva. &lt;b&gt;%1&lt;/b&gt;: Sulje viiva. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Lopeta keskiarvojen laskeminen koskettamalla karttaa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Kilkkaus&lt;/b&gt;: Lopeta objektin asettelu. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Kulma</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Palauta</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Kulma:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiinteät suunnat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Piirrä pistemäinen kohde.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Piirrä kohde ja aseta suunta.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Palauta pyörimisliike.</translation>
     </message>
@@ -1090,76 +1103,76 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Loppu</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Linjan kiinnitys</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Ajatusviiva</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Keskeytä</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klikkaa tai vedä&lt;/b&gt;: Aloita suorakulmion piirtäminen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Tartu viivoihin. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta kulmapiste. &lt;b&gt;Hiiren oikea tai tuplaklikkaus&lt;/b&gt;: Lopeta suorakulmio. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Lopeta muokkaus. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Peruuta muokkaus. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Kirjoita tekstiä. &lt;b&gt;Vedä&lt;/b&gt;: Tee tekstilaatikko. </translation>
     </message>
@@ -1169,130 +1182,130 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Aseta käyrä</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vapaa liike. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt; viivan osaan: Vaihda suoran ja käyrän välillä. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Napsahda</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Piste / Kulma</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Aseta ajatusviiva</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Lopeta muokkaus. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Säilytä vastakkaiset kahvat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt; pistettä: Poista; viivaa: Lisää uusi katkopiste; &lt;b&gt;%2&lt;/b&gt;:llä: Lisää tavallinen piste. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt; pistettä: Poista; viivaa: Lisää uusi piste; &lt;b&gt;%2&lt;/b&gt;:llä: Lisää katkopiste. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klikkaa&lt;/b&gt; pistettä: vaihda katkopisteen ja tavallisen pisteen välillä. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinaatin siirto:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Etäisyys:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiinteät suunnat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Tartu kohteeseen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Valitse yksittäinen kohde. &lt;b&gt;Vedä&lt;/b&gt;: Valitse useita kohteita. &lt;b&gt;%1+Klikkaa&lt;/b&gt;: Vaihda valintaa. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Poista valitut kohteet. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Korkelaatuinen karttanäyttö (reunojenpehmennys/antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Reunojenpehmennys tekee kartasta paremman näköisen mutta hidastaa karttanäyttöä</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Korkealaatuinen teksti kartassa (reunojenpehmennys/antialiasing), hidas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klikkauksen tarkkuus:</translation>
     </message>
@@ -1301,315 +1314,315 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Tarttumisen etäisyys (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Kiinteästä suunnasta poikkeaminen (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Symbolin kuvakkeen koko:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Kun kohde valitaan, valitse automaattisesti myös sen symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Zoomaa kursorista alkaen kun karttaa loitonnetaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Piirtotyökalut: hiiren oikealla lopeta piirtäminen ja aseta viimeinen piste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Taustakartat: säilytä asetukset kun taustakartta suljetaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Muokkaus-työkalu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Säilytä alkuperäinen muoto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Palauta ulkopuolen kahvat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Säilytä ulkopuolen kahvat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Toiminta kun käyräpiste poistetaan (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Suorakulmio-työkalu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Apuristikon koko:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Näytä viivan leveyt apuristikolla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editori</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Uutta tiedostoa ei voitu tehdä: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Formaatti %1 ei tue vientiä</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Kartan alue on suuri. Täyttötyökalun käyttö voi olla todella hidasta. Käytetäänkö siitä huolimatta?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Valittu alue ei ole suljettu viivoilla tai alueilla, aluetta ei voida täyttää.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Valittu alue ei ole vapaa. Et voi käyttää täyttötyökalua täällä.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Täyttöobjektin luonti epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Täytä alue aktivoidulla symbolilla. Täytetty alueen täytyy olla ympäröity viivoilla tai alueilla. Muita symboleita ei oteta huomioon. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS on poistettu käytöstä laitteen asetuksissa. Avaako asetukset nyt?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Kyllä</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Tuo GDAL/OGR:lla:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Ulkoasu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Kieli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Kuvaruutu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pikseliä tuumalla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Ohjelman käynnistys</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Tiedostojen tallentamista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Säilytä yhteensopivuus Mapper %1:n kanssa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Tallenna kumoa/tee uudestaan historia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Tallenna tiedot automaattista palauttamista varten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Tallennusväli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Tiedostojen tuonti ja vienti</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-bittinen koodaus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Lisää…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Oletusarvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Käytä uutta OCD-tuontia myös version 8 tiedostoille</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Yleinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Huomautus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Ohjelma pitää käynnistää uudelleen jotta kieli voidaan vaihtaa!</translation>
     </message>
@@ -1618,47 +1631,47 @@
         <translation type="vanished">Käytä käännöstiedostoa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Avaa käännöstiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Käännöstiedostot (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Tiedosto ei ole käännöstiedosto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Ensisijainen näytön resoluutio pikseleissä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Ensisijainen näytön koko tuumissa (diagonaali):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM koordinaatit</translation>
     </message>
@@ -1667,80 +1680,80 @@
         <translation type="vanished">UTM Kaista (numero pohjoinen/eteläinen, esim. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM Kaista (numero N/S)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, datumi: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krueger koordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Kaistan numero (1-119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>EPSG-koodilla</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ koordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Paikalliset koordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG koodi</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Muokattu PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Määrittely</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Kartan mittakaavan määritys ei kelpaa tai sitä ei ole.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Virheellinen ruudukon skaalauskerroin: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Tuntematon koordinaattijärjestelmän määrittely: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Koordinaattijärjestelmää ei tueta: %1</translation>
     </message>
@@ -1749,7 +1762,7 @@
         <translation type="vanished">Vain skaalaus</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Paikallinen</translation>
     </message>
@@ -1759,74 +1772,74 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Kartan georeferointi</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Etsi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translatorcomment>#729: &quot;Neulaluvun korjaus (NEK)&quot;</translatorcomment>
         <translation>Deklinaatio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Tasokoordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Tila:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Ruudukon skaalauskerroin:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Maantieteelliset koordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Näytä vertailupiste:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>kelvollinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Etsi deklinaatio netistä</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Kartan koordinaattijärjestelmä</translation>
     </message>
@@ -1839,7 +1852,7 @@
         <translation type="vanished">- Proj.4 määrittelyistä -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- paikallinen -</translation>
     </message>
@@ -1848,113 +1861,113 @@
         <translation type="vanished">Koordinaattijärjestelmän määrittely:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Vertailupiste</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Poimi kartalta</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datumi: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Karttapohjoinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Koordinaattijärjestelmä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Karttakoordinaatit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Maantieteelliset koordinaatit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Muutettaessa säilytä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translatorcomment>#729: &quot;Kokonaiskorjaus (KOK)&quot;</translatorcomment>
         <translation>Eranto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Vertailupisteen magneettinen deklinaatio %1° %2° haetaan nyt &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;:sta. Jatketaanko?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Deklinaation muutos</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Deklinaatio on muutettu. Kierretäänkö kartan sisältö?</translation>
     </message>
@@ -1963,66 +1976,66 @@
         <translation type="vanished">Tasokoordinaatit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Paikalliset koordinaatit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Lataa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>lukittu</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Tietoa ei voitu jäsentää.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Deklinaation arvoa ei löydy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Deklinaation etsiminen epäonnistui:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta vertailupiste. Valitse toinen painike keskeyttääksesi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta vertailupiste. &lt;b&gt;Klikkaa oikealla&lt;/b&gt;: Peruuta.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Tervetuloa ohjelmaan OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Activities</source>
         <translation type="vanished">Toiminnot</translation>
@@ -2086,118 +2099,118 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Toiminnat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Luo uusi kartta …</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Avaa kartta …</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Tietoja %1ista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Lopeta</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Viimeisimmät kartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Avaa viimeisin tiedosto käynnistettäessä</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Tyhjennä lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Päivän vinkki</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Näytä päivän vinkki</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Esimerkit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Tietoja Mapperista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Tiedostolista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Kartta tiedostoa ei löydy!&lt;br/&gt;&lt;br/&gt; Kopio karttatiedosto laitteen tai muistikortin juuressa olevaan &apos;OOMapper&apos; kansioon.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Virhe ladattaessa symbolia %1 rivillä %2 sarakkeessa %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symboli ID &apos;%1&apos; ei yksilöllinen rivillä %2 sarakkeessa %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Virhe ladattaessa symboli tyyppiä %1 rivillä %2 sarakkeessa %3:%4</translation>
     </message>
@@ -2206,84 +2219,84 @@
         <translation type="vanished">Virhe ladattaessa symbolia.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Virhe ladattaessa kohdetta %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Virhe ladatessa %1-tyypin objektia kohteessa %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Kohteelle ei löydy symbolia: %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Pistemäisen kohteen symbolia ei ole määritelty tai se on virheellinen: %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versiot 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Koordinaattien tulkitseminen ei onnistu.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Vaaditaan %1 koordinaatteja, löydetty %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Virhe ladattaessa tulostus asetuksia %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Virhe ladattaessa kumoa / tee uudestaan vaiheita %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Ei ole sellaista vaihtoehtoa: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Paikkatietodata</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Löytyi objekti jolla ei ole symbolia.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Pudottu %n epäsäännöllinen kohde.</numerusform>
@@ -2291,36 +2304,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Virhe symbolin jälkikäsittelyssä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Taustakartta &quot;%1&quot; on ladattu kartan kansiosta aikaisemman sijannin sijaan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Virhe taustakartan latauksessa &apos;%1&apos;, syy: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Varoitus ladattaessa taustakarttaa &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Ainakin yksi taustakarttaa puuttuu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klikkaa punaista taustakartan nimeä kohdassa Taustakartta -&gt; Taustakartan asetukset löytääksesi taustakarttatiedoston nimen.</translation>
     </message>
@@ -2330,173 +2343,173 @@
 löytääksesi taustakarttatiedoston nimen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Tämä tiedosto käyttää vanhentunutta tiedostomuotoa, jota ei tueta ohjelman tulevissa versioissa. Mikäli haluat avata tiedoston tulevaisuudessa, tallenna se eri tiedostomuodolla.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Tiedostomuodon versio ei kelpaa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Näin vanhaa tiedostomuotoa ei tueta. Käytä vanhempaa ohjelmaa päivittääksesi tiedoston.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Näin uutta tiedostomuotoa ei tueta. Joitain kartan ominaisuuksia ei voida ladata tai tallentaa tällä versiolla. Harkitse päivittämistä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Maantieteellinen koordinaattijärjestelmä kartassa on &quot;%1&quot;, jota ei tueta. Käytetään &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Virhe ladattaessa symbolia %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Virhe symbolia ladattaessa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Virhe ladattaessa kumoa-vaiheita.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Virhe luettaessa kartan osia.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Virhe ladattaessa kartan osaa %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Tiedostoa %1 ei voitu lukea</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Tiedostomuotoa ei tueta.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Näin uutta tiedostomuotoa ei tueta. Joitain kartan ominaisuuksia ei voida ladata tai tallentaa tällä versiolla.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Formaattia (%1) ei tueta ladattaessa</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Ei voitu lukea &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Viivan asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Viivan leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Viivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Viivan minimipituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Viivanpää:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>tasainen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>pyöreä</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>neliö</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>terävä</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Viivan kulmat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>jiiriliitos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>viisto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Viivan pään pituus:</translation>
     </message>
@@ -2506,334 +2519,335 @@ löytääksesi taustakarttatiedoston nimen.</translation>
         <translation>Katkoviiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Näytä vähintään yksi välisymboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Pienin välisymbolien määrä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Pieni välisymbolien määrä suljetussa viivassa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Katkoviivan pituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Katkoviiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Katkon pituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Katkoviivoja yhdessä ryhmässä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>ei yhtään</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Viivan pituus ryhmässä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Ensimmäinen ja viimeinen katkoviiva puolet viivan pituudesta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Välisymbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Välisymboleita pisteessä:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Välisymbolien etäisyys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Reunaviivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Erilainen reunaviiva vasemmalla ja oikealla</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Vasen reunaviiva:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Oikea reunaviiva:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Aloitussymboli</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Välisymboli</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Lopetussymboli</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Solmupisteen symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Käytä reunaviivoja</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Pisteiden etäisyys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Etäisyys viivan lopusta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Älä tee solmupisteen symbolia viivan alkuun tai loppuun</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished">Skaalaa väliviiva symbooli nurkissa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Reunaviivan leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Reunaviivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Reunaviivan siirto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Reunaviiva on katkotettu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Katkoviivan pituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Katkon pituus:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Uusi</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Luo uusi kartta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Avaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Avaa &amp;viimeisimmät</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Tallenna &amp;nimellä…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Asetukset…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Sulje tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Lopeta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Lopeta ohjelma</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Yleistä</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>&amp;Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Avaa ohjeet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Tietoja %1ista</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Näyttää tietoja ohjelmasta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Tetoja &amp;Qt:stä</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Näyttää tietoja Qt:stä</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Haluatko poistaa automaattisesti tallennettu version?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Tiedostoa on muutettu.
 Tallennetaanko?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Tallentamaton</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2842,60 +2856,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Skaalataanko symbolit?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Varoitus-ohjelma kaatuu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>%1 kaatui kun tämä tiedosto avattiin viimeksi:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Avataanko silti?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Automaattinen tallennus…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Automaattinen tallennus epäonnistui!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Kaikki kartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Kaikki tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Sinun täytyy sulkea nykyinen tiedosto ennen kuin voit avata toinen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Avataan %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2906,19 +2920,19 @@ File format not recognized.</source>
 Tuntematon tiedostomuoto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Tiedosto on muutettu.
 Haluatko hylkää muutokseni?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2929,44 +2943,44 @@ Paina Kyllä jos haluat tallentaa tässä tiedostomuodossa.
 Paina Ei valitaksesi toisen tiedostomuodon.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Tallenna tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Tiedostoa ei voitu tallentaa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Tiedostomuodon määrittely ei onnistunut.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Ilmoita tämä bugina.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2975,7 +2989,7 @@ because saving as %2 (.%3) is not supported.</source>
 tallentaminen %2 (.%3) ei ole tuettu.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2990,31 +3004,31 @@ tiedostomuoto on tuntematon.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Kartan vienti aiheutti varoituksia.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Sisäinen virhe tallennettaessa:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Kartan tuonti aiheutti varoituksia.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3023,12 +3037,12 @@ for reading.</source>
 ei voi avata luettavaksi.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Virheellinen tiedostomuoto.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3039,7 +3053,7 @@ ei voi avata luettavaksi.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3048,17 +3062,17 @@ ei voi avata luettavaksi.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Ei tuotavaa.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Kysymys</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3067,23 +3081,23 @@ Rescale the imported data?</source>
 Skaalataanko tuotu tieto?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>virheellinen osa</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Uusi väri</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Tuo…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Symbolin korvaaminen peruutettiin.
@@ -3091,215 +3105,215 @@ Haluatko silti tuoda datan?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Värierottelu (kaikki tulostettavat värit)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Koordinaatit ovat rajojen ulkopuolella.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Kumoa edellinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Tee uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Tee uudelleen edellinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>&amp;Leikkaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>&amp;Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>Lii&amp;tä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Älä valitse mitään</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Valitse muut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Lähennä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Loitonna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Kokoruututila</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Aseta zoom-kerroin…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Symboli-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Näytä/Piilota symboli-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Väri-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Näytä/Piilota väri-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Korvaa symbolit toisesta tiedostosta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Skaalaa symbolit…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Skaalaa kaikki symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Muuta mittakaavaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Muuta kartan mittakaavaa ja säädä kohteita sekä symbolien kokoa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Huomioita kartasta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Taustakartan asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Näytä/Piilota taustakartta-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Avaa taustakartta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Näytä koko kartta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Muokkaa kohteita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Piirrä pistemäinen kohde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Piirrä viivoja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Piirrä ympyröitä ja ellipsejä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Kirjoita tekstiä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Monista</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Vaihda symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Täytä / Tee reunaviiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Käännä suunta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Yhdistä viivat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Katkaise kohde</translation>
     </message>
@@ -3308,169 +3322,169 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Kierrä kohteita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mittaa pituuksia ja pinta-aloja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Leikkaa pois alueelta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Lisää uusi osa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Nimeä nykyinen osa uudelleen…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Poista nykyinen osa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Yhdistä kaikki osat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Tuo…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muokkaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Näytä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Työkalut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>&amp;Symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Kartta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>T&amp;austakartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Piirtää</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Piirrä taustakarttaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Muokkaus käynnissä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Karttaa muokataan. Lopeta editointi ennen tallentamista.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Näytä ruudukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Ruudukon asetukset…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Viivoitetut alueet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Viivanäkymä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Piilota kaikki taustakartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Korvaa symbolit…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferointi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Kierrä karttaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Kierrä koko karttaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Avaa taustakartta uudelleen…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Piirrä suorakulmioita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Leikkaa aukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Leikkaa pyöreä aukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Leikkaa suorakulmainen aukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Kierrä kuviota</translation>
     </message>
@@ -3479,12 +3493,12 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Skaalaa kohteita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Yhdistä alueita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Risteävät alueet</translation>
     </message>
@@ -3493,52 +3507,52 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Päällekkäiset alueet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Leikkaa päälleikkäiset alueet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Leikkaa rajattu alue</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Leikkaa rajaus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Tee pisteitä viivaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Karttakoordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Projektion koordinaatit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Leveysaste/Pituusaste (aste)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Leveysaste/Pituusaste (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Näytä koordinaatit…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Leikkaa reikä</translation>
     </message>
@@ -3547,51 +3561,51 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Dummy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Näytä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Karttaosat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Valitse taustakartta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Muokkaus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Muokkauksen lisätyökalut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Ei kumottavaa.</translation>
     </message>
@@ -3601,8 +3615,8 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Leikkaa %1 kohde(tta)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Sisäinen virhe, pahoittelut!</translation>
     </message>
@@ -3611,7 +3625,7 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Kopioitu %1 kohde(tta)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Leikepöydällä ei ole liitettäviä kohteita!</translation>
     </message>
@@ -3620,259 +3634,259 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Liitetty %1 kohde(tta)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Aseta zoom-kerroin</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Zoom-kerroin:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Värit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Skaalaa kaikki symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Skaalaa prosentteina:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Huomioita kartasta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Taustakartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Aseta pistemäisiä kohteita kartalle.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Valitse pistemäinen symboli käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Piirrä monikulmio- ja käyräviivoja.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Valitse viiva-, alue- tai yhdistetty symboli käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Piirrä ympyröitä ja ellipsejä.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Aseta alueen täytön kuvioiden tai pistemäisten kohteiden suunta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Valitse aluemainen kohde kierrettävällä täyttökuviolla tai kierrettävä pistemäinen kohde käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Tuloksena symboli: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Valitse vähintään kaksi aluetta tai reittiä aktivoidaksesi tämän työkalun.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Liitä päällekkäiset objektit.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Poista kaikki osat, jotka eivät ole päällekkäin ensiksi valitun objektin kanssa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Poista päällekkäiset osat ensimmäisestä valitusta objektista.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Poista kaikki osat, jotka ovat päällekkäin ensiksi valitun objektin kanssa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Leikkaa rajattu alue kohteista tai koko kartasta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Valitse suljettu kohde leikkauksen muodoksi käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Leikkaa joitakin kohteita tai kaikki rajatulta alueelta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Asettaa tasavälein pistemäisiä kohteita viivamaiseen kohteeseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Valitse ainakin yksi viivakohde ja pistemäinen symboli käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Yhdistä tämä viivakohde objektiin</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Siirrä valitut kohteet päälle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Anna karttaosan nimi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Vaihdettiin kartan osaan &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Yhdistä karttaosat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Haluatko siirtää kaikki kohteet karttaosasta &quot;%1&quot; &quot;%2&quot;:een, ja poistaa &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Haluatko siirtää kaikki kohteet karttaosaan &quot;%1&quot;, ja poistaa kaikki muut karttaosat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Valittua karttatiedostoa ei voitu tuoda koska sitä ei voitu ladata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Piirrä suorakulmioita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Tulosta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Kuva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Tyhjennä kumoa / tee uudestaan historia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Tyhjennä kumoa / tee uudestaan historia pienentääksesi karttatiedoston kokoa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Siirrä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Overprinting simulaatio</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Muokkaa viivoja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Muuta kaariviivaksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Yksinkertaista viivan jälkeä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Vie tiedostona…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Kirjoita tekstiä kartalle.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Valtise tekstisymboli käyttääksesi tätä työkalua.</translation>
     </message>
@@ -3881,185 +3895,185 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Monista valittu kohde/kohteet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Valitse ainakin yksi kohde käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Kartta tallennettu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Tagieditori</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Näytä/Piilota tagieditori-ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Piirrä vapaalla kädellä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Täytä ympäröidyt alueet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Symbolijoukon ID…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Muokkaa symbolijoukon ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Lataa CRT-tiedosto…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Nimitä uudet symbolit CRT-taulukon mukaan</translation>
     </message>
@@ -4072,102 +4086,102 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Näytä/piilota tagit-valintaikkuna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation type="unfinished">Yhdistä alueen reiät</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Maalaa malliasetusten päälle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Ota kosketuskohdistin käyttöön</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Ota GPS-näyttö käyttöön</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Ota GPS-etäisyysrenkaat käyttöön</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Aseta pistemäinen kohde GPS-kohdalle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Aseta väliaikainen merkki GPS-kohdalle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Luo väliaikainen viiva GPS-kohdalle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Tyhjennä väliaikaiset GPS-merkit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Ota kompassinäyttö käyttöön</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Kohdista kartta pohjoiseen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Kopioi kohdan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Kopioi kohdan leikepöydälle.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Valitse symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Piilota yläpalkki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Näytä yläpalkki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Tulostus / vienti ei ole käytettävissä tässä ohjelman versiossa!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Symbolijoukon ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Muokkaa symbolijoukon ID:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Tagieditori</translation>
     </message>
@@ -4176,7 +4190,7 @@ Haluatko silti tuoda datan?</translation>
         <translation type="vanished">Tagin valinta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4186,7 +4200,7 @@ symbolia
 valittu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4196,12 +4210,12 @@ symboleja
 valittu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Piirtää polku vapaasti käsin.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Täytä suljetut alueet.</translation>
     </message>
@@ -4210,18 +4224,18 @@ valittu</translation>
         <translation type="vanished">Poista valittu kohde/kohteet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Käännä viivamaisen kohteen symbolien suunta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Valitse ainakin yksi viivamainen kohde käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Yhdistä kahden lähekkäin olevan viivan päätepisteet.</translation>
     </message>
@@ -4230,17 +4244,17 @@ valittu</translation>
         <translation type="vanished">Leikkaa valittu kohde useampaan osaan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Valitse ainakin yksi viivamainen tai aluemainen kohde käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Leikkaa reikä valittuun alueeseen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Valitse aluemainen kohde käyttääksesi tätä työkalua.</translation>
     </message>
@@ -4277,28 +4291,28 @@ valittu</translation>
         <translation type="vanished">Poista alueiden päällekkäiset osat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation type="unfinished">Valitse yksi alue-esine reikien kanssa aktivoidaksesi tämän työkalun.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Muuta suorat viivat pehmeiksi bezier-splineiksi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Valitse viivamainen kohde käyttääksesi tätä työkalua.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Vähennä viivan pisteiden määrää, viivan muoto pyritään säilyttämään.</translation>
     </message>
@@ -4307,8 +4321,8 @@ valittu</translation>
         <translation type="vanished">Vaihtaa valittuna olevan kohteen symbolin valituksi symboliksi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Valitse ainakin yksi kohde ja sopiva eri symboli käyttääksesi tätä työkalua.</translation>
     </message>
@@ -4321,7 +4335,7 @@ valittu</translation>
         <translation type="vanished">%1 kohde(tta) monistettu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Kohteiden valinta</translation>
     </message>
@@ -4330,92 +4344,92 @@ valittu</translation>
         <translation type="vanished">Valitun symboli(e)n kohteita ei ole.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mittaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Yhdistäminen epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Risteäminen epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Päällekkäisyys epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Päällekkäisten alueiden leikkaus epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Reikien yhdistäminen epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Tyhjennä väliaikaiset merkit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Oletko varma, että haluat poistaa kaikki väliaikaiset GPS-merkit? Tätä toimintoa ei voi peruuttaa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Haluatko poistaa karttaosan &quot;%1&quot; ja kaikki kohteensa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Piirrä vapaasti taustakarttaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Piirrä vapaasti taustakarttaan. Luo tai lataa taustakartta johon voi piirtää käyttääksesi painiketta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Tuo %1, GPX-, OSM- tai DXF-tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Tuotavat tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Kaikki tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Tiedostoa ei voi tuoda. Tiedostomuotoa ei tueta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Kierrä kohteita</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Skaalaa kohteita</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4424,7 +4438,7 @@ valittu</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Kopioitu %n kohde</numerusform>
@@ -4432,7 +4446,7 @@ valittu</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Liitetty %n kohde</numerusform>
@@ -4440,42 +4454,42 @@ valittu</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Poista valittu kohteet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Monista valittu kohteet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Kierrä valittua kohteita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Skaalaa valittua kohteita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Leikkaa valittu kohde useampaan osaan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Vaihtaa valittuna olevan kohteen symbolin valituksi symboliksi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Täytä valittu viivat tai tee reunaviiva valitulle alueelle.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Monistettu %n kohde</numerusform>
@@ -4483,178 +4497,178 @@ valittu</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Valitun symbolien kohteita ei ole.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Keskeytä. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Lisää: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Lisää: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Lisää: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Etsi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Etsi &amp;seuraava</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Etsi kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Etsi seuraava</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Etsi &amp;kaikki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Kyselyeditori</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Kartta -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Käsitellään sivujen erotuksia %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Käsitellään sivua %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Keskeytetty</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Valmis</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Tekstin lähde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Kartta (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>määrittelemätön kieli</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Käännös (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Ennen muokkaamista, tallennettu teksti korvataan nykyisellä käännöksellä. Haluatko jatkaa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Tallennetun tekstin muokkaamisen jälkeen, käännöstä ei enää löydy. Haluatko jatkaa?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4667,7 +4681,7 @@ Aloita määrittelemällä värit:
 Valitse Symbolit -&gt; Värit-ikkuna.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4682,7 +4696,7 @@ symbolit-ikkunaa ja valitse
 &quot;Uusi symboli&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4695,7 +4709,7 @@ taustakartta:
 Taustakartat -&gt; Avaa taustakartta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Vihje: Paina hiiren keskipainiketta siirtääksesi karttaa,
@@ -4703,123 +4717,123 @@ zoomaa hiiren rullalla.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Reunaviivan pituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Pituus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Pinta-ala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Kohdetta ei ole valittu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 kohde(tta) valittu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Valittu kohde ei ole viivamainen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Kohde on liian pieni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Minimi pinta-ala on %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Huom: Reunaviivan pituus ja pinta-ala ovat oikein vain jos viiva ei ole itsensä leikkaava ja reikiä on käyettty oikein.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Viiva on liian lyhyt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimipituus on %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Tee uusi kartta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Valitse uuden kartan mittakaava ja symbolijoukko.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Mittakaava:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Symbolijoukot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Näytä vain valittuun mittakaavaan sopivat symbolijoukot</translation>
     </message>
@@ -4828,140 +4842,140 @@ zoomaa hiiren rullalla.</translation>
         <translation type="vanished">Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Luo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Tyhjä symbolijoukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Lataa symbolijoukko tiedostosta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Kaikki symbolijoukko-tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Kaikki tiedostot</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Kartassa on enemmän kuin 256 väriä mitä ei tueta Ocad 8-versiossa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad palautti %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Värierottelu viedään tavallisena värinä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Täyttökuvion siirtoa ei voi viedä</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Taustakarttaa ei voi viedä: tiedostomuotoa &quot;%1&quot; ei vielä tueta</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Koordinaatit ovat mukautettu sopimaan OCAD 8 piirtoalueeseen (-2 m ... 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Jotkut koordinaatit pysyvät OCAD 8 piirtoalueen ulkopuolella. Ne saattavat olla saavuttamattomia OCADissa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Viivasymbolissa &quot;%1&quot;, viivan pää/liitos-yhdistelmää ei voida esittää.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Viivasymbolissa &quot;%1&quot;,katkoviivojen ryhmiä ei huomioida.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Viivasymbolissa &quot;%1&quot;, katkoviivojen määrä ryhmässä vähennetään kahteen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Viivasymbolissa &quot;%1&quot;, reunaviivoja ei voida viedä oikein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Aluesymbolissa &quot;%1&quot;, ohitetaan täyttökuvio.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Aluesymbolissa &quot;%1&quot;, oletetaan &quot;siirretyt rivit&quot;-kuvio. Voi olla oikein tai väärin.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Tekstisymbolissa %1: käytetään muokattua merkkiväliä, OCAD ei vielä tue sen esittämistä</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Tekstisymbolissa %1: ohitetaan alleviivaus</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Tekstisymbolissa %1: ohitetaan välistys</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Merkkijono typistetty (typisteys merkitty kolmella &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Ei voitu varata puskuria.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad palautti %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD version %1 tiedostoja ei tueta!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n värierottelu ohitettiin, tuonti ei toiminnassa.</numerusform>
@@ -4969,334 +4983,334 @@ zoomaa hiiren rullalla.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Spottivärin määrittelyä ei voitu ladata, virhe %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Väri &quot;Värierottelu&quot; tuodaan erikoisvärinä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Ei voitu tuoda symbolia &quot;%3&quot; (%1 %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD tuontitaso</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Katkoviivasymbolissa %1 terävän viivanpään pituus on eri alussa ja lopussa (%2 ja %3). Käytetään %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Katkoviivasymbolissa %1 loppuosan pituutta ei voi tuoda oikein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Katkoviivasymbolissa %1 viivanpään loppua ei voi tuoda oikein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Katkoviivasymbolissa %1 pääviivan ja loppuosan pituudet ovat erilaiset (%2 ja %3). Käytetään %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Katkoviivasymbolissa %1 katkot D ja E ovat erilaiset (%2 ja %3). Käytetään %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Viivasymboli %1: häivytetään solmupisteen symboli viivan päistä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Tekstisymbolin %1 tuonti: ohitetaan tasattu tasaus</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Tekstisymbolin %1 tuonti: ohitetaan muokattu korostus (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Tekstisymbolin %1 tuonti: muokattu merkkiväli on käytössä, OCAD ei vielä tue sen esittämistä</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Tekstisymbolin %1 tuonti: ohitetaan muokattu sanaväli (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Tekstisymbolin %1 tuonti: ohitetaan muokattu sisennys (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Tekstisymbolin %1 tuonti: ohitetaan tekstin kehykset (muoto %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Kohdetta ei voitu ladata</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Suorakulmaista kohdetta ei voitu tuoda</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tekstisymbolia ei tuoda, couldn&apos;t figure out path&apos; (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Taustakartta ei voitu tuoda: tausta &quot;%1&quot; ei näyttäisi olevan rasterikuva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Yritetään tuoda tekstisymbolia jonka koordinaattimuotoa ei tunnisteta</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Värin id ei löydy: %1, ohitetaan tämä väri</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>on</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>ei ole</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>sisältää</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Haku</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Teksti</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>ja</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>tai</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symboli</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>virheellinen</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Viivasymbolissa %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Tekstisymbolissa %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Koordinaattijärjestelmää &apos;%1&apos; ei voitu ladata.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Spottivärin tiedot ohitettiin.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Ei voi tuoda symbolia  %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Tyyppiä ei tueta &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Taustakarttaa ei voitu tuoda: &quot;%1&quot; ei ole tuettu taustakartan muoto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Viivatyyliä &apos;%1&apos; ei tueta.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Erilaisia terävän viivanpään pituuksia alussa (%1 mm) ja lopussa (%2 mm) ei tueta. Käytetään %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Viivan katkotusta ei voitu tuoda oikein.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Katkotuksen loppuviivan pituutta (%1 mm) ei voituoda oikein. Käytetään %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Katkotuksen loppukatkoa (%1 mm) ei voi tuoda oikein. Käytetään %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Kehyksen tyyliä &apos;%1&apos; ei tueta.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Ohitettiin toissijainen symboli B.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Häivytetään solmupisteen symboli viivan päissä.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Tätä symboolia ei voitu tallentaa kunnollisena OCD symbolina taas.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Tasattu tasaus ei ole tuettu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Pystysuora tasaus &apos;%1&apos; ei ole tuettu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ohitetaan muokattukorostus (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Muokattu merkkivälti voi olla väärin.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ohitetaan muokattu sanaväli (%1%).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ohitetaan muokattu sisennys (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ohitetaan tekstin kehykset (muoto %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Viivaan sidottua tekstisymbolia ei vielä teta. Merkitään symboli piilotetuksi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Koodaus &apos;%1&apos; ei ole käytettävissä. Tarkista asetukset.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>Aluesymbolissa %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Kohdetta ei voitu ladata</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Suorakulmaista kohdetta ei voitu tuoda</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tekstisymbolia ei tuoda, couldn&apos;t figure out path&apos; (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Yritetään tuoda tekstisymbolia jonka koordinaattimuotoa ei tunnisteta</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Virheellinen data.</translation>
     </message>
@@ -5305,59 +5319,59 @@ zoomaa hiiren rullalla.</translation>
         <translation type="vanished">Tiedoston tuontia ei ole testattu tyylille: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>Version %1 OCD-tiedostoja ei vielä tueta!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Värin id ei löydy: %1, ohitetaan tämä väri</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>&quot;%1&quot; SRS:ta ei voi asettaa GDAL:lle: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Sinipunainen</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Piste</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Viiva</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Alue</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Teksti</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Tasoa %1 ei voitu ladata.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>%n kohdetta eI voi ladata, syy: %1</numerusform>
@@ -5365,434 +5379,421 @@ zoomaa hiiren rullalla.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Tyhjä geometria.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Ei voitu määrittää koordinaattitransformointia: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Koordinaattien muuntaminen epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Geometrian tyyppiä ei tunnisteta tai ei tueta.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Ei ole riittävästi koordinaatteja.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Ei voitu käyttää tätä välillistä viittausta:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished">Geospatiaalisella tiedolla ei ole sopivaa välillistä viittausta.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Suunnistuskartta</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Ohjelma suunnistuskarttojen tekemiseen</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Valitse taustakartta johon haluat piirtää</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Piirrä</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klikkaa ja vedä&lt;/b&gt;: Piirrä. &lt;b&gt;Vedä hiiren oikealla&lt;/b&gt;: Pyyhi. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Värin valinta</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä karttaa. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Lisää koordinaatti. &lt;b&gt;%1+Klikkaa&lt;/b&gt;: Muuta valittu koordinaatti. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Aina etelä-pohjois-suuntainen (ei kierrettävä)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Piste</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Viiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Alue</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Keskitä kaikki elementit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Valittu elementti</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Halkaisija &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Sisempi väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Ulompi leveys &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Ulompi väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Viivan leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Viivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Viivanpää:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>tasainen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>pyöreä</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>neliö</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Viivan kulmat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>jiiriliitos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>viisto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Suljettu viiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Alueen väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinaatit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Kaariviivan alku</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Keskitä koordinaatin keskiarvoon</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Keskipiste]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Tuntematon</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Pistesymboli</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Tulostaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Virhe tapahtui käsittelyn aikana.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä karttaa, tulostusaluetta tai tulostusalueen reunoja. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä tulostusaluetta. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä karttaa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä tulostusalueen reunaa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Siirrä tulostusalueen reunoja. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Vie PDF:ksi tai PS:ksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Näytä taustakartat</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Näytä ruudukko</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Sivun suunta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Tulostin:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Pysty</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Vaaka</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Paperikoko:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopioita:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Vasen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Yläreuna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Korkeus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Esikatselu…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Yksi sivu</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Muokattu alue</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Tulostusalue:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Keskitä tulostusalue</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Sivujen limitys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Valinnat</translation>
     </message>
@@ -5805,226 +5806,226 @@ zoomaa hiiren rullalla.</translation>
         <translation type="vanished">Värierottelut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Resoluutio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Tulosta eri mittakaavassa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Taustakartan ulkonäkö voi vaihdella.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simuloi päällepainatus</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Oletusarvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Laitteen CMYK (kokeellinen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Väritila:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Vie…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF vienti</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Kuvan vienti</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Tallenna PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Ei tueta Androidilla.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Esikastelun valmistelu epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Esikatselun eteneminen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Vakionäkymä ei ole päällä. Haluatko varmasti tulostaa / viedä kartan tällaisena?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>PDF-viennin valmistelu epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Virhe tapahtui tulostuksen aikana.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Vie kartta …</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Kaikki tiedostot (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Tulostuksen valmistaminen epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Tulostuksen eteneminen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Ominaisuudet</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektori-
 grafiikka</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Bittikartta-
 grafiikka</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Väri
 erottelut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Moodi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Kuvan valmistaminen epäonnistui. Ei tarpeeksi muistia.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Kuvaa ei voitu tallentaa. Onko tiedostopolku oikein? Onko sinulla riittävät oikeudet?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Viety onnistuneesti %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>PDF-viennin viimeistely epäonnistui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Keskeytetty.</translation>
     </message>
@@ -6033,176 +6034,176 @@ erottelut</translation>
         <translation type="vanished">Tulostaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Tulostustyötä ei voitu pysäyttää.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Tulostustyö luotiin onnistuneesti</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Tuntematon</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Kartan alue on tyhjä. Tulostus keskeytettiin.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Koordinaattijärjestelmä:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Avaa uudelleen taustakartta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Vedä tiedosto vasemmalta haluttuun kohtaan oikealle avataksesi sen uudestaan.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Suljetut taustakartat:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Tyhjennä lista</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktiiviset taustakartat:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Kartta -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Korvaa symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Määrittele miten ja mitkä symbolit korvataan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Tuo kaikki uudet symbolit, vaikka ei käytettäisi korvattaessa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Poista käyttämättömät alkuperäiset symbolit korvaamisen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Poista käyttämättömät värit korvaamisen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Symbolien vertailu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Korvaa symbolit numeroiden perusteella</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Alkuperäinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Muokkaa symbolijoukon ID:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Korvaava</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Täsmää symbolinimen perusteella</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Aseta uudet symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Tyhjennä korvaukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Avaa CRT-tiedosto…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Tallenna CRT-tiedosto…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Symbolien kuvaus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT-tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6213,7 +6214,7 @@ erottelut</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6224,280 +6225,280 @@ erottelut</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Ristiviittaustaulukkoa on muokattu.
 Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Ei mitään -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Valitse karttatiedosto josta symbolit ladataan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Karttatiedostoa ei voi ladata, keskeytetään.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Valittujen symbolien mittakaava on 1:%1, kun kartan mittakaava on 1:%2. Haluatko varmasti käyttää tätä?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>CRT-tiedostoa ei voi ladata, keskeytetään.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Kierrä karttaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Kulma (vastapäivään):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Kierron parametrit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Kierron keskipiste:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Kartan koordinaatiston origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Georeferoinnin kiintopiste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Muu piste,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Valinnat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Säädä georeferoinnin kiintopistettä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Säädä gereferoinnin deklinaatiota</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Kierrä georeferoimattomat taustakartat</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Kulma:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiinteät suunnat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Aseta alueen täytön kuvioiden tai pistemäisten kohteiden suunta. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Kierto:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiinteät suunnat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta kierron keskipiste. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Vedö&lt;/b&gt;: Kierrä valittuja kohteita. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Muuta kartan mittakaavaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Skaalauksen parametrit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Uusi mittakaava:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Skaalauksen keskipiste:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Kartan koordinaatiston origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Georeferoinnin kiintopiste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Muu piste,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Valinnat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Skaalaa symbolien koot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skaalaa kartan kohteiden sijainnit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Säädä georeferoinnin kiintopistettä</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skaalaa georeferoimattomat taustakartat</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skaalataan:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta skaalauksen keskipiste. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;: Skaalaa valitut kohteet. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Valitse koordinaattijärjestelmä</translation>
     </message>
@@ -6506,17 +6507,17 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="vanished">Sama kuin kartalla</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Sama kuin kartalla</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Paikallinen</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Maantieteelliset koordinaatit (WGS84)</translation>
     </message>
@@ -6537,175 +6538,175 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="vanished">Koordinaattijärjestelmän määrittely:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Tila:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>kelvollinen</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; ei voi kirjoittaa. Muutoksia ei voida tallentaa.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; ei ole kelvollista tallennuspaikkaa.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- tyhjä -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Tyhjä -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Numero:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Muokkaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Kuvaus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Apusymboli (ei näytetä valmiissa kartassa)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Yleiset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Painamalla F1 saat näkyviin symbolin kuvauksen vihjelaatikkoon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Uusi symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Piste</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Viiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Alue</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Teksti</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Yhdistetty</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Muokkaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Monista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skaalaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
@@ -6718,12 +6719,12 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="vanished">Täytä / Tee reunaviiva valituille kohteille</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Valitse symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Ota käyttöön &quot;raahaa ja pudota&quot;-toiminto</translation>
     </message>
@@ -6732,197 +6733,197 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="vanished">Skaalaa symboli(t)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Sisäinen virhe, pahoittelut!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Leikepöydällä ei ole liitettäviä symboleita!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Valitse kaikki tämän symbolin kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Lisää kaikki tämän symbolin kohteet valintaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Piilota tämän symbolin kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Suojaa tämän symbolin kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Lisää kaikki valittujen symbolien kohteet valintaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Piilota kaikki valittujen symbolien kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Suojaa valittujen symbolien kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Valitse muut</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Valitse käyttämättömät</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Järjestele symbolit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Numeron mukaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Päävärin mukaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Päävärin tärkeyden mukaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skaalaa prosentteina:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Vahvistus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Kartassa on symbolin &quot;%1&quot; kohteita. Sen poistaminen poistaa myös kohteet ja tyhjentää kumoa-historian! Haluatko todella tehdä niin?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Valitse kaikki valittujen symbolien kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Vaihda symboli tai valitut kohteet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Täytä / Tee reunaviiva valituille kohteille</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Skaalaa symbolit</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Symbolin asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Taustakartta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Malli:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(tyhjä)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Avaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Keskitä malli…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>mallin keskipiste(bbox) origossa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>painopiste origossa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Valitse taustan väri</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6933,58 +6934,58 @@ jokapäiväinen ilmiö
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- nimeämätön -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Ei kuvausta!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Relaatio</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Avain</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Vertailu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Lisää rivi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Poista rivi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Siirrä alas</translation>
     </message>
@@ -6997,7 +6998,7 @@ jokapäiväinen ilmiö
         <translation type="vanished">Ohje</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n kohde valittu</numerusform>
@@ -7005,14 +7006,14 @@ jokapäiväinen ilmiö
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Virheellinen kysely</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Add</source>
         <translation type="vanished">Lisää</translation>
@@ -7043,63 +7044,63 @@ jokapäiväinen ilmiö
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Avain</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Avain on olemassa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Avain &quot;%1&quot; on jo olemassa ja sitä ei saa käyttää kahdesti.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Etsi siirretty taustakartta-tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Kaikki tiedostot (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Tiedostoa ei ole.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Ei ole tarpeeksi vapaata muistia.</translation>
     </message>
@@ -7109,134 +7110,134 @@ jokapäiväinen ilmiö
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Taustakartan asettelu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Asettelua ei voitu laskea!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta piste taustakartalle. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Aseta piste kartalle. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klikkaa&lt;/b&gt;: Poista asettelupisteet. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt;:Siirrä asettelupisteitä. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Asettelupisteet:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Uusi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Siirrä</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Taustakartta X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Taustakartta Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Kartta X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Kartta Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Käytä asettelupisteitä</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Ohje</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Käytä &amp;&amp; tyhjennä kaikki</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Tyhjennä kaikki</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Ei ole tarpeeksi vapaata muistia (kuvan koko: %1x%2 pikseliä)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7245,120 +7246,120 @@ GIF-tiedostojen tallentamista ei tueta. Taustakartalle tehtyjä piirroksia ei ta
 Jos et aio piirtää taustakartalle, tämä ei ole ongelma.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Valitse world-tiedostossa olevien koordinaattien koordinaattijärjestelmä</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Avataan %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Kuvan koko:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Valitse kuinka kuvan sijainti tai mittakaava määritellään:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>World-tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>ei georeferoinnin tietoja</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferoitu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metriä/pikseli:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Skannattu tarkkuudella</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Taustakartan mittakaava:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Näytä</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Läpinäkyvyys</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Ryhmä</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Tiedostonimi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Luonnos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Avaa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georeferoitu: %1</translation>
     </message>
@@ -7367,110 +7368,110 @@ Jos et aio piirtää taustakartalle, tämä ei ole ongelma.</translation>
         <translation type="vanished">Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Monista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Lisää taustakartta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Tuo ja poista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Ohje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Siirrä käsin</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Avaa kuva, GPS-jälki tai DXF-tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Asemointi…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Taustakartta-tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Kaikki tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Säädä…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Tiedostomuotoa ei tunnistettu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Tiedostoa ei voitu ladata. Onko se olemassa ja kelvollinen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Kirjoita sopiva kokonaisluku asettaaksesi ryhmän tai jätä kenttä tyhjäksi jos et halua ryhmitellä taustakarttaa!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Älä skaalaa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Skaalaa kartan mittakaavan suhteessa (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7479,194 +7480,194 @@ Jos et aio piirtää taustakartalle, tämä ei ole ongelma.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Skaalaa nykyisen taustakartan mukaan (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Taustakartan tuonti</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Kuinka tuodun taustakartan symbolit skaalataan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Kartta -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Vedä&lt;/b&gt; siirtääksesi nykyistä taustakarttaa</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Asemointi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Mittakaava:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y:Mittakaava:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Kierto:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Skaalaus ja asemointi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinaatisto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Todellinen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Kartta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Koordinaattiyksikkö vastaa:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Asemoi annettuihin koordinaatteihin</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Asemoi näkymän keskelle</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Tämä taustakartta on ladattava GDAL/OGR:n avulla.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Valitse vektoritiedoston koordinaattien koordinaattijärjestelmä</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Avataan vektoritiedosto…</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Lataa vektoritiedosto georeferoituna tai georeferoimattomana?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Sijoittaa vektoritiedoston kartan georeferoinnin asetusten mukaan.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Näitä ei ole vielä määritelty, joten ne näytetään seuraavana vaiheena.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferoitu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Georeferoimaton</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projisoi vektoritiedoston käyttäen ortografista projektiota keskipiste vektoritiedoston koordinaattien keskiarvossa. Mahdollistaa muunnoksen säätämisen ja kartan georeferoinnin käyttäen säädettyä vektoritiedoston sijaintia.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Vektoritiedosto on tyhjä, ei ole mitään tuotavaa!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Kysymys</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Tuodaanko välipisteet niin, että viiva kulkee niiden kautta?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Ongelmia tuonnissa</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n viivakohde ei voitu tuoda (syy: koordinaatit puuttuvat).</numerusform>
@@ -7674,12 +7675,12 @@ Jos et aio piirtää taustakartalle, tämä ei ole ongelma.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Virhe luettaessa</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7688,39 +7689,39 @@ Jos et aio piirtää taustakartalle, tämä ei ole ongelma.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Ei ole OSM-tiedosto.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM-tiedosto on versio %1.
 Tuetaan vain versiosta %2 alkaen.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM-tiedosto on versio %1.
 Tuetaan vain versioon %2 asti.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Ongelmia</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 solmupistettä(node) ei voitu käsitellä oikein.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Ulkoinen linkki: %1</translation>
@@ -7731,58 +7732,58 @@ Tuetaan vain versioon %2 asti.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Tasaus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Vasen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Keskellä</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Oikea</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Ylös</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Perusviiva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Alas</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Tekstin asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Fontin nimi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Fontin koko:</translation>
     </message>
@@ -7791,297 +7792,297 @@ Tuetaan vain versioon %2 asti.</translation>
         <translation type="vanished">Määrittele koko…</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Tekstin väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>lihavoitu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>kursivoitu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>alleviivattu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Tekstin tyyli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Viivojen väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Kappaleiden väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Merkkien väli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Välistys</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Symbolin kuvakkeen teksti:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Kehykset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD yhteensopivuuden asetukset</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Kehyksen väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Viivavarjostus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Varjostus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Vasen/Oikea Siirto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Ylä/Ala-Siirto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD yhteensopivuus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>käytössä</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Viivan leveys:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Viivan väri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Sijainti:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Viiva kappaleiden alla</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Etäisyys perusviivasta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Muokattu sarkaimen paikka</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Lisää muokattu sarkain</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Laskea</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Ei voi kumota koska edellinen vaihe ei enää ole mahdollinen. Tämä voi tapahtua jos esimerkiksi vaihdat kohteen symbolin ja poistat vanhan symbolin.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Vahvistus</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Tämän vaiheen kumoaminen vie kauemmas kuin kohtaan, jossa tiedosto ladattiin. Oletko varma?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Ei voi tehdä uudestaan koska seuraava vaihe ei enää ole mahdollinen. Tämä voi tapahtua jos vaikka poistat juuri piirretyn kohteen symbolin.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Ohje-tiedostoa ei löytynyt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Ohjeen lukijaa ei löytynyt (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Ohje selainta ei voitu käynnistää (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Katso lisää…</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elementtiä ei tueta: %1 (rivi %2 sarake %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Jotkin koordinaatit ovat tulostusrajojen ulkopuolella. Kartan sisältöä säädetty.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>Epämääräinen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Osaa tiedostosta ei voida lukea tällä Mapper versiolla. Minimi vaadittu versio: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Virhe rivillä %1 sarakkeessa %2: %3</translation>
     </message>
@@ -8090,44 +8091,44 @@ Tuetaan vain versioon %2 asti.</translation>
         <translation type="vanished">Kartan muistiinpanoja ei voitu lukea.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Joitain virheellisiä merkkejä oli poistettava.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Tuntematon virhe</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Georeferoinnin määrittelyä &apos;%1&apos; ei tueta tai ei kelpaa: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Oletettiin %1 väriä, löydetty %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Spottiväriä %1 ei löytynyt käsiteltäessä %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Oletettiin %1 symbolia, löydetty %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Oletettiin %1 karttaosaa, löydetty %2.</translation>
     </message>

--- a/translations/OpenOrienteering_fr.ts
+++ b/translations/OpenOrienteering_fr.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr_FR">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>À propos de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Ce programme est un logiciel libre : vous pouvez le redistribuer ou le modifier suivant les termes de la &lt;a %1&gt;“GNU General Public License” (GPL), version&amp;nbsp;3&lt;/a&gt;, telle que publiée par la Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Ce programme est distribué dans l’espoir qu’il vous sera utile, mais SANS AUCUNE GARANTIE ; sans même la garantie implicite de COMMERCIALISABILITÉ ni D’ADÉQUATION À UN OBJECTIF PARTICULIER. Consultez la General Public License (GPL), version &amp;nbsp;3, pour&lt;a %1&gt;plus de details&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Au sujet des licences, droits d&apos;auteurs, conditions et avertissements.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Les développeurs d&apos;OpenOrienteering par ordre alphabétique :</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(initiateur du projet)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Un logiciel libre pour dessiner des cartes de course d&apos;orientation</translation>
@@ -54,7 +67,7 @@
         <translation type="vanished">Développeurs par ordre alphabétique :</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Pour leurs contributions, merci à :</translation>
     </message>
@@ -76,203 +89,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Ouvrir le fichier le plus récent</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Afficher l&apos;astuce du jour</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Afficher le reste de la liste</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Taille minimale :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Remplissages</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Hachures</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Motifs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Ligne unique</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Lignes parallèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Espacement des lignes :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Rangée unique</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Espacement des motifs :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Décalage des motifs :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Décalage des rangées :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Rangées parallèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Espacement des rangées :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Direction du remplissage</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Angle :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>ajustable pour chaque objet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Element dessiné en bordure</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Fixe les éléments sur la bordure.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Dessine les éléments si leur centre est dans la surface.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Dessine les éléments si une partie est dans la surface.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Trace les éléments si tous les points sont à l&apos;intérieur de la zone définie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Paramètres de surface</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Motif de remplissage %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Ligne de remplissage %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Aucun remplissage sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Couleur de surface :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Décalage de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Couleur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Épaisseur de ligne :</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Fichier auto-sauvegardé</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n octet</numerusform>
@@ -280,249 +293,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Fichier sauvegardé par l&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Fichier de récupération</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Le fichier %1 n&apos;a pas été correctement fermé. Actuellement, il en existe deux versions :</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Sauvegarder le fichier en cours d&apos;édition pour résoudre le conflit de version.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Éditer la palette des couleurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Éditer</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Définit une couleur en ton direct :</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mélanger des tons directs (trames et sur-impression) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout : efface les couleurs les plus basses</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Créer à partir des tons directs</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Créer à partir des couleurs RVB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Créer une couleur personnalisée :</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Noir</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Créer à partir des couleurs CMJN</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Créer une couleur RVB personnalisée :</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRVVBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Menu général</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Impression professionnelle</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- sans nom -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- vide -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Opacité</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Ton direct</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMJN</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RVB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Double-clic sur une couleur pour ouvrir la boîte de dialogue.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>La carte contient des symboles utilisant cette couleur. Sa suppression effacera la couleur de ces objets ! Voulez-vous vraiment le faire ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (dupliqué)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Dupliqué)</translation>
     </message>
@@ -535,300 +548,300 @@
         <translation type="vanished">Veuillez entrer un pourcentage entre 0 et 100% !</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Double-clic pour définir une couleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Cliquez pour sélectionner le nom et cliquez de nouveau pour éditer.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Nombre d&apos;éléments :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Symbole de ligne utilisé en combinaison -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Symbole de surface utilisé en combinaison -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Éditer le symbole personnel…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Paramétrage de la combinaison</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Modifier le statut du symbole de public à personnel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Voulez-vous prendre l&apos;ancien symbole comme modèle pour un symbole de combinaison ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbole %1 :</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Paramétrage de la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Aimanter la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Choisir…</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Toutes les lignes</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Lignes horizontales</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Lignes verticales</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Alignement</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Aligner avec le nord magnétique</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Aligner avec le nord de la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Aligner avec le nord vrai</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Rotation additionnelle (anti-horaire) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Calage</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>mètres sur le terrain</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>millimètres sur la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Espacement horizontal :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Espacement vertical :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Décalage horizontal :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Décalage vertical :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Unité :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Couleur des lignes :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Afficher :</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Choisir la couleur de la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origine placée à: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Origine des coordonnées papier</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>origine des coordonnées projetées</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Clic ou glisser&lt;/b&gt;: pour débuter le dessin d&apos;un trou. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>La ligne de coupe doit se terminer sur la limite de la surface !</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Le début et la fin de la ligne de coupe sont sur différentes parties de l&apos;objet !</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Le début et la fin de la ligne de coupe sont à la même position !</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt; sur une ligne: pour la séparer en deux. &lt;b&gt;Glisser&lt;/b&gt; le long d&apos;une ligne: pour supprimer une partie de cette ligne. &lt;b&gt; Clic ou Glisser&lt;/b&gt; sur la bordure d&apos;une surface: pour dessiner une ligne de coupe. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Les trous de coupe des objets-surfaces ne sont pas encore supportés !</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour rogner toute la carte. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Clic ou Glisser&lt;/b&gt;: pour sélectionner les objets à rogner. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour rogner les objets sélectionnés. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Impossible d&apos;ouvrir le fichier.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Ce fichier n&apos;est pas un fichier DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Déterminer la taille de police</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Lettre :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -842,261 +855,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Distributer des points le long du segment</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Nombre de points sur le segment :</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Placer aussi des points en fin de segment</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Paramétrage de la direction des points</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Aligner les points avec la direction du segment</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Angle de rotation additionnel (sens anti-horaire) :</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Depuis le centre</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour débuter le dessin du cercle ou de l&apos;ellipse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour dessiner le cercle. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Maintenir %1 pour débuter le dessin à partir du centre.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour terminer le cercle. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour dessiner une ellipse. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt; : Dessiner un segment. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Mode insertion pointillé activé.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: pour aimanter ou ajouter à d&apos;autres objets. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: pour prendre la direction à partir des objets existants. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt;: pour aimanter aux objets existants. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt; : Angles fixés. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour annuler le dernier point. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Terminer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Angle</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Mode insertion pointillé</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Abandonner</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Longueur:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour débuter une ligne droite. &lt;b&gt;Glisser&lt;/b&gt;: Débuter une courbe. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Glisser&lt;/b&gt;: pour suivre les objets existants. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour dessiner une ligne droite. &lt;b&gt;Glisser&lt;/b&gt;: pour dessiner une courbe. &lt;b&gt;Clic droit ou double-clic&lt;/b&gt;: pour terminer le segment. &lt;b&gt;%1&lt;/b&gt;: pour fermer le segment. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Toucher la carte pour terminer le calibrage</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour terminer le paramétrage de l&apos;objet. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Angle</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Angle :&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angles fixés. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour créer un objet-point.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour créer un objet et indiquer son orientation.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: pour réinitialiser la rotation.</translation>
     </message>
@@ -1106,76 +1119,76 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Terminer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Ligne aimantée</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Mode insertion pointillé</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Clic ou Glisser&lt;/b&gt;: pour débuter le dessin d&apos;un rectangle. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour aimanter aux lignes précédentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour placer un sommet. &lt;b&gt;Clic droit ou Double-clic&lt;/b&gt;: pour terminer le rectangle. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour terminer l&apos;édition. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Edite l&apos;annulation. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour créer un texte avec un seul ancrage. &lt;b&gt;Glisser&lt;/b&gt;: pour créer une boîte de texte. </translation>
     </message>
@@ -1185,130 +1198,130 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Basculer en mode courbe</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Mouvement libre. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; sur un segment pour basculer entre mode ligne droite et mode courbe. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aimanter</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Point / Angle</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Basculer en mode pointillé</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour terminer l&apos;édition. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour conserver la position de la poignée opposée. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; sur un point pour le supprimer; sur un chemin pour ajouter un nouveau pointillé; avec &lt;b&gt;%2&lt;/b&gt;: pour ajouter un point normal. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; sur un point pour le supprimer; sur un chemin pour ajouter un nouveau point; avec &lt;b&gt;%2&lt;/b&gt;: pour ajouter un pointillé. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Clic&lt;/b&gt; sur un point pour basculer entre le mode pointillés et le mode point normal. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Décalage des coordonnées:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angles fixés. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour aimanter aux objets existants. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour sélectionner un seul objet. &lt;b&gt;Glisser&lt;/b&gt;: pour sélectionner plusieurs objets. &lt;b&gt;%1+Clic&lt;/b&gt;: pour basculer (ou non) en mode sélection. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: pour supprimer les objets sélectionnés. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Affichage de la carte en haute qualité (anti-aliasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>L&apos; anti-crénelage (anti-aliasing) rend la carte plus belle, mais ralentit son affichage</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Affichage du texte en haute qualité (anti-aliasing), lent</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolérance des clics :</translation>
     </message>
@@ -1317,315 +1330,315 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Distance d&apos;aimantage (%1) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Intervalle du mode angles fixés (%1) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>A la sélection d&apos;un objet, automatiquement sélectionner son symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Se déplacer par rapport au curseur lors d&apos;un zoom arrière</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Outils de dessin: définir le dernier point avec un clic droit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Modèles: garder les préférences des modèles fermés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Outil d&apos;édition :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Conserver l&apos;ancienne forme</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Réinitialiser les poignées extérieures de la courbe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Conserver les poignées extérieures de la courbe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Action lors de la suppression d&apos;un point de courbe avec %1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Outil rectangle :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Rayon de la croix d&apos;aide :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Aperçu de l&apos;épaisseur des lignes de la croix d&apos;aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Éditeur</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Impossible de créer le nouveau fichier : %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Le format (%1) ne permet pas l&apos;export</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>La surface de la carte est très grande. L&apos;utilisation de l&apos;outil de remplissage pourrait être très lent. Voulez-vous quand même l&apos;utiliser ?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>La surface sélectionnée n&apos;est pas fermée par des lignes ou surfaces, elle ne peut pas être remplie.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>La position sélectionnée n&apos;est pas libre, l&apos;outil de remplissage ne peut pas être utilisé ici.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Incident durant le remplissage de l&apos;objet.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour remplir la surface avec le symbole sélectionné. La surface à remplir doit être limitée par des lignes ou des surfaces, les autres symboles ne sont pas pris en compte. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS désactivé dans la configuratione de la tablette. Voulez-vous reconfigurer maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importer avec GDAL/OGR :</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Paramétrage</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Paramètre</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Apparence</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Langue :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixels par pouce :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>À l&apos;ouverture du logiciel :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Fichier sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Maintenir la compatibilité avec Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Sauvegarder l&apos;historique des effacement/rétablissement</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Activer la sauvegarde automatique en cas de plantage</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervalles des sauvegardes automatiques :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Fichiers import et export</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>Encodage (8 bits) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Plus…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Utiliser le nouvel importateur Ocad, y compris pour les fichiers version 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Note</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Le programme doit être redémarré pour que le changement de langue soit effectif !</translation>
     </message>
@@ -1634,47 +1647,47 @@
         <translation type="vanished">Utiliser un fichier de traduction…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Ouvrir une traduction</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Fichiers de traduction (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Le fichier de traduction sélectionné n&apos;est pas valide.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>Résolution de l&apos;écran principal (en pixels):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Résolution en pixels de l&apos;écran principal :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Taille de la diagonale de l&apos;écran principal (en pouce) :</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Coordonnées UTM</translation>
     </message>
@@ -1683,80 +1696,80 @@
         <translation type="vanished">Zone UTM (numéro nord/sud, ex: &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>Zone UTM (nombre nord/sud)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krüger (système de coordonnées allemand), datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Coordonnées Gauss-Krüger</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Numéro de zone (1 à 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>par code EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>Coordonnées EPSG @code@</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Coordonnées locales</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Code EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Specification PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Spécification</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Échelle de la carte invalide ou manquante.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Facteur d&apos;échelle incorrect : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Langage de spécification CRS inconnu: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Spécification CRS géographique non supportée: %1</translation>
     </message>
@@ -1765,7 +1778,7 @@
         <translation type="vanished">Échelle seule</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
@@ -1775,73 +1788,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Géoréférencement de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Consultation…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Déclinaison :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Coordonnées projetées</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Statut :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Facteur d&apos;échelle :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Coordonnées géographiques</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Afficher le point de référence sur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>valide</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Consultation en ligne de la déclinaison</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Système de coordonnées de référence (CRS) de la carte</translation>
     </message>
@@ -1854,7 +1867,7 @@
         <translation type="vanished">- à partir de la spécification Proj. 4 -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- local -</translation>
     </message>
@@ -1863,112 +1876,112 @@
         <translation type="vanished">Spécification CRS :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Point de référence</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Choisir sur la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Nord de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Système de coordonnées de référence :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Coordonnées de la carte :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Coordonnées géographiques :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>En cas de changement de CRS, garder :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Déclinaison magnétique :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>La déclinaison magnétique du point de référence %1 %2° ne pourra pas être récupérée à partir de &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Voulez-vous continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Changement de déclinaison</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>La déclinaison a été changée. Voulez-vous appliquer une rotation à la carte en fonction de celle-ci ?</translation>
     </message>
@@ -1977,66 +1990,66 @@
         <translation type="vanished">Coordonnées projetées :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Coordonnées locales :</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Chargement…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>verrouillé</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Impossible de lire et d&apos;analyser les données.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Valeur de déclinaison introuvable.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>La consultation en ligne de la déclinaison a échoué:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Clic&lt;/b&gt; : Placer le point de référence. Appuyez sur un autre bouton pour annuler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Clic&lt;/b&gt; : Placer le point de référence. &lt;b&gt;Clic droit&lt;/b&gt; : Annuler.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Bienvenue sur OpenOrienteering Mapper !</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Clear list</source>
         <translation type="vanished">Effacer la liste</translation>
@@ -2100,118 +2113,118 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Actions</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Créer une nouvelle carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Ouvrir une carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>À propos de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Cartes récentes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Ouvrir le fichier le plus récent lors du démarrage</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Effacer la liste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Astuce du jour</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Afficher l&apos;astuce du jour</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Exemples</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>À propos de Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Liste des fichiers</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Aucun fichier trouvé! &lt;br/&gt;&lt;br/&gt;Copiez les fichiers cartes à la racine du répertoire &apos;OOMapper&apos; dans la tablette ou dans la carte mémoire.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Erreur lors du chargement d&apos;un symbole de type %1 à la ligne %2 colonne %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>L&apos;identifiant du symbole &apos;%1&apos; n&apos;est pas unique à la ligne %2 colonne %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Erreur lors du chargement d&apos;un symbole de type %1 à la ligne %2 colonne %3: %4</translation>
     </message>
@@ -2220,84 +2233,84 @@
         <translation type="vanished">Erreur lors du chargement d&apos;un symbole.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Erreur lors du chargement d&apos;un objet de type %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Erreur lors du chargement d&apos;un objet type %1 à %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Impossible de trouver le symbole de l&apos;objet à %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Objet-point ayant un symbole indéfini ou incorrect à %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD versions 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Impossible de lire et d&apos;analyser les coordonnées.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>%1 coordonnées attendues, %2 trouvées.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Erreur lors du chargement de la configuration de l&apos;imprimante en %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Erreur lors du chargement des scripts &apos;undo/redo&apos; à %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Aucun option : %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Données vectorielles géospatiales</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Un objet n&apos;ayant pas de symbole a été trouvé.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Suppression de %n objet erroné.</numerusform>
@@ -2305,36 +2318,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Erreur durant le post-traitement des symboles.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Le modèle &quot;%1&quot; a été chargé depuis le répertoire de la carte au lieu de l&apos;emplacement relatif au fichier de la carte où il se trouvait précédemment.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Fichier modèle &apos;%1&apos; ne peut pas être chargé, raison: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Alertes durant le chagement du template &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Au moins un fichier modèle n&apos;a pu être trouvé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Cliquez sur le(s) nom(s) des modèles surlignés en rouge dans le menu : Modèles -&gt; Écran de paramétrage des modèles pour localiser le nom du modèle(s).</translation>
     </message>
@@ -2343,173 +2356,173 @@
         <translation type="vanished">Au moins un fichier modèle n&apos;a pu être trouvé. Dans la fenêtre des Modèles, cliquer sur le nom des modèles en rouge, pour rechercher le bon emplacement du fichier.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Ce fichier utilise un format obsolète. Le traitement de ce type de format est absent de cette version du logiciel. Pour pouvoir ouvrir ce fichier ultérieurement, sauvegardez-le de nouveau.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Format du fichier invalide.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Ce fichier est plus supporté (ancien format). Veuillez utiliser le logiciel dans une version plus ancienne pour charger et remettre à jour ce fichier.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Ce fichier n&apos;est pas supporté (format récent). Certains éléments de la carte ne seront pas chargés ou sauvegardés avec cette version du logiciel. Pensez à mettre jour le logiciel.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Le système de coordonnées géographique de référence de la carte était &quot;%1&quot;. Ce CRS n&apos;est plus supporté. Utilisez &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Erreur lors du chargement d&apos;un symbole de type %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Erreur lors du chargement d&apos;un symbole.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Erreur lors du chargement des étapes d&apos;annulation.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Erreur lors de la lecture du nombre de parties de la carte.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Erreur lors du chargement de la partie %2 de la carte.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Impossible de lire le fichier suivant: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Format de fichier non supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Format de fichier trop récent. Certains éléments de la carte ne seront pas chargés ou sauvegardés avec cette version du logiciel.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Le format (%1) ne permet pas l&apos;import</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Ne peux pas lire &apos;%1&apos; : %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Paramétrage de ligne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Épaisseur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Couleur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Longueur minimale de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Extrémité de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>plate</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>ronde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>carrée</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>pointue</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Sommet de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>aigu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>rogné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Longueur des extrémités :</translation>
     </message>
@@ -2519,334 +2532,335 @@
         <translation>La ligne est en pointillés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Afficher au moins un symbole intérieur</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Minimum de symboles intérieurs :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimum de symboles intérieurs dans une ligne close :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Longueur d&apos;un pointillé :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Ligne pointillée</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Espacement des pointillés :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Pointillés groupés :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>aucun</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Espace entre les pointillés groupés :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Demi-pointillés au début et à la fin</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Symboles intérieurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Symboles intérieurs par groupe :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Distance des symboles intérieurs :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Bordures</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Bordures différentes sur les côtés droit et gauche</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Bordure gauche :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Bordure droite :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Supprimer le symbole en pointillés au début et à la fin de la ligne</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Symbole de début</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Symbole intérieur</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Symbole de fin</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Symbole pointillés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Activer les bordures</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Distance entre chaque groupement :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Distance depuis la fin de la ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Redimensionne le symbole pointillé dans les coins</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Épaisseur des bordures :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Couleur des bordures :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Décalage des bordures :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>La bordures est en pointillés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Longueur du pointillé :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Espace entre les pointillés :</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Créer une nouvelle carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Ouvrir…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Ouvrir un fichier existant</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Ouvrir un fichier &amp;récent</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Enregistrer &amp;sous…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Préférences…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Fermer ce fichier</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Quitter le programme</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Ouvrir le &amp;manuel</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Afficher le fichier d&apos;aide de ce logiciel</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>À &amp;propos de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Afficher les informations à propos de ce logiciel</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Afficher les informations à propos de Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Voulez-vous supprimer la version autosauvegardée ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Le fichier a été modifié.
 Voulez-vous enregistrer vos modifications ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Fichier non-sauvegardé</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2855,60 +2869,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Voulez-vous redimensionner ces symboles à l&apos;échelle de la carte ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Avertissement d&apos;anomalie majeure</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Il semblerait que %1 ait provoqué une anomalie majeure lorsque ce fichier a été ouvert pour la dernière fois:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Voulez-vous vraiment réessayer de l&apos;ouvrir ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Auto-sauvegarde…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Anomalie d&apos;autosauvegarde !</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Toutes les cartes</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Vous devez fermer le fichier ouvert avant de pouvoir en ouvrir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Ouverture %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2919,19 +2933,19 @@ File format not recognized.</source>
 Format du fichier non reconnu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Ce fichier a été modifié.
 Voulez-vous annuler vos modifications ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2942,44 +2956,44 @@ Appuyez sur Oui pour enregister dans ce format.
 Appuyez sur Non pour choisir un autre format.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Enregistrer le fichier</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Le fichier ne peut être enregistré :</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Un problème est survenu lors de la détermination du format du fichier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Signaler cela comme étant un bug.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2988,7 +3002,7 @@ because saving as %2 (.%3) is not supported.</source>
 car enregistrer en %2 (.%3) n&apos;est pas supporté.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3003,31 +3017,31 @@ car le format est inconnu.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>L&apos;export de la carte a généré des avertissements.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Erreur interne lors de l&apos;enregistrement:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>L&apos;import de la carte a généré des avertissements.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3036,12 +3050,12 @@ for reading.</source>
 en lecture.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Type de fichier invalide.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3052,7 +3066,7 @@ en lecture.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3061,17 +3075,17 @@ en lecture.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Rien à importer.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3080,23 +3094,23 @@ Rescale the imported data?</source>
 Voulez-vous redimensionner le fichier importé ?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>partie par défaut</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nouvelle couleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importer…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Le remplacement du symbole a été annulé.
@@ -3104,220 +3118,220 @@ Faut-il poursuivre l&apos;import ?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Registration black</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Les coordonnées sont hors des limites.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Imprimer…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Annuler la dernière action</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Rétablir la dernière action</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>&amp;Couper</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>C&amp;opier</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>Co&amp;ller</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Tout désélectionner</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Inverser la sélection</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Basculer en mode plein écran</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Définir un facteur de zoom…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Fenêtre des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Afficher/Masquer la fenêtre des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Fenêtre des couleurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Afficher/Masquer la fenêtre des couleurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Remplacer les symboles par ceux provenant d&apos;un autre carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Redimensionner tous les symboles…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Redimensionner toute la bibliothèque de symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Changer l&apos;échelle de la carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Changer l&apos;échelle de la carte et redimensionner la taille des objets et des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Notes sur la carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Fenêtre des modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Afficher/Masquer la fenêtre des modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Ouvrir un modèle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Afficher toute la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Éditer des objets</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Créer des objets point</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Dessiner des segments</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Dessiner des cercles et des ellipses</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Écrire un texte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Échanger le symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Remplir/Entourer une surface</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Inverser la direction</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Joindre des segments</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Couper l&apos;objet</translation>
     </message>
@@ -3326,126 +3340,126 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">Rotation des objets</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mesurer les longueurs et surfaces</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importer…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Édition</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Vue</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>Ou&amp;tils</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Sy&amp;mboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>C&amp;arte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Dessin</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Dessiner sur le modèle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Configurer la grille…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Afficher surfaces hachurées</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Afficher les lignes de bases</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Masquer tous les modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Géoréférencement…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Pivoter la carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Pivoter toute la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Réouvrir le modèle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Dessiner des rectangles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Découper un trou</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Découper un trou circulaire</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Découper un trou rectangulaire</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Pivoter le motif</translation>
     </message>
@@ -3454,12 +3468,12 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">Redimensionner les objets</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Union de surfaces</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Intersection de surfaces</translation>
     </message>
@@ -3468,37 +3482,37 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">Soustraction de surfaces</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Exclusion de surfaces</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Coordonnées de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Coordonnées projetées</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Latitude/Longitude (Déc)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Latitude/Longitude (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Afficher les coordonnées comme…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Découper un trou</translation>
     </message>
@@ -3507,43 +3521,43 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">Factice</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Vue</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Sélectionner un modèle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Édition</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Édition avancée</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Aucune action ne peut être annulée.</translation>
     </message>
@@ -3553,8 +3567,8 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">%1 objet(s) coupé(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Une erreur interne est survenue, désolé !</translation>
     </message>
@@ -3563,7 +3577,7 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">%1 objet(s) coupé(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Il n&apos;y a aucun objet dans le presse-papier qui puisse être collé !</translation>
     </message>
@@ -3572,589 +3586,589 @@ Faut-il poursuivre l&apos;import ?</translation>
         <translation type="vanished">%1 objet(s) collé(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Définir un facteur de zoom</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Facteur de zoom :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Couleurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Redimensionner tous les symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Facteur de redimendionnement :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Notes sur la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Positionner des objets point sur la carte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Sélectionner un symbole point pour utiliser cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Dessiner des polygones et des lignes courbes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Sélectionner un symbole ligne, surface ou combiné pour utiliser cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Dessiner des cercles et des ellipses.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Définir la direction des objets points ou du motif des objets surfaces.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Sélectionner un objet surface ayant un motif pivotable ou un objet point pivotable pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Symbole final: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Sélectionner au moins deux objets surfaces ou objets segments pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Unir des objets superposés.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Enlever toutes les parties qui ne se superposent pas avec le premier objet sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Supprimer les parties superposées au premier objet sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Supprimer toutes les parties qui se superposent avec le premier objet sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Réunir les trous ensembles, ou fondre les trous avec la limites de l&apos;objet surface.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Sélectionner un symbole surface ayant des trous pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>La réunion des trous n&apos;a pas abouti.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Effacer les marqueurs GPS temporaires</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Êtes-vous sûr de vouloir supprimer tous les marqueurs GPS temporaires? Cette opération est irréversible.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Réunir cette partie avec</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Déplacer les objets sélectionnés vers</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Entrer le nom de la partie de la carte :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Déplacé vers la partie &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Réunir toutes les parties de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Voulez-vous déplacer tous les objets de la partie &quot;%1&quot; vers &quot;%2&quot;, puis supprimer &quot;%1&quot; ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Voulez-vous déplacer tous les objets vers la partie &quot;%1&quot;, et supprimer toutes les autres parties ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Impossible d&apos;importer le fichier de carte sélectionné, car il ne peut pas être chargé.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Dessiner des rectangles.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Édition en cours</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>La carte est en cours d&apos;édition. Veuillez terminer votre édition avant de sauvegarder.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Carte sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Image</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Effacer l&apos;historique des actions (annuler/rétablir)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Efface l&apos;historique des actions (annuler/rétablir) afin de réduire la taille du fichier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Déplacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulation de surimpression</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Remplacer la bibliothèque de symboles…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Éditeur de tags</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Montrer/Cacher la fenêtre d&apos;édition de tags</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Éditer des lignes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Dessiner à main levée</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Remplir des surfaces fermées</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl + M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Table des symboles ID...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Editer la table des symboles ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Charge le fichier de correspondance des symboles...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Assigne les nouveaux symboles avec la table de correspondance des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Couper dans une surface</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Fusionner les trous</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Convertir en courbes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Simplifier le segment</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Découpe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Découpage intérieur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Distribuer des points le long du segment</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Dessiner sur le modèle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Activer le curseur sensitif</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Activer l&apos;affichage du GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Activer le cercle de précision du GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Ajouter un symbole point à la position GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Ajouter un marqueur temporaire à la position GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Créer un segment temporaire à la position GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Supprimer tous les marqueurs GPS temporaires</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Activer l&apos;affichage du compas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Aligner la carte avec le nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Ajouter une nouvelle partie…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Renommer la partie active…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Supprimer la partie active</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Réunir toutes les parties</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Copier la position</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Copier la popsition dans le presse-papier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exporter comme…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Parties de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Sélectionner le symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Cacher la barre du haut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Afficher le barre du haut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Imprimer/Exporter n&apos;est pas disponible dans cette version du logiciel !</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Table des symboles ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Éditeur de tags</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4164,7 +4178,7 @@ symbole
 sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4174,22 +4188,22 @@ symboles
 sdélectionnés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Dessiner des segments à main levée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Remplir une surface fermée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Écrire du texte sur la carte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Sélectionner un symbole de texte pour utiliser cet outil.</translation>
     </message>
@@ -4202,26 +4216,26 @@ sdélectionnés</translation>
         <translation type="vanished">Dupliquer les objets sélectionnés.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Sélectionnez au moins un objet pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Inverser la direction du symbole ligne.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Sélectionner au moins un objet inversable pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Joindre les extrémités des segments qui sont proches.</translation>
     </message>
@@ -4230,17 +4244,17 @@ sdélectionnés</translation>
         <translation type="vanished">Couper l&apos;objet sélectionné en plus petites parties.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Sélectionner au moins un objet ligne ou un objet surface pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Découper un trou dans l&apos;objet surface sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Sélectionner un seul objet surface pour activer cet outil.</translation>
     </message>
@@ -4277,34 +4291,34 @@ sdélectionnés</translation>
         <translation type="vanished">Déterminer les surfaces qui ne se superposent pas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Convertir les segments rectilignes en courbes de bézier lissées.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Sélectionner un objet segment pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Réduire le nombre de points dans un segment tout en essayant de conserver sa forme.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Rogner les objets se trouvant à l&apos;extérieur de la surface choisie ou la carte entière.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Sélectionner un objet segment fermé, comme forme de découpage, pour activer cet outil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Découper tous les objets se trouvant à l&apos;intérieur de la surface choisie.</translation>
     </message>
@@ -4313,8 +4327,8 @@ sdélectionnés</translation>
         <translation type="vanished">Échanger le symbole de l&apos;objet sélectionné par le symbole sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Sélectionner au moins un objet et un symbole différent et compatible, pour activer cet outil.</translation>
     </message>
@@ -4323,12 +4337,12 @@ sdélectionnés</translation>
         <translation type="vanished">Remplir la ligne sélectionnée ou crée une bordure autour de la surface sélectionnée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Ajouter sur le segment sélectionné des symboles points avec des espacements réguliers</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Sélectionner au moins un segment et un symbole point pour activer cet outil.</translation>
     </message>
@@ -4337,7 +4351,7 @@ sdélectionnés</translation>
         <translation type="vanished">%1 objets dupliqués</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Sélection d&apos;objet</translation>
     </message>
@@ -4346,77 +4360,77 @@ sdélectionnés</translation>
         <translation type="vanished">Aucun objet n&apos;a été sélectionné car il n&apos;existe pas d&apos;objet ayant le symbole sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mesure</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>L&apos;unification a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>L&apos;intersection a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>La différence a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>La fonction &quot;ou exclusive&quot; a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Voulez-vous supprimer la partie &quot;%1&quot; et tous les objets qu&apos;elle contient ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Dessiner à main levée sur le modèle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Dessiner à main levée sur le modèle. Créer ou charger un modèle sur lequel il sera possible de dessiner à l&apos;aide de ce bouton</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importer des fichiers %1, GPX, OSM ou DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Fichiers importables</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Impossible d&apos;importer le fichier sélectionné car son format n&apos;est pas supporté.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation type="unfinished">
@@ -4425,7 +4439,7 @@ sdélectionnés</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4433,7 +4447,7 @@ sdélectionnés</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4441,42 +4455,42 @@ sdélectionnés</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4484,178 +4498,178 @@ sdélectionnés</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Abandonner. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Plus avec: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Plus avec: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Plus avec: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Carte -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Calcul de la séparation de la page %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Calcul la page %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Terminé</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4670,7 +4684,7 @@ pour ouvrir la boîte de dialogue correspondante
 et créer des couleurs.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4685,7 +4699,7 @@ et sélectionner &quot;Nouveau symbole&quot;
 pour en créer un.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4698,7 +4712,7 @@ Pour charger un modèle, cliquez sur
 &quot;Modèles&quot; -&gt; &quot;Ouvrir modèle&quot;…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Conseil : Maintenir le bouton central
@@ -4707,123 +4721,123 @@ utiliser la molette de la souris pour zoomer.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Longueur du périmètre :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Longueur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Surface :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Aucun objet est sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objets selectionnés.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>L&apos;objet sélectionné n&apos;est pas un segment.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Cet objet est trop petit.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>La surface minimale est %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Note: La longueur du périmètre et la surface sont justes, uniquement si le périmètre ne forme pas de boucles et l&apos;objet n&apos;a pas de trous.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Cette ligne est trop courte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>La longueur minimale est %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Créer une nouvelle carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Choisir l&apos;échelle et la bibliothèque de symboles pour la nouvelle carte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Échelle:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Bibliothèques des symboles :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>N&apos;afficher uniquement les bibliothèques de symboles compatibles avec l&apos;échelle sélectionnée</translation>
     </message>
@@ -4832,140 +4846,140 @@ utiliser la molette de la souris pour zoomer.</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Créer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>La bibliothèque des symboles est vide</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Charger une bibliothèque des symboles à partir d&apos;un fichier…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Tous les fichiers de bibliothèque de symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>La carte contient plus de 256 couleurs, ceci n&apos;est pas supporté par Ocad version 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad renvoie %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>&quot;Registration black&quot; a été exportée comme une couleur ordinaire.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Impossible d&apos;exporter un motif pour un objet surface</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Impossible d&apos;exporter le modèle: le type du fichier (%1) n&apos;est pas encore supporté</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Pour le symbole ligne &quot;%1&quot;,impossible de dessiner la combinaison entre l&apos;extrémité et la jointure.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Pour le symbole ligne &quot;%1&quot;, le groupe de pointillés a été ignoré.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Pour le symbole ligne &quot;%1&quot;, le nombre de pointillés par groupe a été réduit à 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Pour le symbole ligne &quot;%1&quot;, impossible d&apos;exporter correctement les bordures.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Pour le symbole surface &quot;%1&quot;, un motif a été ignoré.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Pour le symbole surface &quot;%1&quot;, les motifs en rangées sont supposés être décalés. Ceci peut se révéler correct tout comme incorrect.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Pour le symbole texte &quot;%1&quot;: un espacement personnalisé a été choisi entre les caractères, ceci peut être incompatible avec les fonctions d&apos;Ocad</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Pour le symbole texte &quot;%1&quot;, le soulignement a été ignoré</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Pour le symbole texte &quot;%1&quot;, le crénage a été ignoré</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Chaîne de caractère tronquée (Les retraits sont marqués par trois &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Impossible d&apos;allouer de la mémoire tampon.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad renvoie %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>Les fichiers OCAD de version %1 ne sont pas supportés !</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n la séparation des couleurs n&apos;a pas eu lieu, raison: Import désactivé.</numerusform>
@@ -4973,97 +4987,97 @@ utiliser la molette de la souris pour zoomer.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Impossible de charger les définitions des tons directs, erreur: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>La couleur &quot;Registration black&quot; est importée comme une couleur spéciale.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Impossible d&apos;importer le symbole &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Importation des couches OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Pour le symbole ligne pointillés %1, la longueur des extrémités pointues sont différentes entre le début et la fin (%2 et %3). %4 utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Pour le symbole ligne pointillés %1, la longueur de l&apos;extrémité ne peut être importée correctement.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Pour le symbole ligne pointillés %1, l&apos;écart de fin ne peut être importé correctement.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Pour le symbole ligne pointillés %1, la longueur principale et la longueur de fin sont différentes (%2 et %3). %4 utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Pour le symbole ligne pointillés %1, les écarts D et E sont différents (%2 et %3). %4 utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Au symbole ligne %1: suppression du dernier pointillé en fin de ligne.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Lors de l&apos;importation du symbole texte %1: l&apos;alignement justifié a été ignoré</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Lors de l&apos;importation du symbole texte %1: l&apos;épaisseur personnalisée a été ignorée (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Lors de l&apos;importation du symbole texte %1: un espacement personnalisé a été choisi entre les caractères, son utilisation n&apos;est pas encore compatible avec OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Lors de l&apos;importation du symbole texte %1: l&apos;espace personnalisé entre les mots a été ignoré (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Lors de l&apos;importation du symbole texte %1: les identations personnalisés ont été ignorés (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Lors de l&apos;importation du symbole texte %1: le contour du texte a été ignoré (mode %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Impossible de charger l&apos;objet</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Impossible d&apos;importer un objet rectangle</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translatorcomment>Pas très clair !</translatorcomment>
         <translation>Symbole texte non importé, impossible de trouver le chemin (npts=%1): %2</translation>
@@ -5073,239 +5087,239 @@ utiliser la molette de la souris pour zoomer.</translation>
         <translation type="obsolete">Impossible d&apos;importer le modèle: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Impossible d&apos;importer le modèle : l&apos;arrière-plan &quot;%1&quot; ne semble pas être une image binaire</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Tentative d&apos;import d&apos;un objet texte ayant un format de coordonnées inconnues</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>L&apos;identifiant de la couleur est introuvable: %1, le couleur est ignorée</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Texte</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Sur le symbole ligne %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Sur le symbole texte %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Impossible de charger le système de géoréférencement &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Les informations ton direct ont été ignorées.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Impossible d&apos;importer le symbole %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Type &quot;%1&quot; n&apos;est pas-supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Impossible d&apos;importer le modèle: &quot;%1&quot; car il n&apos;est pas un format supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Style de ligne &apos;%1&apos; n&apos;est pas-supportée.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Les longueurs des terminaisons de ligne débutant à (%1 mm) et se terminant à (%2 mm) ne sont pas supportée. %3 mm utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Le motif en pointillés ne peut pas être correctement importé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Le motif en pointillés dont la longueur de terminaison est %1 mm ne peut pas être correctement importé. %2 mm utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Le motif de pointillés ayant un espacement terminal de %1 mm ne peut pas être correctement importé. %2 mm utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Le style de ligne &apos;%1&apos; n&apos;est pas supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Le point secondaire du symbole n&apos;est pas utilisé.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Suppression du pointillé à la fin du segment.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Ce symbole ne peut pas être sauvegardé comme un symbole Ocad.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>L&apos;alignement justifié n&apos;est pas supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>L&apos;alignement vertifical &apos;%1&apos; n&apos;est pas supporté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>L&apos;épaisseur personalisée des caractères (%1) est ignorée.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>L&apos;espacement personalisé entre les caractères peut être incorrect.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>L&apos;espacement personalisé entre les mots (%1 %) est ignoré.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>L&apos;identation personalisée (%1/%2) est ignorée.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Le boite de texte (mode %1) est ignorée.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Les symboles texte en ligne ne sont pas encore supportés. Le symbole est marqué caché.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>Dans le symbole surface %1 &apos;%2&apos; : %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Impossible de charger l&apos;objet</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Impossible d&apos;importer un objet rectangle</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Symbole texte non importé, impossible de trouver le segment (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>La tentative d&apos;import d&apos;un objet texte ayant des coordonnées dans un format inconnu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Données invalides.</translation>
     </message>
@@ -5314,59 +5328,59 @@ utiliser la molette de la souris pour zoomer.</translation>
         <translation type="vanished">L&apos;import de fichier au format OCD %1 n&apos; a pas été testé</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>Les fichiers OCD en version %1 ne sont pas supportés !</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>L&apos;identifiant de la couleur est introuvable: %1, la couleur est ignorée</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Surface</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5374,835 +5388,822 @@ utiliser la molette de la souris pour zoomer.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Sélectionnez un modèle pour dessiner dessus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Dessiner</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Clic et glisser&lt;/b&gt;: pour peindre. &lt;b&gt;Clic-droit et Glisser&lt;/b&gt;: pour effacer. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Sélection de couleurs</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer la carte. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;:  pour ajouter une coordonnée. &lt;b&gt;%1+Clic&lt;/b&gt;: pour changer les coordonnées sélectionnées. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Toujours orienté vers le nord (rotation impossible)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Éléments</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Surface</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centrer tous les éléments</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Élément sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diamètre &lt;b&gt;a&lt;/b&gt; :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Couleur de remplissage :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Épaisseur de bordure &lt;b&gt;b&lt;/b&gt; :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Couleur de bordure :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Épaisseur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Couleur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Extrémité de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>plate</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>ronde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>carrée</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Sommet de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>aigu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>rogné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Ligne fermée</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Couleur de surface :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Coordonnées :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Début de la courbe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centrer par moyenne des coordonnées</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Point central]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Symbole point</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Impression</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Une erreur est survenue durant le calcul.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Glisser&lt;/b&gt; : Déplacer la zone d&apos;impression ou ses limites. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer la carte, la zone d&apos;impression ou les bordures des surfaces. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer la surface d&apos;impression. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer la carte. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer le bordure de la surface d&apos;impression. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer la bordures de la surface d&apos;impression. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Exporter en PDF ou PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Afficher les modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientation de la page :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Imprimante :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Portrait</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Paysage</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Format de la page :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Copies :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Gauche :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Haut :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Aperçu…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Page unique</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Zone personnalisée</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Zone de la carte :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centrer la zone d&apos;impression</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Chevauchement des pages :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Résolution :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Imprimer à une échelle différente :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>L&apos;apparence des modèles peut être différente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simuler la surimpression</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Équipement CMYK (en test)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Mode de couleur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exporter…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Exporter au format PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Exporter au format image</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Enregistrer au format PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Non supporté sous Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Incident durant la préparation de la prévisualisation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Impression de la prévisualisation en cours</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Un mode de vue non standard est activé. Êtes-vous sûr de vouloir imprimer/exporter la carte de cette façon ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Incident durant la préparation de l&apos;export du fichier PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Une erreur est survenue durant l&apos;impression.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Exporter la carte…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Incident durant la préparation de l&apos;impression.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Progression de l&apos;impression</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Dessins
 vectoriel</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Images
 binaires</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Séparation
 des couleurs</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Mode :</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Incident durant la préparation de l&apos;image. Pas assez de mémoire.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>La sauvegarde de l&apos;image a échoué. Le chemin est il valide ? Avez vous les droits suffisants ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Exporté en %1 réussie</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Incident durant la fin de l&apos;export au format PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Annulé.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>La tâche d&apos;impression ne peut pas être stoppée.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Tâche d&apos;impression du fichier réussie</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>La zone de la carte est vide. Impression/Exportation annulée.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Système de coordonnées de référence :</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Réouvrir le modèle</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Glissez les éléments de la liste gauche jusqu&apos;à l&apos;endroit désiré dans la liste droite afin de les recharger.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Modèles fermés :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Effacer la liste</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Activer les modèles :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Carte -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Remplacer la bibliothèque des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Configurer comment les symboles doivent être remplacés et par lesquels.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importer tous les nouveaux symboles, y compris ceux non utilisés lors du remplacement</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Supprimer après le remplacement les anciens symboles inutilisés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Supprimer après le remplacement les couleurs inutilisées</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Association entre symboles :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Conserver le statut caché/protégé à l&apos;ancien jeu de symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Assortir les symboles de remplacement par numéros de symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Remplacement</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6213,7 +6214,7 @@ des couleurs</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6221,279 +6222,279 @@ des couleurs</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Aucun -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Choisir un fichier pour charger les symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Impossible de charger le fichier de la carte, abandon.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>La bibliothèque des symboles sélectionnée a une échelle de 1:%1, alors que la carte est au 1:%2. Voulez-vous vraiment choisir cette bibliothèque ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Pivoter la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Angle (sens anti-horaire) :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Paramètres de rotation</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotation autour de :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Origine du système de coordonnées de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Point de référence pour le géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Autre point,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajuster le point de référence du géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Ajuster la déclinaison du géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Pivoter les modèles non géoréférencés</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Angle :&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angles fixés. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour définir la direction des surfaces avec motifs ou des objets ponctuels. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotation :&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angles fixés. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;:  pour placer le centre de rotation. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour appliquer une rotation aux objets sélectionnés. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Changer l&apos;échelle de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Paramètres de redimensionnement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nouvelle échelle:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Centre du redimensionnement :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Origine du système de coordonnées de la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Point de référence pour le géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Autre point</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Redimensionner la taille des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Redimensionner la position des objets</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajuster le point de référence du géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Redimensionner les modèles non géoréférencés</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Facteur:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour placer le centre de redimensionnement. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour redimensionner les objets sélectionnés. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Sélectionner un système de coordonnées de références</translation>
     </message>
@@ -6502,17 +6503,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Le même que les cartes</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Le même que la carte</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Coordonnées géographiques (WGS84)</translation>
     </message>
@@ -6533,175 +6534,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">Spécification CRS :</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Statut :</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>valide</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- vide -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Vide -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Numéro :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Éditer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Description :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Symbole d&apos;aide (n&apos;apparaît pas sur la carte finale)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Pour afficher l&apos;aide en ligne, appuyer sur F1 lorsque l&apos;info-bulle de l&apos;outil est visible</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nouveau symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Surface</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Combiné</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Éditer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Échelle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
@@ -6714,12 +6715,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Remplir/Créer des bordures pour les objets sélectionnés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Sélectionner des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Activer glisser/déposer</translation>
     </message>
@@ -6728,103 +6729,103 @@ Do you want to save your changes?</source>
         <translation type="vanished">Échelle des symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Une erreur interne est survenue, désolé !</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Il n&apos;y a aucun symbole dans le presse-papier pouvant être collé !</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Sélectionner tous les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Désélectionner tous les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Masquer les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Protéger les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Ajouter à la sélection tous les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Retirer de la sélection tous les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Masquer les objets ayant l&apos;un des symboles sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Protéger les objets ayant l&apos;un des symboles sélectionnés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Inverser la sélection</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Sélectionner les inutilisés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Classer les symboles</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Classer par numéro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Classer par couleur primaire</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Classer par ordre de priorité des couleurs primaires</translation>
     </message>
@@ -6833,96 +6834,96 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Échelle du symbole %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Redimensionner au ratio :</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>La carte contient des objets avec le symbole suivant &quot;%1&quot;. En le supprimant, vous supprimerez ces objets et effacerez l&apos;historique de vos dernières actions ! Voulez-vous vraiment continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Ajouter à la sélection tous les objets ayant ce symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Sélectionner tous les objets ayant les symboles sélectionnés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Paramètres du symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Modèle :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Modèle:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(aucun)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Ouvrir…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centrer le modèle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>Bordure sur l&apos;origine</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Centre de gravité sur l&apos;origine</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Sélectionner une couleur de fond</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6933,58 +6934,58 @@ traverser les jattes de kiwis
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>-sans nom-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Aucune aide en ligne !</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Clé</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
@@ -6993,7 +6994,7 @@ traverser les jattes de kiwis
         <translation type="vanished">Aide</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7001,77 +7002,77 @@ traverser les jattes de kiwis
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Close</source>
         <translation type="obsolete">Fermer</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Clé</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>La clé existe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>La clé &quot;%1&quot; existe déjà et ne doit pas être utilisée une seconde fois.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Trouver le fichier modèle déplacé</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Aucun fichier.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Le format du fichier est-il adapté à ce type de modèle ?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7081,134 +7082,134 @@ traverser les jattes de kiwis
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Calage du modèle</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Le calcul du calage a échoué !</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour définir la position du point de calage sur le modèle. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour définir la position du point de calage sur la carte. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Clic&lt;/b&gt;: pour effacer les points de calage. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Glisser&lt;/b&gt;: pour déplacer les points de calage. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Points de calage :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>X sur modèle</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Y sur modèle</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>X sur carte</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Y sur carte</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Appliquer la transformation</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Appliquer &amp;&amp; tout effacer</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Tout effacer</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Pas assez de mémoire disponible (taille de l&apos;image : %1x%2 pixels)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7217,98 +7218,98 @@ L&apos;enregistrement des fichiers GIF n&apos;est pas supporté. Cela signifie q
 Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun problème.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Sélectionner le système de coordonnées de référence pour les coordonnées du fichier &quot;World file&quot;</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Ouverture %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Taille de l&apos;image :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Spécifier comment positionner ou mettre à l&apos;échelle l&apos;image :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished">World file</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>Aucune information de géoréférencement</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Géoréférencé</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Mètres par pixel :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Scanné en</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Échelle du modèle:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Opacité</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nom du fichier</translation>
     </message>
@@ -7317,19 +7318,19 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
         <translation type="obsolete">Créer...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Esquisser</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Ouvrir…</translation>
     </message>
@@ -7354,7 +7355,7 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
         <translation type="obsolete">non</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georéférencé: %1</translation>
     </message>
@@ -7363,89 +7364,89 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
         <translation type="vanished">Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Ajouter un modèle…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importer et supprimer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Déplacer à la main</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Ouvrir une image, une trace GPS ou un fichier DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Positionnement…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Fichiers modèles</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Ajuster…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Format de fichier non reconnu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Le chargement du modèle a échoué. Le fichier existe-t-il, si oui est-il valide ?</translation>
     </message>
@@ -7454,23 +7455,23 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
         <translation type="obsolete">Veuillez saisir un nombre valide entre 0 et 1 ou entrer un pourcentage entre 0 et 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Veuillez saisir un nombre entier valide pour définir un groupe ou laissez le champ libre pour ne pas grouper les modèles !</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Ne pas redimensionner</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Redimensionement à l&apos;échelle norminale selon un ratio de %1 %</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7479,194 +7480,194 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Redimensionner à l&apos;échelle du modèle sélectionné (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Import de modèle</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Comment les symboles du modèles importé doivent-ils être redimensionné ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Le modèle sera invisible dans la simulation de surimpression. Basculer en mode normal ?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Carte -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Glissez&lt;/b&gt; pour déplacer le modèle actuel</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Positionnement</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Échelle en X :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Échelle en Y :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotation :</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Redimensionnement et positionnement de la trace</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Système de coordonnées</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Sur le terrain</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Carte</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Une unité de coordonnées équivaut à :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Positionner la trace aux coordonnées indiquées</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Positionner la trace au centre de la fenêtre</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Seléctionner le système de coordonnées de référence des coordonnées de la trace</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Ouvrir une trace…</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Charger la trace en mode géoréférencé ou non-géoréférencé ?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Positionner la trace en s&apos;appuyant sur les paramètres de géoréférencement de la carte.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Ils ne sont pas encore configurés, ils seront donc affichés à l&apos;étape suivante.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Géoréférencé</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Non géoréférencé</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projeter la trace en utilisant une projection orthographique avec pour centre la moyenne des coordonnées de la trace. Autoriser l&apos;ajustement de la transformation et le paramétrage du géoréférencement de la carte en utilisant la position ajustée de la trace.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>La trace est vide, il n&apos;y a rien à importer !</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Les points GPS (waypoints), doivent-ils être importés dans une ligne reliant tous les points ?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problèmes d&apos;importation</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n chemin n&apos;a pas pu être importé (raison: coordonnées manquantes).</numerusform>
@@ -7674,7 +7675,7 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Erreur de lecture</translation>
     </message>
@@ -7687,7 +7688,7 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7696,39 +7697,39 @@ Si vous ne souhaitez pas dessiner sur le modèle, cela ne pose alors aucun probl
 %2 {1:?}</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 N&apos;est pas un fichier OSM.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>La fichier OSM est en version %1.
 La version minimale supportée est la version %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>La fichier OSM est en version %1.
 La version maximale supportée est la version %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problèmes</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 nœuds n&apos;ont pas pu être calculés correctement.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Lien externe : %1</translation>
@@ -7739,58 +7740,58 @@ La version maximale supportée est la version %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Alignement</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Droit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Sur la ligne de base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Bas</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Paramètres du texte</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Choix de la police :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Taille de la police :</translation>
     </message>
@@ -7799,339 +7800,339 @@ La version maximale supportée est la version %2.</translation>
         <translation type="vanished">Déterminer la taille…</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Couleur du texte :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>gras</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>italique</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>souligné</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Style du texte :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Espace entre les lignes :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Espace entre les paragraphes :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Espace entre les caractères :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Crénage</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Icône du symbole :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Contour/Ombre</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Paramètres de compatibilité avec OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Couleur du contour :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Contour en ligne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Épaisseur :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Ombre</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Décalage Gauche/Droite :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Décalage Haut/Bas :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Compatibilité avec OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>activé</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Épaisseur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Couleur de ligne :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Position :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Ligne sous les paragraphes</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Distance depuis la ligne de base :</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Positions de tabulateurs personnalisés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Ajouter un tabulateur personnalisé</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Calculer</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Impossible d&apos;annuler car la dernière action &quot;Annuler&quot; deviendrait alors invalide. Cela peut arriver par exemple lorsque vous changez le symbole d&apos;un objet par un autre et qu&apos;ensuite vous supprimez l&apos;ancien symbole.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Annuler cette action vous ramènera dans l&apos;état ANTÉRIEUR au chargement de ce fichier. Êtes vous sûr de vouloir annuler ?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Impossible d&apos;annuler la dernière action car elle deviendrait invalide. Cela peut arriver par exemple lorsque vous supprimez le symbole d&apos;un objet que vous avez dessiné.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>La localisation des fichiers d&apos;aide a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>La localisation du fichier d&apos;aide a échoué (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Le lancement du fichier d&apos;aide (&quot;Qt Assistant&quot;) a échoué.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>En savoir plus…</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Les anciennes versions de Mapper ne supportent pas les cartes ayant plusieurs parties. Pour sauvegarder la carte dans un mode compatible, vous devez d&apos;abord réunir les parties entre elles.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Élément non supporté: %1 (ligne %2 colonne %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Des coordonnées étaient en dehors des limites d&apos;impression. Le contenu de la carte a été ajusté.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Les différentes parties du fichier ne peut pas être lu par cette version de Mapper. Ma version minimale requise est : %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Erreur à la ligne %1 colonne %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Des caractères non-valides ont été supprimés.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Erreur inconnu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Spécification de géoréférencement &apos;%1&apos; ,non supportée ou inconnue: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Impossible de définir la propriété &quot;knockout&quot; pour la couleur &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>%1 couleurs attendues, %2 trouvées.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Ton direct %1 non trouvé lors du calcul %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>%1 symboles attendus, %2 trouvés.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>%1 parties de carte attendues, %2 trouvées.</translation>
     </message>

--- a/translations/OpenOrienteering_he.ts
+++ b/translations/OpenOrienteering_he.ts
@@ -2,5104 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="he">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation type="unfinished">על %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation>הכל אודות רשיונות, זכויות יוצרים, תנאים והגבלות</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation>המפתחים של OpenOrienteering בסדר אלפבתי:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation>(יוזם הפרוייקט)</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation>לעת עתה, אנו משתמשים בתרגום הנוכחי במקום בקודם</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation>תוכנית זו היא תוכנה חופשית: אתה יכול להפיצה ו/או לשנות אותה תחת התנאים של &lt;a %1&gt;  גנו (מערכת הפעלה)  רשיון ציבורי כללי (GPL)  , גרסה 3&lt;/a&gt;, כפי שפורסם על ידי קרן התוכנה החופשית.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation>תוכנה זו מופצת בתקווה שתהיה שימושית, אך זאת ללא אחריות כלשהי; אפילו ללא אחריות משתמעת לגבי סחירות או התאמה למטרה מסוימת. ראה את גנו - הרשיון הציבורי הכללי (GPL), גרסה 3, &lt;a %1&gt; לפרטים נוספים&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation>לתרומות, תודה:</translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation>פתח קבצים אחרונים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation>הראה את הטיפ היומי</translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation>הצג פריטים נותרים</translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation>גודל מינימלי:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation>מילויים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation>מילוי קו</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation>מילוי צורה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>מ&quot;מ</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation>קו בודד</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation>קווים מקבילים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation>ריווח</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation>שורה יחידה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation>מירווח הצורה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation>היסט צורה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation>היסט שורה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation>שורות מקבילות</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation>ריווח שורות:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation>הטיית מילוי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation>זווית:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation>מתכוונן לכל אובייקט</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation>הגדרות אזור</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation>מילוי צורה 1%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation>מילוי שורה 1%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation>לא נבחר מילוי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation>צבע אזור:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation>היסט קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation>צבע קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation>רוחב קו:</translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation>קובץ שמור אוטומטית</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation>
-            <numerusform>%n בתים</numerusform>
-            <numerusform>%n בתים</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation>הקובץ נשמר על-ידי המשתמש</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation>שחזור קובץ</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation>הקובץ %1 לא נסגר כראוי. כרגע, ישנן שתי גירסאות:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation>שמור את הקובץ הפעיל כדי להסיר את הגרסה הסותרת.</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation>עריכת צבע מפה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation>מגדיר צבע נקודה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished">תערובת של צבעי ספוט (מסכים ואוברפרינט):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished">הסתרה: מוחק צבעים נמוכים יותר</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation type="unfinished">חישוב מצבעי ספוט</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation>חישוב של צבע RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation>צבע מותאם אישית:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation>ציאן</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation>מג׳נטה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation>צהוב</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation>שחור</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation>חישוב מצבעי CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation>צבע RGB מותאם אישית:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>אדום</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>ירוק</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>כחול</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation>שולחן עבודה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation>הדפסה מקצועית</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished">שם</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation>- ללא -</translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>שם</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation>שקיפות</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation>צבע</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation>הסתרה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>חדש</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation>מחק</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation>שכפל</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation>העבר למעלה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation>העבר למטה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation>עזרה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation>לחץ פעמיים על ערך צבע כדי לפתוח תיבת דו-שיח.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation>אישור</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation>המפה מכילה סמלים עם הצבע הזה. מחיקתו תסיר את הצבע של אובייקטים אלה!  האם אתה באמת רוצה לעשות את זה?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation> שכפול</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation>לחץ פעמיים כדי להגדיר את צבע</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation>לחץ כדי לבחור את השם ולחץ שוב כדי לערוך.</translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation>&amp; מספר חלקים:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation>-סימן קו אישי-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation>-אזור סמל אישי-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation>עריכת סמל אישי...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation>הגדרות משולבות</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation>שנה סמל מציבורי לפרטי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation>האם לקחת את הסמל הישן כתבנית עבור הסימן הפרטי?</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation type="unfinished">סמל %1:</translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished">קביעת התצורה של הרשת</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation>הצג רשת</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation>הצמד לרשת</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation>בחר…</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation>כל הקווים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation>קווים אופקיים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation>קווים אנכיים</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation>יישור</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation>יישור עם הצפון המגנטי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation>יישור עם רשת צפונית</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation>יישור עם צפון אמיתי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation>סיבוב נוסף (נגד כיוון השעון):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation>מיקום</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation>מטרים בשטח</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation>מילימטרים על המפה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation>מרווח אופקי:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation>מרווח אנכי:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation>הסטה אופקית:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation>הסטה אנכית:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation>יחידה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation>צבע קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation>תצוגה:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation>בחר צבע קו רשת</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>מֶטֶר</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>גודל מ&quot;מ</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation>מקור ב: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation>קואורדינטות מקור בדף</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished">מקור קואורדינטות משוערות</translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation>&lt;b&gt;לחץ או גרור&lt;/b&gt;: התחל לצייר את החור. </translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation>שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation>קו הפיצול חייב להסתיים על גבול אזור!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation>ההתחלה והסיום של קו פיצול נמצאים בחלקים שונים של האובייקט!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation>ההתחלה והסיום של קו פיצול נמצאים באותו המיקום!</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation>&lt;b&gt;לחץ&lt;/b&gt; על קו: לפצל אותו לשניים. &lt;b&gt;גרור&lt;/b&gt; לאורך קו: להסיר חלק קו זה. &lt;b&gt;לחץ או גרור&lt;/b&gt; בגבול אזור: להתחיל שורה מפוצלת. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished">פיצול חורים של אובייקטים אזוריים אינה נתמכת עדיין!</translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: גזור את כל המפה. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation>&lt;b&gt;% 1 + לחץ או גרור&lt;/b&gt;: בחר אובייקטים שייגזרו. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: גזור את האובייקטים שנבחרו. </translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation>לא היתה אפשרות לפתוח את הקובץ.</translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation>הקובץ אינו קובץ DXF.</translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation>אות:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished">A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation>גובה:</translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation>להפיץ נקודות באופן שווה לאורך נתיב</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation>מספר נקודות לנתיב:</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation>גם למקם אובייקטים נקודות הקצה של הקו</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation>הגדרות הסיבוב</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation>יישור נקודות עם כיוון של קו</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation>זווית סיבוב נוספת (נגד כיוון השעון):</translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation>ממרכז</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation>&lt;b&gt;לחץ על&lt;/b&gt;: להתחיל עיגול או אליפסה. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation>&lt;b&gt;גרור&lt;/b&gt;: לצייר עיגול. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation>החזק את %1 כדי להתחיל ציור מן המרכז.</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation>&lt;b&gt;הקלק&lt;/b&gt;: לסיים את המעגל. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation>&lt;b&gt;גרור&lt;/b&gt;: לשרטט אליפסה. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation>&lt;b&gt;גרור&lt;/b&gt;: לצייר נתיב. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation>&lt;b&gt;קו מקווקו פעיל.&lt;/b&gt; </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation type="unfinished">&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: הצמד או הוסף לאובייקטים קיימים. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished">&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: לבחור כיוון מאובייקטים קיימים. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: הצמד לאובייקטים הקיים. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: לבטל את הנקודה האחרונה. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation>סיום</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation>סגור</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>זווית</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>מקף</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation>בטל</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation>בטל</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation type="unfinished">&lt;b&gt;אורך:&lt;/b&gt; %1 מ&apos; </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished">&lt;b&gt;לחץ&lt;/b&gt;: התחל קו ישר. &lt;b&gt;גרור&lt;/b&gt;: התחל עקומה. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation>&lt;b&gt;%1+גרור&lt;/b&gt;: עקוב אחר אובייקט קיים. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation>&lt;b&gt;לחץ&lt;/b&gt;: צייר קו ישר. &lt;b&gt;גרור&lt;/b&gt;: צייר עקומה. &lt;b&gt;קליק ימיני או כפול&lt;/b&gt;: סיים את המסלול. &lt;b&gt;%1&lt;/b&gt;: סגור מסלול. </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation>מגע במפה לסיים מיצוע</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>זווית</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation>איפוס</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation>סיום</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation>צימוד לקו</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>מקף</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation>בטל</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation>בטל</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation type="unfinished">הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished">הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished">הצמד</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished">שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished">°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation>1% בקירוב</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished">עזרה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished">הראה את הטיפ היומי</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished">רוחב קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished">צבע קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation type="unfinished">סגור</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished">שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation type="unfinished">שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished">בטל</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished">שכפל</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation type="unfinished">הצג רשת</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation type="unfinished">מחק</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation type="unfinished">שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation>ביטול</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation>שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation>הסתיים</translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation type="unfinished">%1x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>מ&quot;מ</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>מטר</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation>שגיאה</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation>מפה ריקה!
-
-התחל בהגדרת מספר צבעים:
-בחר סמלים -&gt; צבע חלון ל
-פתח את דיאלוג הצבע והגדר את הצבעים שם.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation>אין סמלים!
-
-עכשיו הגדר מספר סמלים:
-קליק ימני על תיבת הסמלים
-ליצירת סמל בחר &quot;סמל חדש&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation>מוכן לציור!
-
-התחל לצייר או העלה תמונת רקע.
-להעלאת תמונת רקע לחץ על תבניות -&gt; פתח תבנית...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation>רמז: החזק את הכפתור האמצעי בעכבר כדי לגרור את המפה,
-הגדל באמצעות גלגל העכבר.</translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation>אורך הגבול:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation>אורך:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation>שטח:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation>לא נבחר אובייקט.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation>1% מהאובייקטים נבחרו.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation>האובייקט הנבחר אינו מסלול.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>מ&quot;מ</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>מטר</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation>מ&quot;מ רבוע</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation>מטר רבוע</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation>האובייקט הזה קטן מידי.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5113,767 +15,2854 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
+        <translation type="unfinished">על %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
+        <translation>הכל אודות רשיונות, זכויות יוצרים, תנאים והגבלות</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation>המפתחים של OpenOrienteering בסדר אלפבתי:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation>(יוזם הפרוייקט)</translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
+        <translation>לעת עתה, אנו משתמשים בתרגום הנוכחי במקום בקודם</translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
-        <translation type="unfinished">%</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
+        <translation>תוכנית זו היא תוכנה חופשית: אתה יכול להפיצה ו/או לשנות אותה תחת התנאים של &lt;a %1&gt;  גנו (מערכת הפעלה)  רשיון ציבורי כללי (GPL)  , גרסה 3&lt;/a&gt;, כפי שפורסם על ידי קרן התוכנה החופשית.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation>תוכנה זו מופצת בתקווה שתהיה שימושית, אך זאת ללא אחריות כלשהי; אפילו ללא אחריות משתמעת לגבי סחירות או התאמה למטרה מסוימת. ראה את גנו - הרשיון הציבורי הכללי (GPL), גרסה 3, &lt;a %1&gt; לפרטים נוספים&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
+        <translation>לתרומות, תודה:</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
+        <translation>פתח קבצים אחרונים</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation>הראה את הטיפ היומי</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation>הצג פריטים נותרים</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
+        <translation>גודל מינימלי:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
+        <translation>מילויים</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
+        <translation>מילוי קו</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
+        <translation>מילוי צורה</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
+        <translation>מ&quot;מ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
+        <translation>קו בודד</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
+        <translation>קווים מקבילים</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
+        <translation>ריווח</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
+        <translation>שורה יחידה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
+        <translation>מירווח הצורה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
+        <translation>היסט צורה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
+        <translation>היסט שורה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
+        <translation>שורות מקבילות</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
+        <translation>ריווח שורות:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
+        <translation>הטיית מילוי</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
+        <translation>זווית:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
+        <translation>מתכוונן לכל אובייקט</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
-        <translation type="unfinished">רוחב קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
-        <translation type="unfinished">צבע קו:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation>הגדרות אזור</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation>מילוי צורה 1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation>מילוי שורה 1%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation>לא נבחר מילוי</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
-        <translation type="unfinished">צבע אזור:</translation>
+        <translation>צבע אזור:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
+        <translation>היסט קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
+        <translation>צבע קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
+        <translation>רוחב קו:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AutosaveDialog</name>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation>קובץ שמור אוטומטית</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation>
+            <numerusform>%n בתים</numerusform>
+            <numerusform>%n בתים</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation>הקובץ נשמר על-ידי המשתמש</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation>שחזור קובץ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation>הקובץ %1 לא נסגר כראוי. כרגע, ישנן שתי גירסאות:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
+        <translation>שמור את הקובץ הפעיל כדי להסיר את הגרסה הסותרת.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDialog</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
+        <translation>עריכת צבע מפה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation>מגדיר צבע נקודה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished">תערובת של צבעי ספוט (מסכים ואוברפרינט):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished">הסתרה: מוחק צבעים נמוכים יותר</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation type="unfinished">חישוב מצבעי ספוט</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation>חישוב של צבע RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation>צבע מותאם אישית:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation>ציאן</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation>מג׳נטה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation>צהוב</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation>שחור</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation>חישוב מצבעי CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation>צבע RGB מותאם אישית:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>אדום</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>ירוק</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>כחול</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation>שולחן עבודה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation>הדפסה מקצועית</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished">שם</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
+        <translation>- ללא -</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>שם</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation>שקיפות</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation>צבע</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation>הסתרה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>חדש</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation>מחק</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation>שכפל</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation>העבר למעלה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation>העבר למטה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>עזרה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation>לחץ פעמיים על ערך צבע כדי לפתוח תיבת דו-שיח.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation>אישור</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation>המפה מכילה סמלים עם הצבע הזה. מחיקתו תסיר את הצבע של אובייקטים אלה!  האם אתה באמת רוצה לעשות את זה?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation> שכפול</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation>לחץ פעמיים כדי להגדיר את צבע</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation>לחץ כדי לבחור את השם ולחץ שוב כדי לערוך.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation>&amp; מספר חלקים:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation>-סימן קו אישי-</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation>-אזור סמל אישי-</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation>עריכת סמל אישי...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation>הגדרות משולבות</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation>שנה סמל מציבורי לפרטי</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation>האם לקחת את הסמל הישן כתבנית עבור הסימן הפרטי?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation type="unfinished">סמל %1:</translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished">קביעת התצורה של הרשת</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
-        <translation type="unfinished">הצג רשת</translation>
+        <translation>הצג רשת</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
+        <translation>הצמד לרשת</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
+        <translation>בחר…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
+        <translation>כל הקווים</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
+        <translation>קווים אופקיים</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
+        <translation>קווים אנכיים</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
+        <translation>יישור</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
+        <translation>יישור עם הצפון המגנטי</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
+        <translation>יישור עם רשת צפונית</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
+        <translation>יישור עם צפון אמיתי</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
-        <translation type="unfinished">גובה:</translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
+        <translation>סיבוב נוסף (נגד כיוון השעון):</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
+        <translation>מיקום</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
+        <translation>מטרים בשטח</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
+        <translation>מילימטרים על המפה</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
+        <translation>מרווח אופקי:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation>מרווח אנכי:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation>הסטה אופקית:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation>הסטה אנכית:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation>יחידה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation>צבע קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation>תצוגה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation>בחר צבע קו רשת</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>מֶטֶר</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>גודל מ&quot;מ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
+        <translation>מקור ב: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
+        <translation>קואורדינטות מקור בדף</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
+        <translation type="unfinished">מקור קואורדינטות משוערות</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
+    <message>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
+        <translation>&lt;b&gt;לחץ או גרור&lt;/b&gt;: התחל לצייר את החור. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Error</source>
+        <translation>שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
+        <translation>קו הפיצול חייב להסתיים על גבול אזור!</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
+        <translation>ההתחלה והסיום של קו פיצול נמצאים בחלקים שונים של האובייקט!</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
+        <translation>ההתחלה והסיום של קו פיצול נמצאים באותו המיקום!</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
+        <translation>&lt;b&gt;לחץ&lt;/b&gt; על קו: לפצל אותו לשניים. &lt;b&gt;גרור&lt;/b&gt; לאורך קו: להסיר חלק קו זה. &lt;b&gt;לחץ או גרור&lt;/b&gt; בגבול אזור: להתחיל שורה מפוצלת. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
+        <translation type="unfinished">פיצול חורים של אובייקטים אזוריים אינה נתמכת עדיין!</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutoutTool</name>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: גזור את כל המפה. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
+        <translation>&lt;b&gt;% 1 + לחץ או גרור&lt;/b&gt;: בחר אובייקטים שייגזרו. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: גזור את האובייקטים שנבחרו. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
+        <translation>לא היתה אפשרות לפתוח את הקובץ.</translation>
+    </message>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation>הקובץ אינו קובץ DXF.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation>אות:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation>גובה:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation>להפיץ נקודות באופן שווה לאורך נתיב</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation>מספר נקודות לנתיב:</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation>גם למקם אובייקטים נקודות הקצה של הקו</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation>הגדרות הסיבוב</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation>יישור נקודות עם כיוון של קו</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation>זווית סיבוב נוספת (נגד כיוון השעון):</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation>ממרכז</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation>&lt;b&gt;לחץ על&lt;/b&gt;: להתחיל עיגול או אליפסה. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation>&lt;b&gt;גרור&lt;/b&gt;: לצייר עיגול. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation>החזק את %1 כדי להתחיל ציור מן המרכז.</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation>&lt;b&gt;הקלק&lt;/b&gt;: לסיים את המעגל. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation>&lt;b&gt;גרור&lt;/b&gt;: לשרטט אליפסה. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation>&lt;b&gt;גרור&lt;/b&gt;: לצייר נתיב. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation>&lt;b&gt;קו מקווקו פעיל.&lt;/b&gt; </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation type="unfinished">&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: הצמד או הוסף לאובייקטים קיימים. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished">&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: לבחור כיוון מאובייקטים קיימים. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;% 1 + לחיצה&lt;/b&gt;: הצמד לאובייקטים הקיים. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: לבטל את הנקודה האחרונה. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation>סיום</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation>סגור</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>זווית</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>מקף</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation>בטל</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation>בטל</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation type="unfinished">&lt;b&gt;אורך:&lt;/b&gt; %1 מ&apos; </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished">&lt;b&gt;לחץ&lt;/b&gt;: התחל קו ישר. &lt;b&gt;גרור&lt;/b&gt;: התחל עקומה. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation>&lt;b&gt;%1+גרור&lt;/b&gt;: עקוב אחר אובייקט קיים. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation>&lt;b&gt;לחץ&lt;/b&gt;: צייר קו ישר. &lt;b&gt;גרור&lt;/b&gt;: צייר עקומה. &lt;b&gt;קליק ימיני או כפול&lt;/b&gt;: סיים את המסלול. &lt;b&gt;%1&lt;/b&gt;: סגור מסלול. </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation>מגע במפה לסיים מיצוע</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>זווית</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation>איפוס</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation>סיום</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation>צימוד לקו</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>מקף</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation>בטל</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation>בטל</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation type="unfinished">הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished">הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished">הצמד</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation>1% בקירוב</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished">עזרה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished">הראה את הטיפ היומי</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished">רוחב קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished">צבע קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation type="unfinished">סגור</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished">שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation type="unfinished">שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5881,7 +2870,3019 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished">בטל</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished">שכפל</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation type="unfinished">הצג רשת</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation type="unfinished">מחק</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation type="unfinished">שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation>ביטול</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation>שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation>הסתיים</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation type="unfinished">%1x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>מ&quot;מ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>מטר</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation>שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation>מפה ריקה!
+
+התחל בהגדרת מספר צבעים:
+בחר סמלים -&gt; צבע חלון ל
+פתח את דיאלוג הצבע והגדר את הצבעים שם.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation>אין סמלים!
+
+עכשיו הגדר מספר סמלים:
+קליק ימני על תיבת הסמלים
+ליצירת סמל בחר &quot;סמל חדש&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation>מוכן לציור!
+
+התחל לצייר או העלה תמונת רקע.
+להעלאת תמונת רקע לחץ על תבניות -&gt; פתח תבנית...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation>רמז: החזק את הכפתור האמצעי בעכבר כדי לגרור את המפה,
+הגדל באמצעות גלגל העכבר.</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation>אורך הגבול:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation>אורך:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation>שטח:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation>לא נבחר אובייקט.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation>1% מהאובייקטים נבחרו.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation>האובייקט הנבחר אינו מסלול.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>מ&quot;מ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>מטר</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation>מ&quot;מ רבוע</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation>מטר רבוע</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation>האובייקט הזה קטן מידי.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished">רוחב קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished">צבע קו:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished">צבע אזור:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished">הצג רשת</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished">גובה:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished">שגיאה</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5889,672 +5890,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: זוויות קבועות. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished">- ללא -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished">שכפל</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished">מחק</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6562,58 +6563,58 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">העבר למעלה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">העבר למטה</translation>
     </message>
@@ -6622,7 +6623,7 @@ to jump over the lazy dog
         <translation type="obsolete">עזרה</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6630,625 +6631,625 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished">עזרה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished">חדש</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished">מחק</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished">עזרה</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished">שקיפות</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished">סגור</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished">שכפל</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished">העבר למעלה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished">העבר למטה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished">עזרה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished">מיקום</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7256,436 +7257,436 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished">יישור</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished">A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished">ריווח</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished">רוחב קו:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished">צבע קו:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_hu.ts
+++ b/translations/OpenOrienteering_hu.ts
@@ -2,10 +2,23 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="hu_HU">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>%1 névjegye</translation>
     </message>
@@ -18,494 +31,494 @@
         <translation type="vanished">Kattins a megtekintéshez</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Minden engedélyekről, szerzői jogi értesítésekről, feltételekről és lemondásokról.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Az OpenOrienteering fejlesztői névsorban:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(projekt kezdeményező)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translatorcomment>Tartalmilag ez az igazság</translatorcomment>
         <translation>Egy szabad szoftver tájékozódási sportok térkpeinek rajzolásához</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Ez a program egy szabad szoftver, ami a &lt;a %1&gt; GNU General Public License (GPL) &amp;nbsp;3. verziója&lt;/a&gt; - (ahogy a Szabad Szoftver Alapítvány kiadta)- szerint terjeszthető és/ vagy módosítható.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Ezt a programot abban a reményben terjesztik, hogy hasznos lesz, de BÁRMILYEN GARANCIA NÉLKÜL beleértve az ELADHATÓSÁGRA vagy BÁRMELY MÁS KÜLÖNÖS CÉLRA vonatkozóan. Lásd a GNU General Public License (GPL), 3. verzióját&amp;nbsp; &lt;egy %1&gt;részletek&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>A hozzájárulásért köszönet nekik:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>A leggyakrabban használt fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Mutasd a napi tippet</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Megmaradó tételeket mutat</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Legkisebb méret:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Kitöltések</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Vonal kitöltése</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Minta kitöltése</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translatorcomment>Szimpla vonal</translatorcomment>
         <translation>Egyszeres vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translatorcomment>Párhuzamosok</translatorcomment>
         <translation>Párhuzamos vonalak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translatorcomment>Sortávolság:</translatorcomment>
         <translation>Vonalköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Egyetlen sor</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Minta távolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Minta eltolás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Sortávolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Párhuzamos sorok</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Sorköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Kitöltés elforgatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Szög:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>objektumonként állítható</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Terület beállÍtások</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Minta kitöltés %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Vonal kitöltés %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Nincs kitöltés kiválasztva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Terület szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Vonal távolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Vonal szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Vonal vastagság:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automatikusan mentett fájl</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>A fájlt mentette a felhasználó</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Fájl helyreállítás</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>A %1 fájl nem szabályosan lett lezárva. Ebben a pillanatban két különböző állapota van:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Mentsd el az aktív fájlt, hogy eltávolíthasd az ütköző verziót.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Térképszín módosítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Szerkeszt</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Egy folt szín megadása:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>A helybeni színek keveréke (képernyők és felülnyomás):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Kiütés: törli a gyengébb színeket</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Számol egy folt színéből</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Számol egy RGB színből</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Beállított folyamat szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cián</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Sárga</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Fekete</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Számol a CMYK színekből</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>RGB színek beállítása:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Vörös</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Züld</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Kék</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Asztal</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Professzionális nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Név</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished">Figyelmeztetés</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- semmilyen -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Átlátszóság</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Folt színe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Új</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Töröl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Megkettőz</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Fölfelé mozgat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Lefelé mozgat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dupla kattintás a színérték párbeszéd ablak megnyitásához.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>A térkép szimbólumokat tartalmaz ezzel a színnel. A szín törlése a szimbólumokból is törli ezt a színt. Valóban ezt akarja?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Megkettőz)</translation>
     </message>
@@ -518,301 +531,301 @@
         <translation type="vanished">Kérem adja meg a százalék értéket 0%-tól 100%-ig!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Kettős kattintás a szín megdásához</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Kattintson a név kiválasztásához és ismét kattintson a módosításához.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Részek száma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Saját vonal szimbólum -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Saját terület szimbólum -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Saját szimbólum módosítása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Kombináció beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Közös szimbólumot egyénire cserél</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>A régi szimbólumot sablonként használja az egyéni szimbólumhoz?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>%1 szimbólum:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Rács beállítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Rács be</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Rácsra illeszt</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Kiválaszt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Minden vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Vízszintes vonalak</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Függőleges vonalak</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Igazítás</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Igazítás mágneses Északhoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Igazítás hálózati Északhoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Igazítás valódi Északhoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Forgatás (óramutató járásával ellenkező irányban):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Elhelyezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>méter a terepen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>miliméter a térképen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Vízszintes térköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Függőleges térköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Vízszintes eltolás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Függőleges eltolás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translatorcomment>mértékegység</translatorcomment>
         <translation>Egység:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Vonal szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Megjelenít:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Rácsvonal színt választ</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Eredet: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>papír koordináták eredete</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>vetített koordináták eredete</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Kattint vagy megragad&lt;/b&gt;: Kezdje rajzolni a lyukat. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>A vágó vonalnak a terület határain kell végződnie!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>A vágóvonal kezdő és végpontja az objektum különböző részeinél legyenek!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>A vágóvonal kezdő és végpontja az objektum ugyanazon pozíciójában van!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Kattintson&lt;/b&gt; a vonalon a két részre vágáshoz. &lt;b&gt;Megragad&lt;/b&gt;ja a vonalszakaszt: Eltávolítja a vonalszakaszt. &lt;b&gt;Kattintson vagy Ragadja meg&lt;/b&gt; egy területhatárain: Indítson egy vágó vonalat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>A terület objektumokba a lyukak vágása nem támogatott!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kivágja az egész térképet. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Kattintás vagy megragadás&lt;/b&gt;: Válassza ki a kivágandó objektumot. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kivágja a kijelölt objektumot. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>A fájl nem megnyitható.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Ez a fájl nem egy DXF fájl.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Betűméret meghatározása</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Betű:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -827,267 +840,267 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Magasság:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Vonal mentén oszt el pontokat egyenletesen</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Pontok száma vonalanként:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Objektumokat helyez a vonal végeire is</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Forgatási beálítás</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Vonal által meghatározott pontok igazítása</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>További forgásszög (óramutató járásával ellentétes):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translatorcomment>Kör rajzolása a középpont köré</translatorcomment>
         <translation>A középpontból</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Kattintson&lt;/b&gt;: egy kör vagy ellipszis indításához. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Egy kört rajzol. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Nyomja le %1, hogy elkezdje a rajzolást a központból.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Befejezi a kört. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;Egy ellipszist rajzol. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Utat rajzol. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Sarok pontok be.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt;Ugrás vagy hozzáírás egy létező objektumhoz. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt;Olvassa ki az irányt a létező objektumokból. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt;: Ugorjon létező ojektumokhoz. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fix szögek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Az utolsó pont visszavonása. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Befejez</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Bezár</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Létező objektumokhoz ugrik</translatorcomment>
         <translation>Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translatorcomment>Kényszerítse a szögeket</translatorcomment>
         <translation>Szög</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Sarokpont rajzolása</translatorcomment>
         <translation>Sarok</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Visszavon</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Elvet</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Hosszúság:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Elindít egy egyenes vonalat. &lt;b&gt;Megragad&lt;/b&gt;: Elindít egy görbét. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Létező objektumot követ. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Egyenes vonal rajzolása. &lt;b&gt;Húzás&lt;/b&gt;: Görbe rajzolása. &lt;b&gt;Jobb vagy dupla kattintás&lt;/b&gt;: Rajzolt vonal vége. &lt;b&gt;%1&lt;/b&gt;: A vonal visszazárása a kezdőponthoz. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Érintse meg a térképet az átlagolás befejezéséhez</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Az objektum beállítás befejezése. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Létező objektumhoz illeszt</translatorcomment>
         <translation>Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translatorcomment>Erőltetett szögek használata</translatorcomment>
         <translation>Szög</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Alaphelyzet</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Szög:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fix szögek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Pont objektum létrehozása.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Húzás&lt;/b&gt;: Objektum létrehozása és irányának beállítása (ha forgatható).</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Elforgatás alaphelyzetbe állítása.</translation>
     </message>
@@ -1097,528 +1110,528 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Befejez</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Illesztés egy létező objektumhoz</translatorcomment>
         <translation>Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translatorcomment>Egy előző vonalra illeszt</translatorcomment>
         <translation>Vonalra illesztés</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Sarokpontokat rajzol</translatorcomment>
         <translation>Szaggatott</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Visszavon</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Elvet</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Kattint-vagy megragad &lt;/b&gt; Elkezd rajzolni egy téglalapot. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Az előző vonalhoz illeszt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Beállít egy sarokpontot. &lt;b&gt;Jobb vagy kettős kattintás&lt;/b&gt;: Téglalap befejezése. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation type="unfinished">Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Szerkesztés befejezése. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Kattint&lt;/b&gt;: Egy szövegobjektum létrehozása egy horgonnyal. &lt;b&gt;Megragad&lt;/b&gt;: Egy szövegdobozt készít. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Létező objektumokhoz illeszt</translatorcomment>
         <translation>Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translatorcomment>Váltás egy görbített és egy egyenes rész között</translatorcomment>
         <translation>Görbévé alakít</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Szabad mozgatás. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt; egy részen: Váltás. egyenes és görbített között. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Illesztés egy létező objektumokhoz</translatorcomment>
         <translation>Illeszt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translatorcomment>Pontokat módosít vagy erőltetett szögeket használ</translatorcomment>
         <translation>Pont /Szög</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Sarokpontot vált</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Befejezi a szerkesztést. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Tartsa a szembenfekvő fogantyúpozíciókat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt;a ponton: Törli azt; az útvonalon: Hozzáad egy új sarokpontot; &lt;b&gt;%2&lt;/b&gt;: Adj hozzá egy normál pontot. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt; ponton: Törli azt; az útvonalon: Hozzáad egy új pontot; &lt;b&gt;%2&lt;/b&gt;-val: Adj hozzá egy sarokpontot. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Kattintás&lt;/b&gt;a ponton a sarok és normál pont közötti váltáshoz. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordináta távolság:&lt;/b&gt;%1, %2 mm &lt;b&gt;Különbség&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fix szögek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Létező objektumhoz igazít. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Egy objektum kiválasztása. &lt;b&gt;Megragad&lt;/b&gt;: Több objektum kiválasztása. &lt;b&gt;%1+Kattintás&lt;/b&gt;: Kiválasztás megfordítása. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kiválasztott objektum törlése. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Magas minőségű megjelenítés (élsimítással)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Az élsimítás szebb kinézetű térképet eredményez, de lelassítja a térkép megjelenítését</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Magas minőségű szöveg megjelenítés a térképen (élsimítás), lassú</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Kattintás tűréshatár:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>miliméter</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Illesztés különbség (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Fix szög mód lépés (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translatorcomment>Fok jel a szögekhez</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Amikor kiválaszt egy objektumot, a szimbóluma is kiválasztásra kerül</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>A kurzor helye máshová kerül a kicsinyítésnél</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Rajzoló eszköz: az utolsó pontot jobb gombbal adja meg</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Sablonok: megtartják a beállításokat a lezárt sablonok</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Szerkesztő eszköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>A régi formát megtartja</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Újraállítja a görbe külső kezelőit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Megtartja a görbe külső kezelőit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Görbe pontjának törlése esetén így jár el %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Téglalap eszköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>A segítő kereszt hatósugara:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Előnézet a segítő kereszt vonalszélességével</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Szerkesztő</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Nem tudta a %1 fájlt létrehozni</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>(%1) - Ezt a formátumot nem lehetséges exportálni</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>A térkép területe nagy. A kitöltő eszköz használata sokáig tarthat. Így is használni akarja?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>A kiválasztott területet nem határolják vonalak, nem lehet kitölteni ezt a területet.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>A kiválasztott pozíció nem szabad, a kitöltés eszköz nem használható.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Nem lehetett létrehozni a kitöltő objektumot.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Terület kitöltése aktív szimbólummal. A kitöltendő területet vonalaknak, vagy más területeknek kell határolniuk, más szimbólumok nem vehetők figyelembe. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>A GPS tiltva az eszköz beállításokban. Megnyitja a beállításokat?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Igen</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nem</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished">Érték</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Megjelenés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Nyelv:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Képernyő</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Képpont inchenként (1 inch 2,54 cm):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Program indítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Fájl mentése</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Mapper %1-rel megtartja a kompatibilitást</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Információk mentése az automatikus helyreállításhoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Helyreállítási információk mentésének gyakorisága:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translatorcomment>mértékegység perc</translatorcomment>
         <translation>perc</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Fájl import és export</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8 bites titkosítás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Tovább...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Használja az új OCD importálót a 8-as verzióhoz is</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Egyéb beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Megjegyzés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>A programot újra kell indítani a nyelv váltás érvényesítéséhez!</translation>
     </message>
@@ -1627,48 +1640,48 @@
         <translation type="vanished">Használja a fordítás fájlt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Fordítás megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Fordítás fájlok (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>A kiválasztott fájl érvénytelen fordítás.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation type="unfinished">%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Az elsődleges képernyő felbontása képpontokban:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Az elsődleges képernyő mérete inchekben (átló):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translatorcomment>UTM koordináta referencia rendszer</translatorcomment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM koordináták</translation>
     </message>
@@ -1677,81 +1690,81 @@
         <translation type="vanished">UTM zóna (szám Észak/Dél, pl. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM zóna (szám Észak/Dél)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger koordináta referencia rendszer</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krueger koordináták</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translatorcomment>Zóna szám a Gauss-Krueger koordinátákhoz</translatorcomment>
         <translation>Zóna szám (1-től 119-ig)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>EPSG kód alapján</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ koordináták</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG kód</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Egyedi PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Helyi koordináták</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Specifikáció</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Térkép skálák megadása helytelen vagy elveszett.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Ismeretlen CRS leíró nyelv: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Nem támogatott földrajzi CRS leírás: %1</translation>
     </message>
@@ -1760,7 +1773,7 @@
         <translation type="vanished">Csak méretez</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Helyi</translation>
     </message>
@@ -1770,73 +1783,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Térkép georeferencia</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Keresés...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Elhajlás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Vetített koordináták</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Állapot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Rács méretezési arány:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Földrajzi koordináták</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Hivatkozási pont keresése itt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>érvényes</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Élő elhajlás keresés</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Térkép koordináta viszonyítási renszer</translation>
     </message>
@@ -1849,7 +1862,7 @@
         <translation type="vanished">- a &quot;Proj 4&quot; leírásból -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- helyi -</translation>
     </message>
@@ -1858,119 +1871,119 @@
         <translation type="vanished">CRS leírás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Viszonyításai pont</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;elhelyezi a térképen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translatorcomment>x koordináta</translatorcomment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translatorcomment>y koordináta</translatorcomment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translatorcomment>Nyugat/ Kelet</translatorcomment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translatorcomment>Észak/Dél</translatorcomment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translatorcomment>Észak</translatorcomment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translatorcomment>Kelet</translatorcomment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Térkép észak</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation type="unfinished">&amp;Koordináta hivatkozási rendszer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Térkép koordináták:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Földrajzi koordináták:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>CRS változtatásoknál megtart:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translatorcomment>A szög bármilyen a Föld felszínén található pontnál a hálózati Észak és az iránytű szerinti Észak között. </translatorcomment>
         <translation>Griváció:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>A referenciapont mágneses elhajlásának %1° %2° visszanyerése &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Folytatni akarja?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Elhajlás váltás</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Az elhajlás megváltoztatva. El akarja forgatni a térképi elemeket is?</translation>
     </message>
@@ -1979,39 +1992,39 @@
         <translation type="vanished">Vetített koordináták:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Helyi koordináták:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Betöltés...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>zárolva</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Nem lehet értelmezni az adatokat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Nem található elhajlási érték.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Az élő elhajlás keresés sikertelen:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translatorcomment>fok érték</translatorcomment>
@@ -2019,110 +2032,110 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Kattintás&lt;/b&gt;: Viszonyítási pont megadása. Más gomb: mégsem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Referencia pont beállítása. &lt;b&gt;Jobb kattintás&lt;/b&gt;: Mégsem.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Üdvözöl az OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Tevékenység</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Új térképet készítése ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Térkép megnyitása ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Névjegy: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Kilép</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Nemrég megnyitott térképek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Indításkor nyissa meg az utoljára használt fájlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Törölje a listát</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>A nap tippje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Mutassa a nap tippjét</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Példák</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>A Mapper-ről</translation>
     </message>
@@ -2131,30 +2144,30 @@
         <translation type="vanished">A Qt-ról</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Fájl lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Nem találtam térkép fájlt!&lt;br/&gt;&lt;br/&gt;Másoljon térkép fájlt egy &apos;OOMapper&apos; nevű főkönyvtárba az eszközön vagy a memória kártyán (/sdcard/OOMapper).</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Hiba történt a %1 típusú szimbólum betöltésekor a %3 oszlop %2 sorában.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>A &apos;%1&apos; szimbólum ID nem egyedi a a %3 oszlop %2 sorában.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Hiba történt az %1 típusú szimbol betöltésekor (%2. sor %3. oszlop): %4</translation>
     </message>
@@ -2163,38 +2176,38 @@
         <translation type="vanished">Hiba szimbólum betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Hiba egy %1 típusú objektum betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Hiba egy %1 típusú objektum betöltésekor %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Nem található szimbólum a %1:%2 -n lévő objektumhoz.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Pont objektum egy definiálatlan vagy hibás szimbólummal a %1:%2 -n.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>Ocad 7, 8 verziók</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2203,255 +2216,255 @@
         <translation type="vanished">Nem értelmezhetők az adatok.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Nem értelmezhetők a koordináták.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Várható %1 koordináták megtalálva %2-n.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Hiba történt a nyomtatási beállítások betöltésekor itt: %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Hiba történt a visszavonás/előrelépés lépéseinek betöltésekor itt: %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Találtam egy szimbólum nélküli objektumot.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Elhagytam %n szabálytalan objektumot.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Hiba a szimbólum utófeldolgozásakor.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>A &quot;%1&quot; háttér a térkép könyvtárából lett betöltve a térképfájlban meghatározott eredeti útvonal helyett.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Nem sikerült betölteni a következő sablont: &apos;%1&apos;, a hiba oka: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Figyelmeztetések a következő sablon betöltése kapcsán &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Legalább egy háttér fájl nem található.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Kattinson a vörös színű nevekre a háttér állományok listáján -&gt; Háttérállományok beállítása ablakban adja meg azok megváltozott nevét/helyét.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Ez a fájl egy régebbi formátumban van. Ennek a formátumnak a támogatása hamarosan ki fog kerülni ebből a programból. Annak érdekében, hogy a jövőben is meg tudja nyitni, kérem mentse el újból.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Érvénytelen fájl formátum verzió.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Nem támogatott régi fájl formátum verzió. Kérem, hogy hhasználjon egy régebbi verziót a fájl betöltéséhez és aktualizálásához.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Nem támogatott új fájl formátum verzió. Néhány térkép tulajdonság nem lesz betöltve vagy mentve a program e verziójában. Gondolkozzon a frissítésen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>A térkép földrajzi koordináta hivatkozási rendszere &quot;%1&quot; volt. Ez a CRS nem támogatott. Használja a &quot;%2&quot;-t.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Hiba a %2 típusú szimbólum betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Hiba egy szimbólum betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Hiba a visszavonás lépés betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Hiba a térképrészek számolása közben.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Hiba a %2 térképrész betöltésekor.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Nem olvasható a %1 fájl</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Nem támogatott fájl formátum.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Nem támogatott új fájl formátum verzió. Néhány térkép tulajdonság nem lesz betöltve vagy mentve a program ezen verziójával.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Az adott formátum (%1) nem támogatja az importálást</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Vonal beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Vonalvastagság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Vonal színe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>A legkisebb vonalhossz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Vonal felirat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>egyenes</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>kör</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>négyszögletes</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>pontozott</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Vonalak összefűzése:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>derékszög</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>tompaszög</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>felirat hossz:</translation>
     </message>
@@ -2461,334 +2474,335 @@
         <translation>A vonal szaggatott</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Legalább egy középső jel mutatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Középső jelek minimuma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Középső jelek minimuma amikor zárva:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Vonalkák hossza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Szaggatott vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Vonalkák közti távolság hossza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Szaggatott vonalak összekötése:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>nincs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Csoporton belüli vonaltörés hossza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Első és utolsó vonalka hosszának fele</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Középső jelek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Középső jelek foltonként:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Középső jel távolsága:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Szegélyek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Eltérő szegély a bal és jobb oldalon</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Baloldali szegély:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Jobboldali szegély:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Kiindulási jel</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Középső jel</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Végjel</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Szaggatott vonal szimbóluma</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Szegélyvonal használata</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Pontok közti távolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Távolság a vonal végétől:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Szaggatott vonal megszüntetése a vonal elején és végén</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Szegély szélessége:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Szegély színe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Szegély elcsúsztatás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>A szegély szaggatott</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Vonalkák hossza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Szegélyvonalak közti távolság hossza:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Új</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Egy új térképet hoz létre</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>Meg&amp;nyit...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Megyit egy létező fájlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Megnyit egy ko&amp;rábbi fájlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Mentés</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Mentés má&amp;sként...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Beállítások...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Bezár</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Bezárja a fájlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Kilép</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Kilépés az alkalmazásból</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Általános</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Súgó &amp;megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Megmutatja az alkalmazás súgóját</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>%1 &amp;névjegye</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Megmutatja az alkalmazás információkat</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>A &amp;Qt névjegye</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Megmutatja a Qt névjegyét</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Súgó</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>El akarja dobni az auomatikusan mentett verziót?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>A fájlt módosította. 
 Menti a változtatásokat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Mentetlen fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2797,60 +2811,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Átméretezi a jelkészletet a válsztott térkép új méretarányának megfelelően?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Összeomlás figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Úgy tűnik %1 összeomlott amikor ezt a fájlt legutóbb megnyitotta &lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Biztos megpróbálja megnyitni?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Automatikus mentés...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Automatikus mentés sikertelen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Minden térkép</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Minden fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>%1 megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2861,19 +2875,19 @@ File format not recognized.</source>
 A fájl formátum nem felismerhető.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>A fájlt módosították.
 El akarja dobni a módosításokat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2884,44 +2898,44 @@ Ebben a formátumban mentem - nyomja meg az Igen gombot.
 Más formátumot választok - nyomja meg a Nem gombot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Fájl mentése</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>A fájl nem lehetett menteni:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Valamilyen probléma van a fájl formátum meghatározásában.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Kérem, hogy jelezze ezt a hibát.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2930,7 +2944,7 @@ because saving as %2 (.%3) is not supported.</source>
 mert a mentés mint %2 (.%3) nem támogatott.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2945,31 +2959,31 @@ mert a formátum ismeretlen.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>A térkép exportálása figyelmeztetéseket generált.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Belső hiba a mentés során:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>A térkép importálása figyelmeztetéseket generált.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2978,12 +2992,12 @@ for reading.</source>
 olvasásra.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Érvénytelen fájl formátum.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2993,7 +3007,7 @@ olvasásra.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3002,17 +3016,17 @@ olvasásra.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nincs mit importálni.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Kérdés</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3021,223 +3035,223 @@ Rescale the imported data?</source>
 Átméretezi az importált adatokat?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>alapértelmezett része</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Új szín</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished">Importálás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>A beállítás fekete (minden nyomtatott szín)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>A koordináták a széleken kívül esnek.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Visszavon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Utolsó lépés visszavonása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Mégis</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Visszavont lépés végrehajtása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Ki&amp;vág</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>Más&amp;ol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Beilleszt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Nagyít</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Kicsinyít</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Teljes képernyőre vált</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Nagyítás beállítása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Térképjelek ablak</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Térképjelek ablak mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Színkészlet ablak</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Színkészlet ablak mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Szimbólumtábla lecserélése egy másik térképfájléval</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Minden térképjel átméretezése...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>A teljes jelkészlet méretezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Térkép méretarányának megváltoztatása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Megváltoztatja a térkép méretarányát és beállítja a térkép objektumok és jelek méretét</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Térképhez fűzött megjegyzések...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Háttér beállítás ablak</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Háttér ablak mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Háttér megnyitása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Mutassa az egész térképet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Objektumok szerkesztése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Pont objektum rajzolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Vonal rajzolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Kör és ellipszis rajzolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Szöveg írása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Megkettőz</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Térképjel cseréje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Szegély kitöltés/létrehozás</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>A jel iránynak megfordítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Vonalak egyesítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Objektum vágása</translation>
     </message>
@@ -3246,67 +3260,67 @@ Import the data anyway?</source>
         <translation type="vanished">Objektum(ok) elforgatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Hossz és terület mérése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Kivágás egy területből</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Lyukak egyesítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Háttérre rajzolás beállításai</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Érintő kurzor engedélyezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>GPS megjelenítés engedélyezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>GPS pontosság kör megjelenítés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Pont objektum beállítása a GPS pozíción</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Egy átmeneti jelölő elhelyezése a GPS pozíción</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Egy átmeneti vonal létrehozása a GPS pozíción</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>GPS átmeneti jelölők törlése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Tájoló megjelenítésének engedélyezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>A térkép Északra tájolása</translation>
     </message>
@@ -3315,189 +3329,189 @@ Import the data anyway?</source>
         <translation type="vanished">Átkapcsolja a háttér láthatóságát</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Új rész hozzáadása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Az aktuális rész átnevezése...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Az aktuális rész eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Részek egyesítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importálás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Szerkesztés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Nézet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Eszközök</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Térkép&amp;jelek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>Tér&amp;kép</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Hátterek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Rajzolás</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Háttérre rajzolás</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Szerkesztés folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>A térkép szerkesztés alatt. Kérem, hogy fejezze be a műveletet a mentés előtt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Térkép mentve</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Mutassa a rácsot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Rács beállítása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Sraffozott területek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Alapvonal nézet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Minden háttér elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Jelkészlet cseréje innen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferálás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Térkép forgatás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Az egész térkép elforgatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Háttér újranyitása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Címke szerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Címke szerkesztő ablak mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Téglalap rajzolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Szabadkézi rajzolás</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Kitöltés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Töröl</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Szabadkézi lyuk vágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Kerek lyuk vágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Téglalap alakú lyuk vágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Minta elforgatása</translation>
     </message>
@@ -3506,301 +3520,301 @@ Import the data anyway?</source>
         <translation type="vanished">Objektum(ok) méretezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Terület egyesítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Átfedések meghagyása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Átfedések kitörlése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Terület kivágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Terület kitörlése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Pontok elosztása egy vonal mentén</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Térkép koordinátái</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Vetített koordináták</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Szélesség/hosszúság (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Szélesség/Hosszűság (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>A koordinátákat mutatja mint...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Lyuk vágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation type="unfinished">Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Mindent kijelöl</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Kijelölés megfordítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Elhelyezkedés másolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Elhelyezkedés vágolapra másolása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Térkép részei</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Háttér kiválasztása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Szerkesztés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Haladó szerkesztés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Térképjel kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Elrejti a felső állapotsort</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Mutatja a felső állapotsort</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>A Nyomtatás/Exportálás nem működik ebben a program verzióban!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Nincs elérhető visszavonási lépés.</translation>
     </message>
@@ -3810,8 +3824,8 @@ Import the data anyway?</source>
         <translation type="vanished">%1 objektum(ok) vágása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Egy belső hiba keletkezett, bocsánat!</translation>
     </message>
@@ -3820,7 +3834,7 @@ Import the data anyway?</source>
         <translation type="vanished">%1 objektum(ok) másolva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Nincs beilleszthető objektum a vágólapra másolva!</translation>
     </message>
@@ -3829,72 +3843,72 @@ Import the data anyway?</source>
         <translation type="vanished">%1 objektum(ok) beillesztve</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>A nagyítási faktor beállítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Nagyítási faktor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Térképjelek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Színek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Minden térképjelet átméretez</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Átméretezési arány (százalék):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Térképhez fűzött megjegyzések</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Hátterek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Címke szerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3904,7 +3918,7 @@ térképjel
 kiválasztva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3914,41 +3928,41 @@ térképjel
 kiválasztva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Pont objektum elhelyezése a térképre.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy pont objektumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Sokszög és görbe vonal rajzolás.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy vonalat, területet vagy kombinált szimbólumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Körök és ellipszisek rajzolása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Szabadkézi rajz készítése.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Körülhatárolt terület kitöltése.</translation>
     </message>
@@ -3957,110 +3971,110 @@ kiválasztva</translation>
         <translation type="vanished">Kijelölt objektum(ok) törlése.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Területkitöltés és pont objektum irányának állítása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy forgatható mintával kitöltött területobjektumot vagy egy forgatható pontobjektumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Létrejövő térképjel: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Az eszköz használatához legalább két terület vagy vonal objektum kijelölése szükséges.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Átfedésben lévő területek egyesítése.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Az elsőnek kiválasztott objektummal átfedésben nem lévő részeket kitörli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Az elsőnek kijelölt objektummal átfedésben lévő területeket kitörli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Az elsőnek kijelölt objektummal átfedésben lévő területeket kitörli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translatorcomment>&quot;cut out this part&quot; nem tudom mire vonatkozik</translatorcomment>
         <translation>Lyukak egyesítése, vagy lyukak egyesítése az objektum határvonalával.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy lyukat tartalmazó területet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Kivágat készítése néhány objektumról vagy az egész térképről.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Jelöljön ki egy zárt határvonalú objektumot a kivágandó terület meghatározásához.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Néhány objektum vagy minden kitörlése egy meghatározott területen belül.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Egy meglévő vonal mentén pont objektumokat helyez el egyenletesen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Az eszköz használatához legalább egy vonal és egy pont objektum kijelölése szükséges.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Lyukak egyesítése sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Törli az átmeneti jelölőket</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Biztos, hogy törli az összes átmeneti GPS jelölőt? Ezt a lépést nem lehet visszavonni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>A rész egyesítése ezzel</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Kijelölt objektumok mozgatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>A térképrészlet nevének bevitele:</translation>
     </message>
@@ -4069,93 +4083,93 @@ kiválasztva</translation>
         <translation type="vanished">Biztos, hogy törli a a &quot;%1&quot; térképrészletet minden objektumával együtt? Ezt a lépést nem lehet visszavonni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Térképrészek egyesítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Biztos, hogy a &quot;%1&quot; térképrész minden objektumát &quot;%2&quot;-be mozgatja, és törli &quot;%1&quot;-t?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Biztos, hogy minden objektumot áthelyez a &quot;%1&quot; térképrészbe, és minden más térképrészt töröl?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Nem lehetséges a kiválasztott fájl importálása, mert nem sikerült betölteni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Téglalap rajzolása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Nyomtatás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Kép</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Törli a visszavonás / mégis listát</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Törli a visszavonás/ mégis listát, hogy csökkentse a térkép fájl méretét.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Megfog</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Felülnyomás szimulációja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Vonalak szerkesztése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Görbévé alakít</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Vonal(ak) egyszerüsítése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exportálás mint...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Szöveget ír a térképre.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy szöveg objektumot.</translation>
     </message>
@@ -4164,26 +4178,26 @@ kiválasztva</translation>
         <translation type="vanished">Megkettőzi a kiválasztott objektumo(ka)t.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki legalább egy objektumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Jelek irányának változtatása vonal objektumon.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki legalább egy vonal objektumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Utak egymáshoz közeli végpontjainak egyesítése.</translation>
     </message>
@@ -4192,17 +4206,17 @@ kiválasztva</translation>
         <translation type="vanished">Kiválasztott objektum(ok) szétdarabolása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Az eszköz használatához legalább egy terület vagy vonal objektum kijelölése szükséges.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Lyuk vágása a kijelölt területbe.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki egy területet.</translation>
     </message>
@@ -4215,18 +4229,18 @@ kiválasztva</translation>
         <translation type="vanished">Kiválasztott objektum(ok) átméretezése.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Szögletes vonalak bezier görbévé alakítása.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Az eszköz használatához jelöljön ki legalább egy vonal objektumot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Vonal objektumon a töréspontok számának csökkentése az eredeti alak megtartásával.</translation>
     </message>
@@ -4235,8 +4249,8 @@ kiválasztva</translation>
         <translation type="vanished">A kijelölt objektum(ok) jelkulcsát erre változtatja.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Az eszköz használatához válasszon ki egy objektumot, és egy azonos típusú, de másik jelkulcsot.</translation>
     </message>
@@ -4249,7 +4263,7 @@ kiválasztva</translation>
         <translation type="vanished">%1 objektum(ok) megkettőzve</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Objektum kiválasztás</translation>
     </message>
@@ -4258,82 +4272,82 @@ kiválasztva</translation>
         <translation type="vanished">Objektum kijelölése sikertelen, mert nincs a kijelölt jelkulcsnak megfelelő objektum a térképen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mérés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Egyesítés sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Átfedés sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Szétválasztás sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Átfedések kitörlése sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Szabadkézi rajz készítése háttérre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Szabadkézi rajz készítése háttérre. Hozzon létre vagy töltsön be egy rajzolható hátteret a gomb bekapcsolásához</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importálja a %1, GPX, OSM or DXF fájlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importálható fájlok</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Minden fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Nem lehetséges a kiválasztott fájl importálása, mert nem támogatott formátumú.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation type="unfinished">
@@ -4341,237 +4355,237 @@ kiválasztva</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Megszakítás. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Több: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Több: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Több: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation type="unfinished">- Térkép -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>%1 oldal szétbontása folyamatban...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>%1 oldal feldolgozása folyamatban...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Elvetve</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Befejezve</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translatorcomment>Zoom tényező</translatorcomment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>milliméter</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>méter</translatorcomment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4586,7 +4600,7 @@ megnyíljon a színválasztó ablak és
 ott határozza meg a színeket.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4601,7 +4615,7 @@ majd válassza az &quot;Új szimbólum&quot; opciót
 a létrehozáshoz.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4614,7 +4628,7 @@ Alaptérkép betöltéséhez kattintson az alábbi menüpontra:
 Háttér -&gt; Háttér hozzáadása ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Tipp: tartsa az egér középső gombját lenyomva a térkép megfogásához,
@@ -4622,127 +4636,127 @@ zoomoljon az egér görgetőgombjával, ha van ilyen lehetősége.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Kerület hossza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Hossz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Terület:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nincs objektum kiválasztva.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objektum kiválasztva.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>A kijelölt objektum nem útvonal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>milliméter</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>méter</translatorcomment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translatorcomment>négyzetmiliméter</translatorcomment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translatorcomment>négyzetméter</translatorcomment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Ez az ojektum túl kicsi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>A minimum terület %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Megjegyzés: Kerület és terület csak akkor pontos, ha az objektumban nincsenek lukak és önmagával nem kereszteződik.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>A vonal túl rövid.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>A minimum hossz %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Új térkép létrehozása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Válassza ki az új térkép méretarányát és szimbólumkészletét.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Méretarány:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Szimbólumtábla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Csak a kiválasztott méretaránynak megfelelő szimbólumok mutatása</translation>
     </message>
@@ -4751,474 +4765,474 @@ zoomoljon az egér görgetőgombjával, ha van ilyen lehetősége.</translation>
         <translation type="vanished">Elvet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Létrehoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Üres szimbólumtábla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Szimbólumtábla betöltése fájlból...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Minden szimbólumtábla fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Minden fájl</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>A térkép több, mint 256 színt tartalmaz, ami nem támogatott az OCAD8-as verzióban.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad visszatért %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Fekete beállítás helyi színként exportálva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Nem lehet exportálni a terület objektum megváltoztatott kitöltési mintáját</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Nem exportálható háttér: %1 típusú fájl jelenleg nem támogatott</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>A(z) &quot;%1&quot; vonalas szimbólumban ebben a kombinációban nem ábrázolható.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>A(z) &quot;%1&quot; vonalas szimbólumban a szaggatott vonalak csoportosítása kihagyva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>A(z) &quot;%1&quot; vonalas szimbólumban, a szaggatott vonalak csoporton belüli száma kettőre csökkentve.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>A(z) &quot;%1&quot; vonalas szimbólumban a szegélyek nem exportálhatók megfelelően.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>A(z) &quot;%1&quot; terület szimbólumban a kitöltési minta kihagyva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>A(z) &quot;%1&quot; terület szimbólumban váltakozó pontsoros minta alkalmazva. Ez lehet hogy megfelelő, de az is hogy nem.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>A(z) &quot;%1&quot; szöveges szimbólumban: egyedi betűköz van beállítva, aminek a végrehajtása egyelőre nem illeszkedik az OCAD működéséhez</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>A(z) &quot;%1&quot; szöveges objektumban: aláhúzás figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>A(z) &quot;%1&quot; szöveges szimbólumban: alsó index figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>A szöveg levágva (A vágást három &apos;|&apos; karakter jelzi): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Háttérkapacitás foglalása sikertelen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad visszatért %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>Az OCAD %1 verziójú fájlok nem támogatottak!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n  szín(ek) szétválasztása kihagyva, ok: Import letiltott.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Pontszín betöltése sikertelen, hiba: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>&quot;Fekete beállítás&quot; szín különleges színként importálva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Szimbólum &quot;%3&quot; importálása sikertelen (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD importálási réteg</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>A(z) %1 szaggatott vonalas szimbólumban különböző végződések (%2 és %3) vannak. %4 alkalmazva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>A(z) %1 szaggatott vonalas szimbólumban a végződés hossza nem importálható megfelelően.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>A(z) %1 szaggatott vonalas szimbólumban a befejeződési távolság nem importálható megfelelően.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>A(z) %1 szaggatott vonalas szimbólumban a fő és a záró távolságok (%2 és %3) eltérnek. %4 alkalmazva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>A(z) %1 szaggatott vonalas szimbólumban D és E távolságok eltérnek. (%2 és %3). %4 alkalmazva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>A(z) %1 vonal szimbólum végeinél a szaggatott jel elnyomva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: sorkizárás figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: (%2) egyedi súlyozás figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: egyedi betűköz van beállítva, aminek a végrehajtása egyelőre nem illeszkedik az OCAD működéséhez</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: (%2%) egyedi betűköz beállítás figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: (%2/%3) egyedi bekezdés beállítások figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>A(z) %1 szöveges szimbólum importálása során: (%2) szövegkeretezés figyelmen kívül hagyva</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Objektum betöltése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Szögletes objektum importálása sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Szöveg szimbólum importálás sikertelen, útvonal nem található &apos; (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Háttér importálása sikertelen: a &quot;%1&quot; háttérkép nem raszteres</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Ismeretlen koordináta formátumú szöveges objektum importálásának megkísérlése</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Színkód nem ismert: %1, ez a szín figyelmen kívül hagyva</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Szöveg</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>%1 &apos;%2&apos;: %3 vonalas szimbólum</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>%1 &apos;%2&apos;: %3 szöveges szimbólum</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Folt szín információ figyelmen kívül hagyva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>%1.%2 &quot;%3&quot;: %4 Szimbólumok importálása sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Nem támogatott típus &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Háttér importálása sikertelen: &quot;%1&quot; nem támogatott háttértípus.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Nem támogatott vonal stílus &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Külömböző végződés a kezdeténél (%1 mm) és a végénél (%2 mm) nem támogatott. %3 mm-es alkalmazva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>A vonalkázott minta nem importálható megfelelően.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>A vonalkázott minta végének hossza (%1 mm) nem importálható megfelelően. Importálás %2 mm használatával.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>A vonalkázott minta végtávolsága (%1 mm) nem importálható megfelelően. Importálás %2 mm használatával.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Nem támogatott keretvonal stílus &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Másodlagos pontszimbólum átugorva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Vonalvégi szaggatott szimbólum törölve.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Az igazított illesztés nem támogatott.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>A vertikális illesztés &apos;%1&apos; nem támogatott.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Egyedi súlyozás (%1) figyelmen kivül hagyva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Az egyedi karaktertávolság lehet, hogy hibás.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Egyedi szóköztávolság (%1 %) figyelmen kívül hagyása.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Egyedi behúzás (%1/%2) figyelmen kívül hagyása.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Szöveg keret (%1 mód) figyelmen kívül hagyása.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Vonal-szöveg szimbólum még nem támogatott. Rejtett szimbólumként jelölve.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Objektum betöltése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Szögletes objektum importálása sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Szöveg szimbólum importálása sikertelen, útvonal nem található (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Ismeretlen koordináta formátumú szöveges objektum importálási kísérlete</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Érvénytelen adat.</translation>
     </message>
@@ -5227,706 +5241,693 @@ zoomoljon az egér görgetőgombjával, ha van ilyen lehetősége.</translation>
         <translation type="vanished">Nem tesztelt fájl importálás az alábbi formátumhoz: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>A %1 verziójú OCD fájlok nem támogatottak!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation type="unfinished">Színkód nem ismert: %1, ez a szín figyelmen kívül hagyva</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation type="unfinished">Pont</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation type="unfinished">Vonal</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation type="unfinished">Terület</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation type="unfinished">Szöveg</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Válasszon hátteret a rárajzoláshoz</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Rajzol</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Kattint és megragad&lt;/b&gt;: Fest. &lt;b&gt;Jobb kattintás és megragad&lt;/b&gt;: Törlés. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Színkiválasztás</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: A térkép mozgatása. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Egy koordinátát hozzáad &lt;b&gt;%1+kattintás&lt;/b&gt;Változtasd meg a kiválasztott koordinátát. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Mindig tájolja északra (nem lehet elforgatni)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elemek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Pont</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Terület</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Minden elem középre</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Aktuális elem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Átmérő &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Belső szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Körvonal vastagsága &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Körvonal színe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Vonalvastagság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Vonal színe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Vonal felirat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>egyenes</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>kör</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>négyzet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Vonalak összefűzése:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>derékszög</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>tompaszög</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Zárt vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Terület színe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordináták:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Görbe indítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Átlag középpontba helyez</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Felezőpont]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Ismeretlen</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Pont szimbólumok</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished">Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Mozgatja a térképet, a nyomtatási területet vagy a terület határait. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Mozgatja a nyomtatási területet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Mozgatja a térképet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Mozgatja a nyomtatási terület határát. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Mozgatja a nyomtatási terület határait. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Hátterek mutatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Rács mutatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Oldal tájolása:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Nyomtató:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Álló</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Fekvő</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Oldal formátuma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Másolatok:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Bal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Felső:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Szélesség:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Magasság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Előnézet...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Egy oldalas</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Egyedi méret beállítás</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Térkép területe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Nyomtatási területet középpontba helyezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Oldal átlapolása:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opciók</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Felbontás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Nyomtatás más méretarányban:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>A háttér megjelenítése eltérő lehet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Felülnyomás szimulálása</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exportálás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF export</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Kép export</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Menés PDF-ben</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Nem támogatott Androidon.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Nyomtatási előnézet folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Ez egy nem szabványos nézet. Biztos nyomtatni/exportálni akarja így a térképet?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Térkép exportálása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Minden fájl (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Nyomtatás folyamatban</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektoros
 grafikák</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Raszteres
 grafikák</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Színrebontás</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Mód:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Kép mentése sikertelen. Létezik az útvonal? Elegendő a jogosultsága?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Sikeresen exportálva %1-be</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Elvetve.</translation>
     </message>
@@ -5935,181 +5936,181 @@ separations</source>
         <translation type="vanished">Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>A nyomtatási feladat nem leállítható.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>A nyomtatási feladat sikeresen létrehozva</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Ismeretlen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>A térkép területe üres. A kimenet elvetve.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Koordináta hivatkozási rendszer:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>A háttér újranyitása</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Bal oldali listából az elemek megfogásával és a jobb oldali listába mozgatásával újratölti azokat.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Bezárt hátterek:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Törölje a listát</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktív hátterek:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Térkép -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Szimbólumtábla cseréje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Konfigurálja, hogy hogyan és mivel cserélje a szimbólumtáblát.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importálja az összes új szimbólumot, akkor is ha az nem helyettesít egy régi szimbólumot</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Törli azokat a szimbólumokat a csere után, amelyek nincsenek használatban</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Törli a nem használt színeket a csere után</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Szimbólum térkép:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Megtartja a régi szimbólumkészletből származó szimbólumok rejtett/védett állapotát</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Szimbólumszám alapján párosít össze szimbólumokat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6119,7 +6120,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6127,286 +6128,286 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Nincs -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Válasszon térkép fájlt a szimbólumok fájlból való betöltéséhez</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Nem lehet betölteni a térkép fájlt, elvetés.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>A cserélt jelkészlet méretaránya 1:%1, amíg a térképé 1:%2. Valóban erre a jelkészletre akarja cserélni?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Térkép elforgatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Szög (óramutató járásával ellentétes):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Elforgatás paraméterei</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Megforgatás a következő körül:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translatorcomment>Forgatási középpont</translatorcomment>
         <translation>Térkép koordinátarendszer középpont</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translatorcomment>Forgatás központja</translatorcomment>
         <translation>Georeferálás referencia pontja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Más pont,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translatorcomment>x:koordináta</translatorcomment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translatorcomment>y koordináta</translatorcomment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opciók</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Georeferálás referencia pontjának beállítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Georeferálás deklinációjának beállítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Nem georeferált háttér forgatása</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Szög:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fix szögek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Beállítja a kitöltési minta, vagy pont objektum irányát. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Forgatás:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fix szögek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: A forgatás középpontjának beállítása. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: A kiválasztott objektum forgatása. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>A térkép méretarányának megváltoztatása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Méretarány beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Új méretarány 1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Méretezés középpontja:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translatorcomment>Mérearány középpont</translatorcomment>
         <translation>Térkép koordináta rendszer eredet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Georeferencia illesztési pont</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Méretezés központ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translatorcomment>x koordináta</translatorcomment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translatorcomment>y koordináta</translatorcomment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opciók</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Szimbólum méretezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Térképobjektumok helyzetének méretezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Georeferencia illesztő pont beállítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Nem georeferrált háttér méretezése</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Méretezés:&lt;/b&gt;%1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: A méretezés középpontjának beállítása. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: A kiválasztott objektum méretezése. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Koordináta viszonyítási rendszer kiválasztása</translation>
     </message>
@@ -6415,17 +6416,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Ugyanaz mint a térképen</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Helyi</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Földrajzi koordináták (WGS84)</translation>
     </message>
@@ -6446,175 +6447,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">CRS leírás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Állapot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>érvényes</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- nincs -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Nincs -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Szám:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Szerkeszt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Név:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Leírás:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Segéd szimbólum (nem látható a végleges térképen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Általános</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>A szimbólum leírásának mutatásához tartsa nyomva az F1-et amíg a súgószöveg megjelenik</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Új szimbólum</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Pont</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Terület</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Szöveg</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Kombinált</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Szerkeszt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Meggkettőz</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Töröl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Méretez...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Másol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Beilleszt</translation>
     </message>
@@ -6627,12 +6628,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Kitölt/Keretezi a kiválsztott objektumot</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Kiválasztja a szimbólumokat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6641,198 +6642,198 @@ Do you want to save your changes?</source>
         <translation type="vanished">Méretezi a szimbólumo(ka)t</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Egy belső hiba keletkezett, bocsánat!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>A vágólapon nincsenek beilleszthető szimbólumok!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Kiválasztja az ilyen szimbólummal jelölt objektumokat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Minden ilyen szimbólummal jelölt objektum kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Ezzel a szimbólummal jelölt objektumok kivétele a kiválasztásból</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Kijelölt szimbólummal jelölt objektumok elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Ezzel a szimbollal jelölt objektumok zárolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Ezzel a szimbólummal jelölt objektumok hozzáadása a kiválasztáshoz</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Ezzel a szimbólummal jelölt objektumok törlése a kijelölésből</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Kijelölt szimbólummal jelölt objektumok elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Ezzel a szimbólummal jelölt objektumok zárolása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Kijelölés megfordítása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translatorcomment>Gyorsbillentyű a szimbol leírásához</translatorcomment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Mindent kijelöl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Nem használtak kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Szimbólumok rendezése</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Kódszám szerinti sorrendezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Alapszínek szerinti sorrendezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Alapszín prioritás szerinti sorrendezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Méretezés százalékban:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>A térkép tartalmaz &quot;%1&quot; szimbólummal jelölt objektumot. A törléssel az objektumok is törlődnek és a változtatás nem visszavonható. Valóban ezt akarja csinálni?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Kijelöli ezzel a szimbólummal jelölt objektumokat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Szimbólum beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt; Háttér:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>- nincs -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Megnyitás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Háttér középre igazítása ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Háttérszín kiválasztása</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6843,58 +6844,58 @@ a lusta kutyát átugrotta
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Nincs leírás!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished">Kulcs</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished">Érték</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">Fölfelé mozgat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">Lefelé mozgat</translation>
     </message>
@@ -6903,210 +6904,210 @@ a lusta kutyát átugrotta
         <translation type="obsolete">Súgó</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Kulcs</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Érték</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>A kulcs létezik</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>A %1 kulcs már létezik és nem lehet kétszer használni.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Keresem az elmozgatott háttér fájlt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Minden fájl (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Nincs ilyen fájl.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>A fájl formátuma használható ehhez a háttértípushoz?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Háttér igazítása</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Hiba az igazítás kiszámításában!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Adja meg az illesztőpont helyét a háttéren. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Adja meg az illesztőpont helyét a térképen. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Kattintás&lt;/b&gt;: Törli az illesztőpontokat. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt;: Az illesztőpontokat mozgatja. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Illesztőpontok:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Új</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Mozgat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Töröl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Háttér X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Hátér Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Térkép X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Térkép Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Alkalmazza az illesztő pontokat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Alkalmaz &amp;&amp;mindent töröl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Mindent töröl</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Nincs elég szabad memória (képméret: %1x%2 képpont)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7115,84 +7116,84 @@ A GIF fájlok mentése nem támogatott. Ez azt jelenti, hogy rajzokat ezen a sab
 De ha nem akarsz a háttérre rajzolni, akkor ez nem jelent problémát.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Kiválasztja a koordináták egyenrangú hivatkozási rendszerét a világfájlban</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>%1 megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Kép mérete:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Adja meg, hogy hogyan helyezze vagy méretezze a képet:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Világfájl</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nincs georeferencia információ</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferált</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Méter per pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>-vel szkennelve</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Háttér méretaránya: 1:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Megnyit</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7201,351 +7202,351 @@ De ha nem akarsz a háttérre rajzolni, akkor ez nem jelent problémát.</transl
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished">Átlátszóság</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished">Csoportosít</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished">Fájl név</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished">Mutat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished">Megnyitás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished">Vázlat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished">Háttér hozzáadása...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished">Bezár</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished">Fölfelé mozgat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished">Lefelé mozgat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished">Georeferált: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished">Kézi mozgatás</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished">Igazítás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished">Pozicionálás...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished">Importálás és törlés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished">Súgó</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished">Kép, GPS útvonal vagy DXF fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished">Háttér fájlok</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished">Minden fájl</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished">Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished">Ismeretlen fájl formátum.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished">Nem sikerült a háttér betöltése. A fájl nem létezik, vagy hibás?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished">Kérem, hogy adjon meg egy érvényes egész számot a csoport beállításához, vagy a mezőt hagyja üresen a háttér állományok csoportjának felbontásához!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished">Méretezés a térkép névleges méretarányával: (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished">Méretezze az aktuális háttér mérearányához (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished">Nincs méretezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished">Háttér importálása</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished">Hogy szeretné méretezni az importálandó szimbólumokat?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished">- Térkép -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Megragad&lt;/b&gt; az aktuális háttér mozgatásához</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Elhelyezés</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Méretek:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Méretek:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Forgatás:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Nyomvonal méretaránya és helyzete</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordináta rendszer</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Valós</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Térkép</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Egy koordináta egység egyenlő:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translatorcomment>Adott koordinátán helyezi el a nyomot</translatorcomment>
         <translation>Pozíció nyom a kért koordinátáknál</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>A pozíciók nyoma a nézet közepén</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Kiválasztja az útvonal koordináták egyenrangú hivatkozási rendszerét</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Útvonal megnyitása ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Az útvonalat georeferált vagy nem georeferált módon töltse be?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Az útvonalat a térkép georeferációs beállításai szerint helyezi el.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Ezek még nincsenek konfigurálva, a következő lépésben lesznek láthatóak.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferált</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Nem georeferált</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Fájl útvonal üres, nincs mit importálni!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Kérdés</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Az útvonalpontok importálása olyan vonalként, ami minden ponton átmegy?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Probléma import</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n útvonal objektum(ok) nem importáható(k). (Ok: hiányzó koordináták).</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Olvasási hiba</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7554,39 +7555,39 @@ De ha nem akarsz a háttérre rajzolni, akkor ez nem jelent problémát.</transl
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Nem OSM fájl.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Az OSM fájl verziója %1.
 A legkisebb támogatott verzió a %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Az OSM fájl verziója %1.
 A legnagyobb támogatott verzió a %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problémák</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 csomópontok feldolgozása nem volt megfelelő.</translation>
     </message>
 </context>
 <context>
-    <name>TemplateWidget</name>
+    <name>OpenOrienteering::TemplateWidget</name>
     <message>
         <source>Show</source>
         <translation type="vanished">Mutat</translation>
@@ -7725,7 +7726,7 @@ A legnagyobb támogatott verzió a %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="obsolete">Külső link: %1</translation>
@@ -7736,58 +7737,58 @@ A legnagyobb támogatott verzió a %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Igazítás</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Balra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Középre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Jobbra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Felülre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Alapvonalra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Alulra</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Szöveg beállítások</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Betűtípus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Betűméret:</translation>
     </message>
@@ -7796,340 +7797,340 @@ A legnagyobb támogatott verzió a %2.</translation>
         <translation type="vanished">Méret beállítás...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translatorcomment>A nyelvi ABC első nagy betűje</translatorcomment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Szöveg szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>félkövér</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>dőlt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>aláhúzott</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Betű stílus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Sorköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Bekezdés térköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Betűköz:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Alsó index</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Szimbólumikon-szöveg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Keretezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD kompatibilitás beállításai</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Keretező szín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Vonal keretezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Szélesség:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Árnyék keretezés</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Bal/Jobb távolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Felső/Alsó távolság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD kompatibilitás</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>engedélyezve</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Vonalvastagság:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Vonalszín:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Helyzet:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Bekezdések alatti vonal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Távolság az alapvonaltól:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Beállítja a tabulátor pozíciókat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Egyedi tabulátor hozzáadása</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Nem lehet visszavonni, mert az utolsó visszavonási lépés érvénytelenné vált. Ez például akkor történhet, ha egy objektumot egy újra cserélt és azután a régi szimbólumot törölte.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Ennek a lépésnek a visszavonása túl menne azon a ponton, amikor a fájl be lett töltve. Biztosan ezt akarja?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Nem lehet mégis végrehajtani, mert a &quot;mégis&quot; lépés érvénytelenné vált. Ez például akkor történhet, ha törölve lett a szimbólum, amivel rajzolt.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Nem található a súgó fájl.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Nem található a súgó böngésző program (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>A súgó fájl böngésző (&quot;Qt Assistant&quot;) nem indult el.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>A Mapper régebbi verziói nem támogatnak többszörös térképrészeket. Ahhoz, hogy kompatibilis üzemmódban mentse el a térképet, először össze kell olvasztania minden térképrészt.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Nem támogatott elem: %1 (%2. sor, %3. oszlop)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>ismeretlen</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>A fájl részei nem olvashatók a Mapper ezen verziójával. Legalább %1 verzióra van szüksége</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Ismeretlen hiba</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Nem támogatott vagy érvénytelen georeferációs leírás &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Nem lehet beállítani a színátmenetek tulajdonságait &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>A várt %1 színből %2 megtalálva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>A %2 feldolgozása közben a %1 pont szín nem található (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>A várt %1 szimbólumból %2 megtalálva.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>A várt %1 térképrészből %2 megtalálva.</translation>
     </message>

--- a/translations/OpenOrienteering_id.ts
+++ b/translations/OpenOrienteering_id.ts
@@ -2,2344 +2,2357 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="id">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Peta orienteering</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Perangkat lunak untuk menggambar peta orienteering</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Tentang %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt; semua tentang lisensi, pemberitahuan hak cipta, kondisi dan penyangkalan.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Para pengembang OpenOrienteering dalam urutan abjad:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(proyek inisiator)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Perangkat lunak gratis untuk menggambar peta orienteering</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Program ini adalah perangkat lunak bebas: Anda dapat mendistribusikan dan memodifikasi di bawah &lt;a %1&gt;GNU General Public License (GPL), versi&amp;nbsp;3&lt;/a&gt;, seperti dipublikasikan oleh Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Program ini didistribusikan dalam harapan bahwa itu akan berguna, tetapi TANPA ADANYA JAMINAN; tanpa bahkan jaminan tersirat dapat DIPERJUALBELIKAN atau KESESUAIAN untuk TUJUAN TERTENTU. Lihat GNU General Public License (GPL), versi&amp;nbsp;3, untuk &lt;a %1&gt;lebih jelasnya&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Untuk kontribusi, terima kasih kepada:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Buka berkas yang terakhir digunakan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Tampilkan tips</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Tampilkan item yang tersisa</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Ukuran minimum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Mengisi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Mengisi garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Pola mengisi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Garis tunggal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Paralel baris</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Spasi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Baris tunggal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Interval pola:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Pola offset:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Offset baris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Paralel baris</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Spasi baris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Mengisi rotasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Sudut:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>adjustable per objek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Pengaturan wilayah</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Pola mengisi %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Mengisi garis %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Ada isi yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Area warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Offset baris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Warna garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Lebar garis:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Berkas tersimpan otomatis</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>File yang disimpan oleh pengguna</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Pemulihan berkas</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>File %1 tidak ditutup dengan benar. Saat ini, ada dua versi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Simpan file aktif untuk menghapus versi bertentangan.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Mengedit warna peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Mengedit</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Mendefinisikan warna spot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Campuran warna spot (layar dan mencetak):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Babak: menghapus warna rendah</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Menghitung dari tempat warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Menghitung dari warna RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Proses warna kustom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Kuning</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Hitam</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Menghitung dari warna CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Warna RGB kustom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Merah</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Hijau</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Biru</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Percetakan profesional</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation type="unfinished">- tidak disebutkan namanya -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished">Peringatan</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- tidak ada -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Keburaman</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Warna bintik</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>pindahkan keatas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Pindahkan ke bawah</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Tolong</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Klik dua kali nilai warna untuk membuka dialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Peta berisi simbol dengan warna ini. Menghapusnya akan menghapus warna dari objek-objek ini! Apakah Anda benar-benar ingin melakukan itu?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Klik dua kali untuk menentukan warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klik untuk memilih nama dan klik lagi untuk mengedit.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Jumlah bagian:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Prifat baris simbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Area pribadi simbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Mengedit simbol prifat...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Pengaturan Kombinasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Mengubah dari publik ke simbol prifat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Ambil simbol lama sebagai template untuk simbol pribadi?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Simbol %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Mengkonfigurasi grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Tampilkan grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Snap ke grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Memilih...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Semua garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Garis horizontal</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Garis vertikal</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Garis arah</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Sejajar dengan utara magnetik</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Menyelaraskan dengan grid utara</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Menyelaraskan dengan benar Utara</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Tambahan rotasi (berlawanan arah jarum jam):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Posisi</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>meter di medan</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milimeter pada peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Spasi horisontal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Jarak vertical:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horisontal offset:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikal offset:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Unit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Warna garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Tampilan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Memilih warna baris grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Asal: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>kertas koordinat asal</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>proyeksi koordinat asal</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klik atau drag&lt;/b&gt;: mulai menggambar lubang. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Garis split harus diakhiri pada batas wilayah!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Awal dan akhir dari garis split adalah bagian yang berbeda dari objek!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Awal dan akhir dari garis split berada di posisi yang sama!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt; pada baris: terbelah menjadi dua. &lt;b&gt;Drag&lt;/b&gt; sepanjang jalur: menghapus bagian baris ini. &lt;b&gt;Klik atau Drag&lt;/b&gt; di batas wilayah: memulai baris split. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Membelah lubang daerah objek tidak didukung lagi!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: klip seluruh peta. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+klik atau drag&lt;/b&gt;: pilih objek untuk dipotong. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klip objek yang dipilih. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Tidak dapat membuka file.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>File yang bukanlah DXF file.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Huruf:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Tinggi:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Mendistribusikan poin merata sepanjang jalan</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Jumlah poin per jalur:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Juga menempatkan objek pada titik akhir baris</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Pengaturan rotasi</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Menyelaraskan poin dengan arah jalur</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Sudut rotasi tambahan (berlawanan arah jarum jam):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Dari pusat</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: memulai sebuah lingkaran atau elips. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: Menggambar sebuah lingkaran. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Memegang %1 untuk mulai menggambar dari pusat.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: menyelesaikan lingkaran. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: Menggambar elips. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: Menggambar jalan. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;poin pada tanda pisah.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt;: Snap atau menambahkan ke objek yang sudah ada. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt;: memilih arah dari objek yang sudah ada. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt;: Snap benda-benda yang ada. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Tetap sudut. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Membatalkan titik terakhir. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Sudut</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>garis</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Membatalkan</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Batalkan</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Panjang:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mulai garis lurus. &lt;b&gt;Drag&lt;/b&gt;: mulai kurva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+drag&lt;/b&gt;: Ikuti benda-benda yang ada. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Menggambar garis lurus. &lt;b&gt;Drag&lt;/b&gt;: Menggambar kurva. &lt;b&gt;Hak atau double klik&lt;/b&gt;: menyelesaikan jalan. &lt;b&gt;%1&lt;/b&gt;: menutup jalan. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Sentuh peta untuk menyelesaikan rata-rata</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: menyelesaikan pengaturan objek. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Sudut</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Ulang</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Sudut:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: tetap sudut. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: membuat objek titik.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: Buat objek dan mengatur orientasi.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotasi.</translation>
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Klik garis</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Jalur</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Membatalkan</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Batalkan</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klik atau Drag&lt;/b&gt;: mulai menggambar persegi panjang. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klik jalur sebelumnya. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengatur titik sudut. &lt;b&gt;Hak atau double klik&lt;/b&gt;: menyelesaikan persegi panjang. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation type="unfinished">Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Menyelesaikan pengeditan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Membuat obyek teks dengan jangkar satu. &lt;b&gt;Drag&lt;/b&gt;: Membuat kotak teks. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>beralih kekurva</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Gerakan bebas. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt; pada segmen: beralih antara lurus dan melengkung. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Klik</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Titik / sudut</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Beralih garis</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Menyelesaikan pengeditan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Menjaga posisi pegangan yang berlawanan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt; pada titik: Hapus; di jalan: menambahkan titik dash baru; dengan &lt;b&gt;%2&lt;/b&gt;: menambahkan titik normal. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+klik&lt;/b&gt; pada titik: Hapus; di jalan: menambahkan sebuah titik yang baru; dengan &lt;b&gt;%2&lt;/b&gt;: menambahkan titik dash. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt; pada titik untuk beralih antara dasbor dan titik normal. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinat offset:&lt;/b&gt; %1, %2 mm &lt;b&gt;Jarak:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Sudut tetap. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klik benda-benda yang ada. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: pilih objek tunggal. &lt;b&gt;Drag&lt;/b&gt;: memilih beberapa objek. &lt;b&gt;%1+klik&lt;/b&gt;: beralih pilihan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Hapus objek yang dipilih. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Tampilan peta berkualitas tinggi (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing membuat peta terlihat jauh lebih baik, tetapi juga memperlambat tampilan peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Menampilkan teks berkualitas tinggi dalam peta (antialiasing), lambat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klik toleransi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Klik jarak (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Melangkah tetap sudut mode (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Ketika memilih sebuah objek, secara otomatis memilih simbolnya</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Tampilannya jauh dari kursor ketika zoom out</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Alat gambar: set titik terakhir pada finishing dengan klik kanan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Template: menyimpan pengaturan template tertutup</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Mengedit alat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Mempertahankan bentuk lama</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Mengulang pegangan kurva luar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Menjaga gagang luar kurva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Aksi pada menghapus titik kurva dengan %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Alat persegi empat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Radius garis bantu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Pratinjau lebar garis dengan garis bantu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Tidak dapat membuat file baru: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Format (%1) tidak mendukung ekspor</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Daerah peta sangat besar. Penggunaan alat mengisi mungkin sangat lambat. Apakah Anda ingin menggunakannya?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Daerah diklik tidak dibatasi oleh garis atau daerah, tidak dapat mengisi daerah ini.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Posisi diklik tidak bebas, tidak dapat menggunakan alat isi yang ada.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Gagal membuat untuk mengisi objek.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengisi daerah dengan simbol aktif. Daerah harus diisi harus dibatasi oleh garis atau daerah, simbol-simbol lainnya tidak diperhitungkan. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS dinonaktifkan dalam pengaturan perangkat. Membuka pengaturan sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ya</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Tidak</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation type="unfinished">Konfigurasi</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished">Nilai</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Penampilan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Bahasa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Layar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Piksel per inci:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Mulai program</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Menyimpan file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Mempertahankan kompatibilitas dengan Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Simpan pemulihan informasi otomatis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Menyimpan jarak informasi pemulihan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>File impor dan ekspor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-bit menulis kode:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Lebih...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Standar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Menggunakan importir OCD baru juga file versi 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Umum</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Pemberitahuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Program harus direstart dahulu supaya perubahan bahasa terjadi!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Buka terjemahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>File terjemahan (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>File yang dipilih bukanlah terjemahan yang berlaku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Resolusi layar utama dalam pixel:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Ukuran layar utama dalam inci (diagonal):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Koordinat UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>Zona UTM (nomor Utara/Selatan)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Koordinat Gauss-Krueger</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Zona nomor (1-119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>oleh kode EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ Koordinat</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Koordinat lokal</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Oleh kode EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Kustom PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Spesifikasi</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Skala spesifikasi peta tidak sah atau kehilangan.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Faktor skala grid tidak valid: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Tidak diketahui CRS spesifikasi bahasa: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Tidak didukung geografis CRS spesifikasi: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georeferencing peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Lihatlah...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Deklinasi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Proyeksi koordinat</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Koordinat geografis</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Menunjukkan titik referensi di:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>berlaku</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Pencarian online deklinasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Peta sistem koordinat rujukan</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokal -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Faktor skala grid:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Acuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Memilih pada peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Utara peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Referensi sistem koordinat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Koordinat peta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Koordinat geografis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Perubahan CRS, menjaga:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Grivasi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Deklinasi magnet untuk referensi titik %1° %2° sekarang dapat diperoleh dari &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Apakah Anda ingin melanjutkan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Deklinasi perubahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Deklinasi telah berubah. Apakah Anda ingin memutar konten sesuai peta?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Koordinat lokal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Memuat...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>terkunci</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Tidak bisa mengurai data.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Deklinasi nilai tidak ditemukan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Pencarian online deklinasi gagal:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengatur titik referensi. &lt;b&gt;Klik kanan&lt;/b&gt;: membatalkan.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Selamat datang di OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Kegiatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Membuat peta baru ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Buka peta ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Tentang %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Tolong</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Keluar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Peta terbaru</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Buka paling baru saja digunakan file pada awal</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Hapus daftar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Tampilkan tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Sebelumnya</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Berikutnya</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Contoh</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Tentang Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Daftar file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Tidak ada file peta ditemukan!&lt;br/&gt;&lt;br/&gt;Salin file peta ke folder tingkat atas yang bernama &apos;OOMapper&apos; pada perangkat atau kartu memori.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Error ketika memuat simbol jenis %1 baris %2 kolom %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Simbol ID &apos;%1&apos; tidak unik di baris %2 kolom %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Error ketika memuat simbol jenis %1 baris %2 kolom %3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Error ketika memuat sebuah objek dari tipe %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Error ketika memuat sebuah objek jenis %1 di %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Tidak dapat menemukan simbol untuk objek di %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Titik objek dengan simbol undefined atau salah %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD versi 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Tidak bisa mengurai koordinat.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Diharapkan %1 koordinat, ditemukan %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Error ketika memuat konfigurasi pencetakan pada %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Error ketika memuat undo/mengulang langkah %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Menemukan objek tanpa simbol.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Menjatuhkan %n obyek tidak teratur.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Error selama simbol pasca-pengolahan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Template &quot;%1&quot; telah dimuat dari peta direktori bukan lokasi relatif ke file peta mana itu sebelumnya.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Gagal untuk memuat template &apos;%1&apos;, alasan: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Peringatan ketika memuat template &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>File template setidaknya satu tidak dapat ditemukan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klik nama template merah dalam template-&gt; jendela pengaturan Template untuk mencari nama file template.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>File ini menggunakan format usang. Dukungan untuk format ini adalah untuk dihapus dari program ini segera. Untuk dapat membuka file di masa depan, menyimpannya lagi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Versi format berkas tidak valid.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>File format versi lama tidak didukung. Silakan gunakan versi program yang lebih tua untuk memuat dan memperbarui file.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Tidak didukung versi format file baru. Beberapa fitur peta tidak akan dimuat atau diselamatkan oleh versi program. Coba perbarui.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Sistem koordinat geografis referensi peta adalah &quot;%1&quot;. CRS ini tidak didukung. Menggunakan &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Error ketika memuat simbol dengan tipe %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Error ketika memuat simbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Kesalahan ketika memuat lmengembalikan langkah-langkah.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Kesalahan saat membaca peta bagian hitungan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Kesalahan ketika memuat peta bagian %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Tidak bisa membaca file: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Format file tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Tidak didukung versi format file baru. Beberapa fitur peta tidak akan dimuat atau diselamatkan oleh versi program.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Format (%1) tidak mendukung impor</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Pengaturan garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Lebar garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Warna garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Panjang minimum garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Cap garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>datar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>bulat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>persegi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>lincip</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Gabung garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>mitra</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>memiringkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Panjang cap:</translation>
     </message>
@@ -2349,334 +2362,335 @@
         <translation>Garis putus-putus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Menunjukkan setidaknya satu pertengahan simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Pertengahan jumlah simbol minimum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimum pertengahan simbol menghitung ketika ditutup:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Panjang garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Garis putus-putus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Jeda panjang:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Tanda hubung dikelompokkan bersama:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>tidak ada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Dalam kelompok jeda panjang:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Setengah panjang garis pertama dan terakhir</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Simbol-simbol pertengahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Simbol-simbol pertengahan setiap tempat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Pertengahan simbol jarak:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Perbatasan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Batas-batas yang berbeda pada sisi kiri dan kanan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Perbatasan kiri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Perbatasan yang kanan:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Simbol start</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Pertengahan simbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Simbol akhir</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Garis simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Mengaktifkan garis perbatasan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Jarak antara tempat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Jarak dari garis akhir:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Menekan simbol dash di garis awal dan akhir baris</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Lebar batas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Warna batas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Geser batas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Perbatasan berlari</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Batas garis panjang:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Jeda batas panjang:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Membuat peta baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Terbuka...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Buka file ada</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Buka &amp;baru saja</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Simpan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Simpan &amp;sebagai...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Pengaturan...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Tutup file ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Keluar instalasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Keluar dari aplikasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Umum</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Buka &amp;Manual</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Tampilkan file bantuan untuk aplikasi ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Tentang %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Menampilkan informasi tentang aplikasi ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Tentang &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Menampilkan informasi tentang Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Apakah Anda ingin menghapus versi autosaved?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>File telah dimodifikasi.
 Apakah Anda ingin menyimpan perubahan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>File belum tersimpan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2685,60 +2699,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Apakah Anda ingin skala simbol untuk skala dipilih?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Kecelakaan peringatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Tampaknya bahwa %1 jatuh terakhir waktu file ini dibuka: &lt;br /&gt; &lt;tt&gt; %2&lt;/tt&gt; &lt;br /&gt; &lt;br /&gt; Benar-benar mencoba untuk membukanya?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Simpan otomatis...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Gagal menyimpan ootomatis!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Semua peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Semua file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Buka file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Buka %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2749,19 +2763,19 @@ File format not recognized.</source>
 format File tidak diakui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>File telah dimodifikasi.
 Apakah Anda ingin membuang perubahan Anda?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2772,44 +2786,44 @@ Tekan ya untuk menyimpan dalam format ini.
 Tekan tidak untuk memilih format yang berbeda.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Simpan file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>File tidak bisa diselamatkan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Ada masalah dalam menentukan file format.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Laporkan hal ini sebagai kesalahan.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2818,7 +2832,7 @@ because saving as %2 (.%3) is not supported.</source>
 karena penyimpan sebagai %2 (.%3) tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2827,31 +2841,31 @@ because the format is unknown.</source>
 karena format yang tidak diketahui.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Peta ekspor dihasilkan peringatan.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Kesalahan internal sementara disimpan:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Peringatan Impor peta dihasilkan.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2860,12 +2874,12 @@ for reading.</source>
 untuk membaca.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Jenis file yang falid.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2876,7 +2890,7 @@ untuk membaca.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -2885,17 +2899,17 @@ untuk membaca.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Tidak ada untuk mengimpor.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Pertanyaan</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -2904,223 +2918,223 @@ Rescale the imported data?</source>
 Rescale data yang diimpor?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>bagian standar</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Warna baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Pendaftaran hitam (semua cetak warna)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Koordinat berada di luar batas.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Membatalkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Membatalkan langkah terakhir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Mengulang</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Mengulang langkah terakhir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Cu&amp;t</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>S&amp;alin</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Salin</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Memperbesar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Perkecil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Alihkan ke mode layar penuh</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Mengatur faktor zoom kustom...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Jendela simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Tampilkan/Sembunyikan jendela simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Jendela warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Tampilkan/Sembunyikan jendela warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Menggantikan simbol-simbol mereka dari file peta lain</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Skala semua simbol...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Skala simbol seluruh set</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Perubahan skala peta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Mengubah skala peta dan menyesuaikan objek peta dan ukuran simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Catatan peta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Jendela pengaturan template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Tampilkan/Sembunyikan jendela template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Buka template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Tampilkan seluruh peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Mengedit objek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Titik setel objek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Menggambar jalan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Menggambar lingkaran dan elips</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Menulis teks</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Menukar simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Mengisi / membuat perbatasan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Beralih arah garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Menghubungkan jalur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Memotong objek</translation>
     </message>
@@ -3129,254 +3143,254 @@ Import the data anyway?</source>
         <translation type="vanished">Memutar obyek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mengukur panjang dan daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Memotong dari daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Menggabungkan daerah lubang</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Cat pada pengaturan template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Mengaktifkan sentuhan kursor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Mengaktifkan GPS tampilan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Mengaktifkan GPS cincin jarak</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Titik setel objek di posisi GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Ditetapkan sementara penanda pada posisi GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Membuat jalan sementara di posisi GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Jelas sementara GPS spidol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Mengaktifkan tampilan kompas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Menyelaraskan utara peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Menambahkan bagian baru...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Mengubah nama bagian saat ini...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Menghapus bagian saat ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Menggabungkan semua bagian</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Merubah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Lihat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Alat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Si&amp;mbols</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>M&amp;ap</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Menggambar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Cat pada template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Mengedit dalam kemajuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Peta saat ini sedang diedit. Harap menyelesaikan operasi edit sebelum menyimpannya.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Peta disimpan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Tampilkan grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Mengkonfigurasi kotak...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Merencanakan area</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Pandangan dasar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Menyembunyikan semua template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Menggantikan simbol set...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferencing...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Memutar peta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Memutar peta seluruh</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Membuka kembali template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Tag editor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Tampilkan/Sembunyikan jendela tag editor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Gambarlah persegi panjang</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Menggambar dengan bebas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Mengisi batas daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Lubang dipotong bentuk bebas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Memotong lubang bundar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Memotong lubang persegi panjang</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Memutar pola</translation>
     </message>
@@ -3385,301 +3399,301 @@ Import the data anyway?</source>
         <translation type="vanished">Obyek skala</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Menyatukan wilayah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Daerah berpotongan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>XOr daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Potongan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Memotong</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Mendistribusikan poin sepanjang jalan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Koordinat peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Proyeksi koordinat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Lintang/bujur (des)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Lintang/bujur (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Menampilkan koordinat sebagai...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Memotong lubang</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl + M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Apapun pilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Balikkan seleksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Menyalin posisi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Salin posisi ke clipboard.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Melihat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Bagian peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Pilih template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Mengedit</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Pengeditan lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Pilih simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Menyembunyikan bar bagian atas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Bar bagian atas tampilkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Cetak / ekspor tidak tersedia dalam versi program ini!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Tidak membatalkan langkah tersedia.</translation>
     </message>
@@ -3689,8 +3703,8 @@ Import the data anyway?</source>
         <translation type="vanished">Memotong %1 obyek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Terjadi kesalahan internal, maaf!</translation>
     </message>
@@ -3699,7 +3713,7 @@ Import the data anyway?</source>
         <translation type="vanished">Disalin %1 obyek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Tidak ada objek di papan klip yang bisa disisipkan!</translation>
     </message>
@@ -3708,72 +3722,72 @@ Import the data anyway?</source>
         <translation type="vanished">Disisipkan %1 obyek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Mengatur faktor zoom kustom</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Faktor zoom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Skala semua simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Presentase skala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Catatan peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>Oke</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Tag Editor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3783,7 +3797,7 @@ simbol
 yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3793,41 +3807,41 @@ simbol
 yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Tempatkan titik obyek di peta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Pilih titik simbol untuk dapat menggunakan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Menggambar garis poligonal dan melengkung.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Pilih jalur, daerah, atau gabungan simbol untuk dapat menggunakan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Menggambar lingkaran dan elips.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Menggambar jalan bebas dengan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Isi batas daerah.</translation>
     </message>
@@ -3836,205 +3850,205 @@ yang dipilih</translation>
         <translation type="vanished">Menghapus obyek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Menetapkan arah daerah mengisi pola atau titik objek.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Pilih objek daerah dengan mengisi rotatable pola atau titik rotatable objek untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Simbol yang dihasilkan: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Pilih setidaknya dua daerah atau obyek path aktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Menyatukan benda-benda yang tumpang tindih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Menghapus semua bagian yang tidak tumpang-tindih dengan obyek pertama.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Hapus bagian-bagian yang tumpang tindih dari obyek yang terseleksi pertama.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Menghapus semua bagian yang tumpang tindih pertama objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Menggabungkan lubang daerah bersama-sama, atau menggabungkan lubang dengan batas objek untuk memotong bagian ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Pilih satu daerah objek dengan lubang untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Membuat potongan dari beberapa objek atau seluruh peta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Pilih sebuah obyek path tertutup sebagai bentuk potongan untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Memotong beberapa objek atau segala sesuatu dalam area terbatas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Jarak merata tempat benda-benda titik sepanjang jalan objek yang sudah ada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Pilih obyek path setidaknya satu dan simbol titik tunggal untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Penggabungan lubang gagal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Tanda-tanda yang jelas sementara</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Apakah Anda yakin Anda ingin menghapus semua tanda-tanda GPS sementara? Ini tidak dapat dibatalkan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Menggabungkan bagian ini dengan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Memindahkan objek yang dipilih ke</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Masukkan nama bagian peta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Beralih ke peta bagian &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Menggabungkan bagian-bagian peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Apakah Anda ingin memindahkan semua benda dari peta bagian &quot;%1&quot; ke &quot;%2&quot;, dan menghapus &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Apakah Anda ingin memindahkan semua benda peta bagian &quot;%1&quot;, dan menghapus semua bagian peta lain?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Tidak dapat mengimpor file peta dipilih karena itu tidak dapat dimuat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Menggambar persegi panjang.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Cetak...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Gambar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Clear undo / mengulang sejarah</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Jelas undo / mengulang sejarah untuk mengurangi ukuran file peta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Pot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulasi selama printing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Edit baris</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Mengkonversi ke kurva</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Menyederhanakan jalan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Ekspor sebagai...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Menulis teks pada peta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Pilih teks simbol untuk dapat menggunakan alat ini.</translation>
     </message>
@@ -4043,26 +4057,26 @@ yang dipilih</translation>
         <translation type="vanished">Duplikat obyek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Pilih setidaknya satu objek untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Beralih ke arah simbol pada baris objek.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Pilih setidaknya satu baris objek untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Hubungkan endpoint jalan yang berdekatan.</translation>
     </message>
@@ -4071,17 +4085,17 @@ yang dipilih</translation>
         <translation type="vanished">Potong obyek yang dipilih ke bagian yang lebih kecil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Pilih setidaknya satu baris atau daerah objek untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Potong lubang objek area dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Pilih sebuah objek tunggal daerah untuk mengaktifkan alat ini.</translation>
     </message>
@@ -4094,18 +4108,18 @@ yang dipilih</translation>
         <translation type="vanished">Skala obyek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Mengubah jalan menjadi segmen lurus splines bezier yang halus.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Pilih sebuah obyek path untuk mengaktifkan alat ini.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Mengurangi jumlah poin dalam obyek path sambil berusaha mempertahankan bentuk mereka.</translation>
     </message>
@@ -4114,8 +4128,8 @@ yang dipilih</translation>
         <translation type="vanished">Switch simbol obyek yang dipilih untuk simbol yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Pilih setidaknya satu objek dan pas, berbeda simbol untuk mengaktifkan alat ini.</translation>
     </message>
@@ -4128,7 +4142,7 @@ yang dipilih</translation>
         <translation type="vanished">obyek %1 diduplikasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Pilihan objek</translation>
     </message>
@@ -4137,77 +4151,77 @@ yang dipilih</translation>
         <translation type="vanished">Ada benda yang dipilih karena tidak ada benda dengan simbol-simbol dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Ukuran</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Penyatuan gagal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Persimpangan gagal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Perbedaan yang gagal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOr gagal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Apakah Anda ingin menghapus peta bagian &quot;%1&quot; dan semua objek?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Cat gratis dengan pada template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Cat gratis dengan pada template. Membuat atau memuat template yang dapat ditarik ke untuk mengaktifkan tombol ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>%1, GPX, OSM atau DXF file impor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>File yang diimpor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Semua file</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Tidak dapat mengimpor file yang dipilih karena file format tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Memutar objek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Skala objek</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4215,234 +4229,234 @@ yang dipilih</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Disalin %n obyek</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Obyek disisipkan %n</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Menghapus objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Duplikat objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Memutar objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Skala objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Potong objek yang dipilih ke bagian yang lebih kecil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Switch simbol dari objek yang dipilih untuk simbol yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Isi baris yang dipilih atau untuk daerah yang dipilih.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>%n duplikasi obyek</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Ada benda yang dipilih karena tidak ada benda dengan simbol-simbol yang dipilih.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: membatalkan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Lebih lanjut: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Lebih: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Lebih lanjut: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Peta -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Proses pemisahan Halaman %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Pengolahan Halaman %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Dibatalkan</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Selesai</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4458,7 +4472,7 @@ warna dialog dan
 menetapkan warna yang ada.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4473,7 +4487,7 @@ dan pilih &quot;Simbol baru&quot;
 untuk membuat satu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4486,7 +4500,7 @@ Untuk memuat peta dasar, klik
 template-&gt; terbuka template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Petunjuk: Tahan tombol mouse tengah untuk tarik peta,
@@ -4494,123 +4508,123 @@ zoom menggunakan roda mouse, jika tersedia.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Batas panjang:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Panjang:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Luas area:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Tidak ada objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objek-objek yang dipilih.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Objek yang dipilih adalah tidak jalan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Objek ini terlalu kecil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Daerah minimimum adalah %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Catatan: Batas panjang dan luas yang benar hanya jika tidak ada persimpangan diri dan lubang yang digunakan seperti itu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Baris ini terlalu pendek.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Panjang minimum adalah %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Membuat peta baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Pilih skala dan simbol yang ditetapkan untuk peta baru.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Skala: 1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Simbol set:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Hanya simbol Tampilkan set pencocokan skala dipilih</translation>
     </message>
@@ -4619,1351 +4633,1338 @@ zoom menggunakan roda mouse, jika tersedia.</translation>
         <translation type="vanished">Batal</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Membuat</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Simbol kosong set</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Memuat simbol set dari file...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Semua simbol set file</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Semua file</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Peta berisi lebih dari 256 warna yang tidak didukung oleh ocd versi 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad kembali %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Pendaftaran hitam diekspor sebagai warna yang biasa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Tidak dapat mengekspor pergeseran pola mengisi sebuah objek daerah</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Tidak dapat mengekspor template: file jenis &quot;%1&quot; tidak didukung namun</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Dalam baris simbol &quot;%1&quot;, tidak bisa mewakili topi bergabung-dengan kombinasi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Dalam baris simbol &quot;%1&quot;, mengabaikan pengelompokan dash.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Dalam baris simbol &quot;%1&quot;, jumlah berlari dalam kelompok telah berkurang menjadi 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Dalam baris simbol &quot;%1&quot;, tidak dapat mengekspor perbatasan dengan benar.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Di daerah simbol &quot;%1&quot;, melompat-lompat pola mengisi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Di daerah simbol &quot;%1&quot;, dengan asumsi &quot;bergeser baris&quot; titik pola. Ini mungkin benar serta salah.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Dalam teks simbol %1: spasi karakter kustom terletak, pelaksanaannya tidak sesuai perilaku OCAD yang belum</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Dalam teks simbol %1: mengabaikan menggarisbawahi</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Dalam teks simbol %1: mengabaikan highlight</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>String yang terpotong (pemotongan ditandai dengan tiga &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Tidak dapat mengalokasikan buffer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad kembali %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD file versi %1 tidak didukung!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n warna separation(s) telah dicetak, alasan: impor Cacat.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Tidak dapat memuat spot color untuk definisi, kesalahan: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Warna &quot;Pendaftaran hitam&quot; diimpor sebagai warna khusus.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Dapat mengimpor simbol &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD impor lapisan</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Di garis putus-putus simbol %1, menunjuk topi panjang untuk mulai dan akhir berbeda (%2 dan %3). Menggunakan %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Di garis putus-putus simbol %1, panjang akhir tidak dapat diimpor dengan benar.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Di garis putus-putus simbol %1, kesenjangan akhir tidak dapat diimpor dengan benar.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Pada garis putus-putus simbol %1, utama dan akhir panjang berbeda (%2 dan %3). Menggunakan %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Di garis putus-putus simbol %1, kesenjangan D dan E berbeda (%2 dan %3). Menggunakan %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Baris simbol %1: menekan simbol dash di ujung baris.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Selama impor teks simbol %1: mengabaikan perataan tengah</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Selama impor teks simbol %1: mengabaikan kustom berat (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Selama impor teks simbol %1: spasi karakter kustom terletak, pelaksanaannya tidak sesuai perilaku OCAD yang belum</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Selama impor teks simbol %1: mengabaikan spasi kustom kata (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Selama impor teks simbol %1: mengabaikan kustom indentasi (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Selama impor teks simbol %1: mengabaikan teks pembingkaian (mode %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Tidak dapat memuat objek</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Dapat mengimpor objek persegi panjang</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tidak mengimpor simbol teks, tidak tahu jalan &apos; (npts = %1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Dapat mengimpor template: latar belakang &quot;%1&quot; tidak ada gambar raster</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Mencoba untuk mengimpor sebuah obyek teks dengan format koordinat yang tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Id warna tidak ditemukan: %1, mengabaikan warna ini</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Cari</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Teks</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Dalam baris simbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Dalam teks simbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Tidak dapat memuat sistem koordinat referensi &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Informasi spot color untuk diabaikan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Dapat mengimpor simbol %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Tidak didukung jenis &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Dapat mengimpor template: &quot;%1&quot; bukanlah sejenis template didukung.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Gaya baris tidak didukung &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Panjang yang berbeda untuk menunjuk caps pada Mulailah (%1 mm) dan akhir (%2 mm) tidak didukung. Menggunakan %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Pola dash tidak dapat diimpor dengan benar.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Dash pola akhir panjang (%1 mm) tidak dapat diimpor dengan benar. Menggunakan %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Dash pola akhir kesenjangan (%1 mm) tidak dapat diimpor dengan benar. Menggunakan %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Gaya baris tidak didukung membingkai &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Simbol titik sekunder dilewati.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Menekan dash simbol pada baris berakhir.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Simbol ini tidak dapat disimpan sebagai simbol OCD tepat lagi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Kesejajaran dibenarkan tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Perataan vertikal &apos;%1&apos; tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Mengabaikan kustom berat (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Spasi karakter kustom mungkin salah.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Mengabaikan spasi kustom kata (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Mengabaikan kustom indentasi (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Mengabaikan teks pembingkaian (modus %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Baris teks simbol belum didukung. Menandai simbol sebagai tersembunyi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Pengodean &apos;%1&apos; tidak tersedia. Periksa pengaturan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>Di daerah simbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Tidak dapat memuat objek</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Dapat mengimpor objek persegi panjang</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tidak mengimpor simbol teks, tidak tahu jalan &apos; (npts = %1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Mencoba untuk mengimpor sebuah obyek teks dengan format koordinat yang tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Data tidak valid.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD file versi %1 tidak didukung!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation type="unfinished">Id warna tidak ditemukan: %1, mengabaikan warna ini</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation type="unfinished">Titik</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation type="unfinished">Garis</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation type="unfinished">Daerah</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation type="unfinished">Teks</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Peta orienteering</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Perangkat lunak untuk menggambar peta orienteering</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Pilih template untuk menarik ke</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Menggambar</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klik dan tarik&lt;/b&gt;: cat. &lt;b&gt;Klik kanan dan tarik&lt;/b&gt;: menghapus. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Pilihan warna</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan peta. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Tambahkan koordinat. &lt;b&gt;%1+klik&lt;/b&gt;: Mengubah koordinat dipilih. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Selalu berorientasi Utara (tidak rotatable)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elemen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Titik</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Pusat semua elemen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Elemen saat ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diameter &lt;b&gt;&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Inner warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Lebar luar &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Luar warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Lebar garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Warna garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Topi baris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>datar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>putaran</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>Square</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Bergabung baris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>mitra</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>siku-siku putar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Jalur ini ditutup</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Area warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Mulai kurva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Pusat oleh koordinat rata-rata</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Titik tengah]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>tidak diketahui</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Simbol titik</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Percetakan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Terjadi kesalahan selama proses.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan peta, area cetak atau di daerah perbatasan. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan area cetak. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan peta. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan area cetak perbatasan. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memindahkan area cetak perbatasan. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Template Tampilkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Tampilkan grid</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientasi halaman:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>cetakan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Potret</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Pemandangan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Format halaman:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Salinan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Kiri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Paling atas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Lebar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Tinggi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Tinjauan...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Satu halaman</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Wilayah kustom</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Peta wilayah:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Pusat area cetak</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Properti</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Halaman tumpang tindih:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Resolusi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Cetak dalam skala yang berbeda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Penampilan template mungkin berbeda.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Mensimulasikan overprinting</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Standar</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Perangkat CMYK (eksperimental)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Mode warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Ekspor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF Ekspor</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Ekspor gambar</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Menyimpan PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Tidak didukung pada Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Gagal untuk mempersiapkan pratinjau.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Print Preview kemajuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Lihat non-standar mode diaktifkan. Apakah Anda yakin untuk cetak / ekspor peta seperti ini?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Gagal untuk mempersiapkan PDF Ekspor.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Kesalahan terjadi selama proses percetakan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Peta ekspor...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Semua file (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Gagal untuk mempersiapkan pencetakan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Percetakan kemajuan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektor
 grafis</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Gambar
 bitmap</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Pemisahan
 warna</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Mode:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Gagal untuk mempersiapkan gambar. Memori tidak cukup.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Gagal untuk menyimpan gambar. Apakah ada jalan? Apakah Anda memiliki cukup hak?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Berhasil diekspor ke %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Gagal untuk menyelesaikan PDF Ekspor.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Dibatalkan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Pekerjaan cetak tidak bisa berhenti.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Berhasil menciptakan cetak pekerjaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Peta daerah ini kosong. Keluaran dibatalkan.</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Membuka kembali template</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Seret item dari daftar kiri ke tempat yang diinginkan dalam daftar yang tepat untuk kembali mereka.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Tertutup template:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Hapus daftar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktif template:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Peta -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Menggantikan simbol set</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Mengkonfigurasi bagaimana simbol harus diganti, dan yang.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Mengimpor semua simbol-simbol baru, bahkan jika tidak digunakan sebagai pengganti</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Menghapus simbol-simbol asli yang tidak terpakai setelah penggantian</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Hapus terpakai warna setelah penggantian</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Pemetaan simbol:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Menjaga simbol tersembunyi / dilindungi negara set simbol tua</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Cocok simbol penggantian dengan simbol angka</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Asli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Penggantian</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -5974,7 +5975,7 @@ warna</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5982,467 +5983,467 @@ warna</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>-Tidak ada-</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Pilih file peta untuk memuat simbol dari</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Tidak dapat memuat file peta, aborting.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Set pilihan simbol memiliki skala 1:%1, sementara skala peta adalah 1:%2. Apakah Anda benar-benar ingin memilih set ini?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Memutar peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Sudut (berlawanan arah jarum jam):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parameter rotasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Berputar di sekitar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Peta sistem koordinat asal</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Titik referensi Georeferencing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Titik lain,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Menyesuaikan titik referensi georeferencing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Menyesuaikan georeferencing deklinasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Memutar bebas rujukan geografis template</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Sudut:&lt;/b&gt; %1 ° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: tetap sudut. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: menetapkan arah daerah mengisi pola atau titik objek. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotasi:&lt;/b&gt; %1 ° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: tetap sudut. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Set pusat rotasi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: memutar objek yang dipilih. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Perubahan peta skala</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Scaling parameter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Skala baru: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>pusat skala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Peta sistem koordinat asal</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Titik referensi Georeferencing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Titik lain,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Ukuran skala simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skala peta objek posisi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Menyesuaikan titik referensi georeferencing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skala bebas rujukan geografis template</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skala:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengatur skala pusat. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: skala objek yang dipilih. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Pilih sistem koordinat rujukan</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Sama seperti peta</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Koordinat geografis (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>berlaku</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; disimpan dalam lokasi yang biasa.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; terletak di app penyimpanan. File yang akan dihapus ketika mencopot pemasangan apl.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; ini tidak bisa ditulisi. Perubahan tidak bisa diselamatkan.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; bukanlah lokasi penyimpanan yang berlaku.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>-tidak ada-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>-Tidak ada-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nomor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Mengedit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Keterangan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Simbol penolong (tidak ditampilkan dalam peta selesai)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Umum</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Untuk simbol dengan keterangan, Tekan F1 sementara tooltip terlihat untuk menunjukkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Simbol baru</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Titik</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Garis</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Daerah</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Teks</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Gabungan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Mengedit</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skala...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Salinan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Tempel</translation>
     </message>
@@ -6455,12 +6456,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Mengisi / membuat perbatasan untuk obyek dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Pilih simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Mengaktifkan drag dan drop</translation>
     </message>
@@ -6469,197 +6470,197 @@ Do you want to save your changes?</source>
         <translation type="vanished">Simbol skala</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Terjadi kesalahan internal, Maaf!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Ada tidak ada simbol di clipboard yang dapat disisipkan!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Pilih semua obyek dengan simbol ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Tambahkan semua obyek dengan simbol ini seleksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Hapus semua objek dengan simbol ini dari pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Menyembunyikan objek dengan simbol ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Melindungi objek dengan simbol ini</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Tambahkan semua obyek dengan simbol yang dipilih ke pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Hapus semua objek dengan simbol-simbol yang dipilih dari pilihan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Menyembunyikan objek dengan simbol yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Melindungi objek dengan simbol yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Balikkan seleksi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Pilih tidak terpakai</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>urutkan simbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Urut berdasarkan nomor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Urutkan warna primer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Urutkan warna primer prioritas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skala persentase:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Peta berisi objek dengan simbol &quot;%1&quot;. Menghapusnya akan menghapus objek tersebut dan menghapus Riwayat undo! Apakah Anda benar-benar ingin melakukan itu?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Pilih semua obyek dengan simbol yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Ganti simbol dari objek yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Mengisi / membuat perbatasan untuk objek yang dipilih</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Simbol-simbol skala</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Simbol pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Templat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Background:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(tidak ada)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Buka...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Pusat template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>membatasi kotak pada asal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Pusat gravitasi pada asal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Pilih warna latar belakang</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6667,58 +6668,58 @@ to jump over the lazy dog
         <translation>rubah Cokelat cepat  mengambil pilihan rute untuk melompati anjing malas 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- tidak disebutkan namanya -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Tidak ada Deskripsi!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished">kunci</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished">Nilai</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">Pindahkan ke bawah</translation>
     </message>
@@ -6731,210 +6732,210 @@ to jump over the lazy dog
         <translation type="obsolete">Tolong</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>kunci</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Nilai</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Tolong</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>eksis kunci</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Tombol &quot;%1&quot; sudah ada dan tidak boleh digunakan dua kali.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Menemukan file template pindah</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Semua file (*. *)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Tidak ada file tersebut.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Apakah format file yang benar untuk jenis template ini?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Penyesuaian template</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Gagal untuk menghitung penyesuaian!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengatur posisi titik lewat template. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: mengatur posisi peta titik lulus. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Hapus lulus poin. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Seret&lt;/b&gt;: bergerak melewati poin. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Melewati poin:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Baru</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Bergerak</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Template X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Template Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Peta X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Peta Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Menerapkan lulus poin</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Tolong</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Menerapkan &amp;&amp; Hapus semua</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Hapus semua</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Tidak cukup bebas memori (ukuran gambar: 1%x%2 piksel)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -6943,218 +6944,218 @@ Menyimpan file GIF tidak didukung. Ini berarti bahwa gambar di template ini tida
 Jika Anda tidak berniat untuk menggambar pada template ini namun, itulah tidak ada masalah.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Pilih sistem koordinat koordinat referensi dalam file dunia</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Buka %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Ukuran gambar:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Menentukan cara untuk posisi atau skala gambar:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Dunia file</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>tidak ada informasi georeferencing</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Rujukan geografis</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Meter per pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Scan dengan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Skala template: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Buka</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Tampilkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Keburaman</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Kelompok</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nama file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Sketsa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Terbuka...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Rujukan geografis: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Tambahkan template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Naik</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Pindahkan ke bawah</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Impor dan menghapus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Tolong</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Memindahkan dengan tangan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Buka gambar, melacak GPS atau DXF file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Posisi...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>File template</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Semua file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Menyesuaikan...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Harap masukkan sebuah angka integer berlaku untuk mengatur sebuah kelompok atau meninggalkan bidang kosong ke ungroup template!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Tidak terskala</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Skala dengan nominal peta skala rasio (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7163,216 +7164,216 @@ Jika Anda tidak berniat untuk menggambar pada template ini namun, itulah tidak a
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Format file yang tidak diakui.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Gagal untuk memuat template. Apakah ada file dan tidak berlaku?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Skala oleh saat ini template skala (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Template impor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Bagaimana akan simbol-simbol peta impor template diskalakan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Template akan terlihat dalam simulasi overprinting. Beralih ke tampilan normal?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Peta -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Drag&lt;/b&gt; untuk memindahkan template saat ini</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Posisi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Skala: 1:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-skala:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotasi:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Jarak skala dan posisi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Sistem koordinat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Nyata</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Peta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Satu unit koordinat sama dengan:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Melacak posisi di diberikan koordinat</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Melihat pusat posisi jalur</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Pilih sistem koordinat referensi koordinat jalur</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Pembukaan jalur ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Memuat jalur dalam mode georeferensi atau non-georeferensi?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Pengaturan Posisi jalur menurut peta georeferencing.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Ini tidak dikonfigurasi, sehingga mereka akan ditampilkan sebagai langkah berikutnya.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Rujukan geografis</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Bebas-rujukan geografis</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Proyek jalur yang menggunakan proyeksi orthographic dengan center di rata-rata koordinat trek. Memungkinkan penyesuaian transformasi dan menetapkan georeferencing peta menggunakan posisi disesuaikan trek.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Jalan kosong, tidak ada untuk mengimpor!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Pertanyaan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Harus waypoints diimpor sebagai garis akan melalui semua poin?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Masalah impor</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n jalan obyek tidak dapat diimpor (alasan: hilang koordinat).</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Kesalahan membaca</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7381,39 +7382,39 @@ Jika Anda tidak berniat untuk menggambar pada template ini namun, itulah tidak a
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 bukan file OSM.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM file memiliki versi %1.
 Didukung versi minimum adalah %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM file memiliki versi %1.
 Didukung versi maksimum adalah %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Masalah</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>node %1 tidak akan diproses dengan benar.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Link eksternal: %1</translation>
@@ -7424,353 +7425,353 @@ Didukung versi maksimum adalah %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>garis arah</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Kiri</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Pusat</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Kanan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Atas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Garis dasar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Bawah</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Pengaturan teks</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Jenis huruf:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Ukuran font:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Warna teks:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>tebal</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>miring</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>menggarisbawahi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Gaya teks:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Spasi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Penentuan spasi paragraf:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Spasi karakter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kerning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Simbol ikon teks:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Membingkai</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD kompatibilitas pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Membingkai warna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Membingkai baris</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Lebar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Bayangan membingkai</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Offset kiri/kanan:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Offset atas bawah:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD kompatibilitas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>diaktifkan</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Lebar garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Warna garis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Posisi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Baris di bawah paragraf</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Jarak dari dasar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Posisi tabulator kustom</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Tambahkan tabulator kustom</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Menghitung</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Tidak dapat membatalkan karena langkah undo terakhir menjadi tidak valid. Ini misalnya dapat terjadi jika Anda mengubah simbol objek lain dan kemudian menghapus simbol tua.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Membatalkan langkah ini akan melampaui titik dimana file yang dimuat. Kamu yakin?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Tidak bisa mengulang karena mengulang langkah pertama menjadi tidak valid. Ini misalnya dapat terjadi jika Anda menghapus simbol objek Anda telah ditarik.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Gagal untuk menemukan file bantuan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Gagal untuk menemukan bantuan browser (&quot;Qt asisten&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Gagal untuk memulai bantuan browser (&quot;Qt asisten&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Lihat lanjut...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Versi Mapper tidak mendukung beberapa peta bagian. Untuk menyimpan peta dalam modus kompatibilitas, Anda harus terlebih dahulu menggabungkan seluruh peta.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elemen tidak didukung: %1 (baris %2 kolom %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Koordinat beberapa berada di luar batas-batas untuk pencetakan. Peta konten yang disesuaikan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Bagian dari file ini tidak dapat dibaca oleh versi Mapper. Minimum versi yang diperlukan: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Kesalahan line %1 kolom %2: %3</translation>
     </message>
@@ -7779,44 +7780,44 @@ Didukung versi maksimum adalah %2.</translation>
         <translation type="vanished">Peta catatan tidak dapat dibaca.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Kesalahan tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Spesifikasi georeferencing tidak didukung atau tidak valid &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Bisa tidak mengatur properti babak warna &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Diharapkan %1 warna, ditemukan %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Melihat warna %1 tidak ditemukan saat pemrosesan %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Diharapkan %1 simbol, ditemukan %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Diharapkan %1 bagian peta, ditemukan %2.</translation>
     </message>

--- a/translations/OpenOrienteering_it.ts
+++ b/translations/OpenOrienteering_it.ts
@@ -2,249 +2,262 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="it_IT">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Informazioni %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Tutto su licenze, note di copyright, condizioni e liberatorie.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Gli sviluppatori di OpenOrienteering in ordine alfabetico:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(iniziatore del progetto)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Un software libero per il disegno delle mappe per orienteering</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Queasto programma è software libero: può essere redistribuito e/o modificato in accordo ai termini della &lt;a %1&gt;GNU General Public License (GPL), versione&amp;nbsp;3&lt;/a&gt;, come pubblicato dalla Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Questo programma è distribuito nella speranza che sia utile, ma SENZA NESSUNA GARANZIA; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Vedere la GNU General Public License (GPL), versione&amp;nbsp;3, per &lt;a %1&gt;ulteriori dettagli&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Per i contributori: grazie a:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Apre file usati di recente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Mostra il suggerimento del giorno</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Mostra gli elemneti rimanenti</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Dimensione minima:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Riempie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Riempimento con linee</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Riempimento con motivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Lina Singola</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Linee Parallele</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Spaziatura linee:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Riga singola</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Passo del mootivo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Offset del motivo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Offset della riga:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Righe parallele</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Spaziatura rgihe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Rotazione del riempimento</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>Regolabile per oggetto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Impostazioni area</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Riempimento con motivo %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Riempimento con linee %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Nessun riempimeno selezionato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Color dell&apos;area:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Offset di linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Colore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Spessore linea:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>File salvato automaticamente</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -252,249 +265,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>File salvato dall&apos;utente</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Recupero file</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Il file %1 non è stato chiuso correttamente. Al momento, ci sono due versioni:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Salva il file attivo ed elimina la versione in contrasto.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Modifica la mappa dei colori</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definisce un colore di calamaio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Miscela di colori di calamio (telai e sovrastampa):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Foratura: cancella i colori sottostanti</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Calcola colore a partire da un colore di calamio</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Calcola colore a partire da RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Colore di processo custom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan (Ciano)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Yellow (Giallo)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Black (Nero)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Calcola colore a partire da CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Colore RGB custom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Red (Rosso)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Green (Verde)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Blue (Blu)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Stampa professionale</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished">Attenzione</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- nessuno -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Opacità</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Colore di calamaio</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplica</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Muovi Su</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Muovi Giù</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Doppio click su un valore di colore per aprire la dialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>La mappa contiene simboli con questo colore. L&apos;eliminanazione rimuoverà il colore da quegli oggetti! Voui veramente eliminare?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Duplica)</translation>
     </message>
@@ -507,300 +520,300 @@
         <translation type="vanished">Inserire una percentuale da  0% a 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Doppio click per definire il colore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Cliccare per scegliere il nome e cliccare di nuovo per modificare.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Numero di parti (parts):</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Simbolo di linea privata -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Simbolo di area privata -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Modifica simbolo privato...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Impostazioni di combinazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Cambia da simbolo pubblico a privato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Prendi il vecchio simbolo come template per il simbolo privato?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Simbolo %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Configura la griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Mostra la griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Attrazione magnetica su griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Scegli...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Tutte le linee</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Linee orrizzontali</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Linee Verticali</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Allineamneto</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Allinea con nord magnetico</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Allinea la griglia con il nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Allinea la glriglia con il vero nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Rotazione addizionale (antioraria):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Posizionamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>Metri sul terreno</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>millimetri sulla mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Spaziatura orrizzontale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Spaziatura Verticale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Offset orizzontale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Offset verticale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Unità:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Colore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Schermo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Scegli il colore delle linee della griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origine in: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Origine delle coordinate sulla carta</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>Origina della proiezione delle coordinate</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Cliccare o trascinare&lt;/b&gt;: Iniziare a disegnare un buco. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Il taglio deve terminare sul bordo di un area!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Inizio e fine della linea di divisione (split), sono in differenti parti dell&apos;oggetto!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Inizio e fine della linea di divisione (split), sono nella stessa posizione!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt; su una linea: la divide in due. &lt;b&gt;Trascina&lt;/b&gt; lungo una linea: Rimuove questa linea . &lt;b&gt;Click o Trascina&lt;/b&gt;in un bordo di area Inizia una linea nuova linea (split). </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>La divisione di buchi nei simboli di tipo area non è ancora stata implementata!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ritaglia l&apos;intera mappa. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Clicca o trascina&lt;/b&gt;: Seleziona gli oggetti da ritagliare. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Cliccare per selezionare l&apos;oggetto. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Apertura file non riuscita.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>File NON in formato DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Determina la dimensione del font</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Lettera:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -814,261 +827,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Distribuisce i punti uniformemente lungo il cammino (path)</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Numero di punti per cammino (path):</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Piazza gli oggetti anche nelle estremità della linea</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Impostazioni rotazione</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Allinea i punti nella direzione della linea</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Angolo di rotazione aggiuntiva (antiorario):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Dal centro</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Inizia il disegno di un cerchio o di un ellisse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Disegna un cerchio. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Mantenere %1 per iniziare a disegnare dal centro.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Completa il cerchio. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Disegna un ellisse. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Disegna un percorso (path). </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Punti tratteggio attivi.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt;: Aggancia o accoda ad un oggetto esistente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt;: Prende (copia) la direzione da un oggetto esistente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt;: Si aggancia ad un oggetto esistente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angoli bloccati. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Annulla ultimo punto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Fine</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aggancio magnetico</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Angolo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Abortisci</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Lunghezza:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Inizia una linea dritta. &lt;b&gt;Trascina&lt;/b&gt;: Inizia una linea curva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Trascina&lt;/b&gt;: Segue oggetti esistenti. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Disegna una linea dritta. &lt;b&gt;Trascina&lt;/b&gt;: Disegna una linea curva. &lt;b&gt;Destro o doppio click&lt;/b&gt;: Termina il cammino. &lt;b&gt;%1&lt;/b&gt;: Chiude il tracciato. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Tocca la mappa per terminare il processo di media</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Termina le impostazioni dell&apos;oggetto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aggancia</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Angolo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Resetta</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Angolo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angoli fissati. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Crea un oggetto puntuale.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Crea un oggetto e definisci il suo orientamento.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Resetta la rotazione.</translation>
     </message>
@@ -1078,519 +1091,519 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Conclude</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aggancio magnetico</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Aggancio alla linea</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Abortisci</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Click o Trascina&lt;/b&gt;: Inizia a disegnare un rettangolo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Aggancio alla linea precedente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Imposta un punto d&apos;angolo. &lt;b&gt;Destro o doppio click&lt;/b&gt;: Conclude il rettangolo. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Aggancio magnetico</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Termina la modifica. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Annulla la modifica. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Crea un oggetto di testo con un singolo ancoraggio. &lt;b&gt;Trascina&lt;/b&gt;: Crea una casella di testo. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Aggancia a un oggetto esistente</translatorcomment>
         <translation>Aggancio</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Commuta a curva</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Movimento libero. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt; su un segmento: Commuta fra dritto e curvo. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Aggancia</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punto / Angolo</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Commuta tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Termina la modifica. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;:Mantieni le posizioni delle manigle opposte. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt; su un punto: Lo cancella; su un tracciato: Aggiunge un punto di tipo dash; con &lt;b&gt;%2&lt;/b&gt;: Aggiunge un punto normale. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt; su un punto lo cancella; su un tracciato aggiunge un punto;con &lt;b&gt;%2&lt;/b&gt;: Aggiunge un punto di tipo tratteggio. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt; su un punto per commutarlo fra normale e di tipo tratteggio. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Offset (spostamento) coordinate:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distanza:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angoli fissati. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Aggacio magnetico a oggetti esistenti. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Selsziona un singolo oggetto. &lt;b&gt;Trascina&lt;/b&gt;: Seleziona oggetti multipli. &lt;b&gt;%1+Click&lt;/b&gt;: Commuta selezione. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Cancella gli oggetti selezionati. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Disegno della mappa ad alta qualità (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>L&apos;antialiasing rende l&apos;aspetto della mappa molto migliore, ma rallenta la visualizzazione della stessa da parte del programma</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Rappresentazione del testo nella mappa ad alta qualità (antialiasing), lento</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolleranza del Click:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Distanza di aggancio magnetico (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Modalità di avanzamento ad angoli fissi (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Quando si seleziona un oggetto, automaticamente si selsziona anche il suo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Quando si zoomma all&apos;indietro, ci si allontana dal cursore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Strumento disegno: click destro per impostare l&apos;ultimo punto e terminare</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Template: mantiene le impostazioni dei template chiuso</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Strumento modifica:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Mantieni la vecchia forma</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Reimposta (reset) le maniglie esterne della curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Mantiene  le maniglie esterne della curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Azione legata alla cancellazione di un punto sulla curva con %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Strumento rettangolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Raggio della croce di aiuto (visualizzazione):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Anteprima della larghezza delle linee con la crocetta di aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Impossibile creare il nuovo file: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>L&apos;area della mappa è grande. L&apos;uso dello strumento riempimento può essere lento. Vuoi usalro ugualmente?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>L&apos;area cliccata non è limitata da linee o aree, impossibile riempire questa area.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>La posizione cliccata non è libera, impossibile usare lo strumento riempimento in quel punto.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Creazione dell&apos;oggetto riempimento fallito.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Riempie l&apos;area con il simbolo attivo. L&apos;area da riempire deve essere limitata da linee o aree, altri simboli non sono considerati. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>Il GPS è disabilitato nelle impostazioni del dispositivo. Apro le impostazioni adesso?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Sì</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>No</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished">Valore</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Apparenza</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Lingua:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Screen (Schermi)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixels (punti) per pollice:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Avvio programma</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Salvataggio file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Mantiene la comapatibilità con Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Salva le informazioni per il ripristino automatico</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervallo di salvataggio per il recupero delle informazioni:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Importazione ed esportazione file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>codifica a 8-bit:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Usa il nuovo importatore OCD anche per i file in versione 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation type="unfinished">Generale</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Il programma deve essere chiuso e riaperto affincé il cambio di linguaggio abbia effetto!</translation>
     </message>
@@ -1599,47 +1612,47 @@
         <translation type="vanished">Usa un file di traduzione...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Apri una traduzione</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>File di traduzione (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Il file selezionato non è una traduzione valida.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Risoluzione dello schermo primario in pixel (punti):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Dimensione (diagonale) dello schermo primario in pollici (1pollice=25.4mm):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>coordinate UTM</translation>
     </message>
@@ -1648,80 +1661,80 @@
         <translation type="vanished">Zona UTM (numero Nord/Sud, es. &quot;32 N&quot;, &quot;24.5 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Coordinate Gauss-Krueger</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Numero della Zona (da 1 a 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Specifica della scala della mappa mancante o invalida.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Linguaggio di specifica CRS sconosciuto: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Specifica geografica CRS non supportata: %1</translation>
     </message>
@@ -1730,7 +1743,7 @@
         <translation type="vanished">Scala soltanto</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Locale</translation>
     </message>
@@ -1740,73 +1753,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georefernziazione mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Cerca...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Declinazione:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Coordinate proiettate</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Stato:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Coordinate geografiche</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Mostra il punto di riferimento in:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>valido</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Ricerca della declinazione online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Sistema di riferimento delle coordinate della mappa</translation>
     </message>
@@ -1819,7 +1832,7 @@
         <translation type="vanished">- dalla specifica di Proj 4 -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- locale -</translation>
     </message>
@@ -1828,112 +1841,112 @@
         <translation type="vanished">Specificazione CRS:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Punto di riferimento</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Preleva sulla mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Nord della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation type="unfinished">Sistema di riferimento delle &amp;coordinate:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Coordinate della mappa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Coordinate geografiche:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Al cambio CRS, mantieni:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Declinazione Magnetica:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>La declinazione magnetica per il punto di riferimento %1° %2° verranno recuperati da &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Vuoi procedere?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Cambio di declinazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>La declinazione è cambiata. Vuoi anche ruotare il contenuto della mappa in corrispondenza del nuovo valore?</translation>
     </message>
@@ -1942,39 +1955,39 @@
         <translation type="vanished">Coordinate proiettate:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Coordinate locali:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Caricamneto...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>Bloccato</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Impossibile intepretare i dati.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Valore di declinazione non trovato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Il recupero della declinazione online è fallito:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translatorcomment>Valore in gradi</translatorcomment>
@@ -1982,110 +1995,110 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Click&lt;/b&gt;: Imposta il punto di riferimento. Un altro pulsante annulla.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Benvenuti in OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Attività</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Crea una nuova mappa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Apri mappa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Informazioni su %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Uscita</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Mappe recenti</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>All&apos;avvio apri il file modificato più recentemente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Cancella la lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Suggerimento del giorno</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Mostra il suggerimento del giorno</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Successivo</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Esempi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Informazioni su Mapper</translation>
     </message>
@@ -2094,30 +2107,30 @@
         <translation type="vanished">Informazioni su Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Lista dei file</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Nessuna mappa trovata!&lt;br/&gt;&lt;br/&gt;Copia i file mappa nella cartella di più alto livello chiamata &apos;OOMapper&apos; nel dispositivo o nella memory card.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Errore durante il caricamento di un simbolo di tipo %1 alla linea %2 colonna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Simbolo con ID &apos;%1&apos; non unico alla linea %2 colonna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2126,38 +2139,38 @@
         <translation type="vanished">Errore durante il caricamento del simbolo.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Errore durante il caricamento di un oggetto di tipo %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Errore durante il caricamento di un oggetto di tipo %1 a %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Impossibile trovare il simbolo per l&apos;oggetto a %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Oggetto di tipo punto con simbolo non definito o errato a %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versioni 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2166,48 +2179,48 @@
         <translation type="vanished">Impossibile interpretare i dati.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Impossibile interpretare le coordinate.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Attese %1 coordinate, trovate %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Trovato un oggetto privo di simbolo.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2215,206 +2228,206 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Errore durante il post-processo el simbolo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Il template &quot;%1&quot; è stato caricato dalla cartella della mappa invece della posizione relativa al file mappa dove si trovava precedentemente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Almeno uno dei file template non + stato trovato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Cliccare il(i) nome(i) del template in rosso nei Templates -&gt; Finestra impostazione templates per individuare i nome(i) del(i) file.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Versione del formato del file non valida.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Versione di file vecchia non supportata. Prego usare un versione di programma più vecchia per caricare ed aggiornare il file.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Versione di file nuova non supportata. Alcune caratteristiche della mappa non verranno caricate o salvate de questa versione di programma. Valutare di aggiornare il programma.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Il sistema di rigerimento delle coordinate geografiche (CoordinateReferenceSysytem) della mappa era &quot;%1&quot;. Questo CRS non è supportato. Verrà usato &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Errore durante il caricamento di un simbolo con tipo %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Errore durante il carcamento di un simbolo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Errore durante il caricamento dei passaggi di annulamento.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Errore durante la lettura del conteggio delle &quot;part&quot; della mappa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Errore durante il caricamento della &quot;part&quot; %2 della mappa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Impossibile leggere il file: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Formato file non supportato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Versione del formato del file non supportata (più recente). Alcune caratteristiche della mappa non verranno caricate e/o salvate da questa versione del programma.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Impostazione linee</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Larghezza linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Colore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Lunghezza minima della linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Terminale della linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>piatto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>tondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>quadrato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>appuntito</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Unisci linee:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>Spigolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>spizza</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Lunghezza del terminale:</translation>
     </message>
@@ -2424,334 +2437,335 @@
         <translation>La linea è tratteggiata</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Mostra almeno un simbolo intermedio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Numero minimo di simboli intermedi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimo numero di simboli intermedi quando è chiusa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Lunghezza tratteggio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Linea tratteggiata</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Lunghezza interruzzione:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Tratteggi ragruppati assieme:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>nessuno</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Lunghezza dell&apos;interruzzione all&apos;interno del gruppo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Mezza lunghezza del primo e dell&apos;ultimo tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Simboli intermedi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Numero di simboli intermedi per ogni spot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Distanza dei simboli intermedi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Bordi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Bordi differenti per il lato sinistro e destro</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Bordo sinistro:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Bordo destro:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Simbolo iniziale</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Simbolo intermedio</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Simbolo di termine</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Simbolo di tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Abilita le linee di bordo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Distanza fra gli spot:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Distanza dal termine della linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Sopprimi il simbolo di tratteggio agli estremi della linea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Larghezza bordo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Colore bordo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Spostamento (shift) del bordo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Il bordo è tratteggiato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Lunghezza del bordo del tratteggio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Lunghezza dell&apos;interruzione del bordo:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nuovo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Crea una nuova mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Apri...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Apre un file esistente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Apri un file &amp;recente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Salva</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>S&amp;alva come...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Impostazioni...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Chiudi questo file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Esci dall&apos;applicazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Apri &amp;Manuale</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Mostra il file d&apos;aiuto  per questa applicazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;A Informazioni %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Mostra informazioni su questa applicazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Informazioni su &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Mostra informazioni su Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;H Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Voui eleiminare la versione autosalvata?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Il file è stato modificato.
 Voui salvare le modifiche?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>File NON salvato</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2760,60 +2774,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Voui scalare i simboli nella scala selezionata?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Pericolo di Crash</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Sembra che %1 sia crashato l&apos;ultima volta che il file fu aperto:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Voui veramente tentare di riaprirlo?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Salvataggio autoamtico...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Salvataggio autoamtico fallito!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Tutte le mappe</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Tutti i files</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Apertura %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2824,19 +2838,19 @@ File format not recognized.</source>
 Formato del file non riconosciuto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Il file è stato mdificato.
 Vuoi abbandonare e scartare le tue modifiche?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2847,44 +2861,44 @@ Premi Sì per confermare il salvataggio in questo formato.
 Premi No per scegliere un differente formato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Salva file</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Il file non può essere salvato:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>C&apos;è stato un problema nel tentativo di riconoscimento del formato del file.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Per favore segnalate il problma.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2893,7 +2907,7 @@ because saving as %2 (.%3) is not supported.</source>
 perché il salvataggio come %2 (.%3) non è supportato.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2908,31 +2922,31 @@ causa formato sconosciuto.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>La mappa esportata ha generato warnings (attenzioni).</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Errore interno mentre veniva salvato:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>La mappa importata ha generato avvertimenti (Warnings).</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2941,12 +2955,12 @@ for reading.</source>
 in lettura.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Tipo di file non valido.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2957,24 +2971,24 @@ in lettura.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nulla da importare.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Domanda</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -2983,223 +2997,223 @@ Rescale the imported data?</source>
 Riscalatura dei dati importati?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nuovo colore</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished">Importa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Calibrazione del nero (tutti i colori stampati)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Annulla ultimo passo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Ripeti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Ripeti ultimo passo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Taglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Commuta schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Imposta fattore di zoom custom...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Finestra Simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Mostra/Nascondi la finestra dei simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Finestra Colori</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Mostra/Nascondi la finestra dei colori</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Rimpiazza i simboli con quelli di un altro file mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Scala tutti i simboli...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Scala tutto l&apos;insieme dei simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Cambia la scala della mappa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Cambia la scala della mappa e aggiusta le dimensioni degli oggetti e dei simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Note della mappa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Finestra impostazioni dei Templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Mostra/Nascondi la finestra dei Templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Apri Template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Mostra l&apos;intera mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Modifica oggetti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Imposta oggetti di tipo punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Disegna un tracciato</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Disegna cerchi ed ellissi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Scrivi testo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplica</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Cambia simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Riempie / Crea bordo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Cambia direzione tratteggio</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Collega tracciati</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Taglia oggetto</translation>
     </message>
@@ -3208,67 +3222,67 @@ Import the data anyway?</source>
         <translation type="vanished">Ruota oggetto(i)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Misura lunghezze e aree</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Ritaglia da una area</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Unisce i buchi di area</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Incolla sulle impostazioni dei template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Abilita il cursore di tipo touch (spostato)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Abilita il display GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Abilita gli anelli di distanza GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Imposta un oggetto di tipo punto nella posizione GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Imposta un marker temporaneo alla posizione GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Crea un percorso temporaneo nella posizione GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Azzera i marker GPS temporanei</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Abilita la visualizzazione della bussola</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Allinea la mappa con il Nord</translation>
     </message>
@@ -3277,189 +3291,189 @@ Import the data anyway?</source>
         <translation type="vanished">Commuta la visibilità dei Template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Aggiunge una nuova &quot;part&quot;...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Rinomina la &quot;part&quot; corrente...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Rimuove la &quot;part&quot; corrente</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Fonde tutte le &quot;parts&quot;</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Vista</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>S&amp;trumenti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Si&amp;mboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>M&amp;appa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Disegno</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Disegna sul Template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Modifica in corso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>La mappa è correntemente in modifica. Terminare la modifica prima di salvare.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Mappa salvata</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Mostra griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Configura la griglia...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Incidi aree</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Vista di base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Nascondi tutti i Template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Rimpiazza l&apos;insieme dei simboli...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georefernziazione...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Ruota la mappa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Ruota l&apos;intera mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Ri-Apri Template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Editor di tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Mostra/Nascondi la finestra di modifica dei tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Disegna rettangoli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Disegna a mano libera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Riempi aree delimitate</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Ritaglia liberando da un buco</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Ritaglia un buco tondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Ritaglia un buco rettangolare</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Ruota motivo</translation>
     </message>
@@ -3468,301 +3482,301 @@ Import the data anyway?</source>
         <translation type="vanished">Scala oggetto(i)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Unifica le aree</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Interseca aree</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Area XOR</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Ritaglio (tieni interno)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Ritaglia tenendo l&apos;esterno</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Distribuisci i punti lungo un percorso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Coordinate mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Coordinate proiettate</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Latitudine/longitudine (Decimale)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Latitudine/longitudine (DMS (gradi minuti secondi))</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Rappresenta le coordinate come...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Ritaglia un buco</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation type="unfinished">E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation type="unfinished">N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation type="unfinished">Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation type="unfinished">Inverti la selezione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Parts della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Selziona template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Modifica avanzata</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Selezioneare un simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Nascondi la barra top</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Mostra la barra top</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Stampa / Esportazione non disponibili in questa versione di programma!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Non ci sono operazioni da annullare.</translation>
     </message>
@@ -3772,8 +3786,8 @@ Import the data anyway?</source>
         <translation type="vanished">Tagliati %1 oggetti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Si è verificato un errore interno, siamo spiacenti!</translation>
     </message>
@@ -3782,7 +3796,7 @@ Import the data anyway?</source>
         <translation type="vanished">Copiati %1 oggetti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Non ci sono oggetti negli appunti che possano essere incollati!</translation>
     </message>
@@ -3791,72 +3805,72 @@ Import the data anyway?</source>
         <translation type="vanished">Incollati %1 oggetti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Imposta un fattore di zoom custom</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Fattore di zoom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Colori</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Scala tutti i smboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Scalatura a percentuale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Note della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Editor dei Tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3866,7 +3880,7 @@ simbol
 selez</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3876,41 +3890,41 @@ simbol
 multipli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Piazza oggetti di tipo punto sulla mappa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Per poter usare questo strumento selezionare un simbolo di tipo &quot;punto&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Disegna linee curve e poligonali.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Selezionare una linea, una area on simbolo combinato per poter usare questo attrezzo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Disegna cerchi ed ellissi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Disegna un percorso a mano libera.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Riemie aree delimitate.</translation>
     </message>
@@ -3919,109 +3933,109 @@ multipli</translation>
         <translation type="vanished">Cancella gli oggetti selezionati.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Imposta la direzionedei motivi di riempimento o degli oggetti di tipo punto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Selezionare un oggetto di tipo area avente motivo ruotabile oppure un punto ruotabile per attivare questo strumento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Simboli risultanti: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Per attivare questo strumento bisogna selezionare almeno due oggetti di tipo area o tracciato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Unifica gli oggetti che si sovrappongno.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Rimuovi tutte le parts che non si sovrappongono con il primo oggetto selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Rimuove le parti sovrapposte del primo oggetto selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Rimuove tutte le parti sovrepposte al primo oggetto selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Fonde i buchi di area assieme, oppure unisce i buchi con il contorno dell&apos;oggetto per ritagliare questa &quot;part&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Selezionare un oggetto di area con buchi per attivare questo strumento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Ricava un ritaglio foro da oggetti o dall&apos;intera mappa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Seleziona un percorso chiuso come forma del ritaglio per attivarequesto strumento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Taglia via alcuni oggetti o tutto in una are alimitata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Piazza oggetti punto lungo un oggetto tracciato con spaziatura uniforme</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Selezionare almeno un oggetto percorso ed uno di tipo punto singolo per attivare questo strumento.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Fusione dei fori fallita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Azzera i marcatori temporanei.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Sei sicuro di voler cancellare i marcatori GPS temporanei? Questa operazione non potrà essere annullata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Unisce questa &quot;part&quot; con</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Muove gli oggetti a</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Inserire il nome della part map:</translation>
     </message>
@@ -4030,93 +4044,93 @@ multipli</translation>
         <translation type="vanished">Vuoi rinuovere questa &quot;part&quot; di mappa %1 con tutti i suoi oggetti?  Questa operazione non potrà essere annullata.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Fondi assieme le parts della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Voui spostare tutti gli oggetti dalla &quot;part&quot; di mappa &quot;%1&quot; alla &quot;%2&quot;, e rimuovere &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Voui spostare tutti gli oggetti nella  &quot;part&quot; di mappa &quot;%1&quot;, e rimuovere tutte le altre &quot;parts&quot; di mappa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Impossibile importare la mappa selezionata perché il file non può essere caricato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Disegna rettangoli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Stampa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Immagine</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Azzera lle memorie di annulla / ripeti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Azzera lle memorie di annulla / ripeti per ridurre le dimensioni del file della mappa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Sposta/inquadra</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulazione di sovrastampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Modifica linee</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Converte in curve</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Semplifica il tracciato</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Esporta come...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Scrive testo sulla mappa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Per usare questo strumento selezionare un simbolo di tipo testo.</translation>
     </message>
@@ -4125,26 +4139,26 @@ multipli</translation>
         <translation type="vanished">Duplica l&apos;oggetto selezionato(i).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Per attivare questo strumento, selezionare almeno un oggetto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Cambia la direzione dei simboli di un oggetto linea.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Per attivare questo strumento, selezionare almeno una linea.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Connette le estremità di due tracciati che sono vicine.</translation>
     </message>
@@ -4153,17 +4167,17 @@ multipli</translation>
         <translation type="vanished">Taglia gli oggetti selezionati in pezzi più piccoli.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Per attivare questo strumento, selezionare almeno un oggetto di tipo area.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Ritaglia un buco nell&apos;oggetto selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Per attivare questo strumento, selezionare un singolo oggetto di tipo area.</translation>
     </message>
@@ -4176,18 +4190,18 @@ multipli</translation>
         <translation type="vanished">Scala gli oggetti selezionati.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Trasforma i trcciati composti da linee rette (spezzate) in percorsi arrotondati di tipo splines/bezier.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Per attivare questo strumento, selezionare un oggetto di tipo tracciato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Riduce il numero di punti di un tracciato cercando di mantenerne invariata la forma.</translation>
     </message>
@@ -4196,8 +4210,8 @@ multipli</translation>
         <translation type="vanished">Commuta i simboli degli oggetti selezionati nel nuovo simbolo selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Selezionare almeno un oggetto ed un simbolo diverso dal suo per attivare questo strumento.</translation>
     </message>
@@ -4210,7 +4224,7 @@ multipli</translation>
         <translation type="vanished">%1 oggetto(i) duplicato(i)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Selezione oggetto</translation>
     </message>
@@ -4219,82 +4233,82 @@ multipli</translation>
         <translation type="vanished">Non è stato selezionato nessun oggetto perché non ce ne sono contenenti il simbolo selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Misura</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Unificazione fallita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Intersezione fallita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Differenza fallita.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOr fallito.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Disegna a mano libera su nu template</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Disegna a mano libera su un template. Creare o caricare un tamplate su cui si possa disegnare per attivare questo pulsante</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importa %1, file GPX, OSM o DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>File importabili</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Tutti i files</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Impossibile importare il file selezionato perché il suo formato non è supportato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation type="unfinished">
@@ -4303,7 +4317,7 @@ multipli</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4311,7 +4325,7 @@ multipli</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4319,42 +4333,42 @@ multipli</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4362,178 +4376,178 @@ multipli</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Abortisci. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Altro: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Altro: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Altro: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation type="unfinished">- Mappa -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Processando le separazioni della pagina %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Processando la pagina %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Annullato</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Finito</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4548,7 +4562,7 @@ per aprire la dialog dei colori
 e procedi alla definizione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4563,7 +4577,7 @@ e seleziona &quot;Nuovo simbolo&quot;
 per crearne uno.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4576,7 +4590,7 @@ Per caricare una mappa di base, clicca
 Trmplates .&gt; Apri Template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Suggerimento: Tieni premuto il tasto centrale del mouse per trascinare la mappa,
@@ -4584,123 +4598,123 @@ se disponibile si può zoomare con la rotella del mouse.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Lunghezza contorno:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Area:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nessun oggetto elezionato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 oggetti selezionati.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>L&apos;oggetto selezionato non si trova su un tracciato.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Questo oggetto è troppo piccolo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>L&apos;area minima è %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Nota:La lunghezza del contorno e le arre sono corrette solo in assenza di auto intersezioni e i buchi sono usati come tali.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>La linea è troppo corta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>La lunghezza minima è %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation></translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Crea un nuova mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Scegli la scala e l&apos;insieme dei simboli per la nuova mappa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Scala:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Insieme simboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Solo insiemi simboli corrispondenti alla scala selezionata</translation>
     </message>
@@ -4709,140 +4723,140 @@ se disponibile si può zoomare con la rotella del mouse.</translation>
         <translation type="vanished">Annulla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Insieme simboli vuoto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Carica l&apos;insieme dei simboli da un file...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Tutti i file di simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Tutti i files</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>La mappa contiene più di 256 colori, quindi non è supportata da OCAD versione 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad ha restituito %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Il nero &quot;registration&quot; è esportato come un colore regolare.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Impossibile esportare lo &quot;shift&quot; di un motivo per un oggetto di tipo area</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Impossibile esportare il template: i file di tipo &quot;%1&quot; non sono ancora supportati</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Nel simbolo linea &quot;%1&quot;, impossibile rappresentare la cmbinazione di terminali e giunzioni.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Nel simbolo linea &quot;%1&quot;, viene ignorato il raggruppamento del tratteggio.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Nel simbolo linea &quot;%1&quot;, il numero di tratteggi per gruppo è stato ridotto a 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Nel simbolo linea &quot;%1&quot;, impossibile esportare i bordi correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Nel simbolo linea &quot;%1&quot;, motivo di riempimento saltato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Nel simbolo area &quot;%1&quot;, assumiamo un &quot;shifted rows&quot;come  montivo di tipo punto. Questo può essere sia corretto che non.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Nel simbolo testo %1: è impostata una spaziatura dei caratteri custom, questa implementazione non corrisponde ancora al comportamento di OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Nel simbolo di testo %1: viene ignorata la sottolineatura</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Nel simbolo testo %1: crenatura ignorata</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Stringa truncata (abbreviazione marcata con tre &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Impossibile allocare buffer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad ha restituito %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>I file OCAD versione %1 non sono supportati!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>Il separatore di colore %n è stato ignorato, motivo: Importazione disabilitata.</numerusform>
@@ -4850,334 +4864,334 @@ se disponibile si può zoomare con la rotella del mouse.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Impossibile importare la definizione del colore di calamaio, errore: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Il colore &quot;Calibrazione del nero&quot; è importato come colore speciale.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Impossibile importare il simbolo &quot;%3&quot; (%1,%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Strato di importazione OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Nel simbolo linea tratteggiata %1, le lunghezza dei terminali appuntiti di inizio e fine differiscono (%2 e %3). Viene usato %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Nel simbolo linea tratteggiata %1, la lunghezza dei terminali non può essere importata correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Nel simbolo linea tratteggiata %1, la lunghezza dell&apos;intervallo  terminale non può essere importata correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Nel simbolo linea tratteggiata %1, lunghezza principale e finale differenti (%2 e %3). Viene usato %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Nel simbolo linea tratteggiata %1, gli intervalli D ed E sono differenti (%2 e %3). Viene usato %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Simbolo linea %1: viene soppresso il simbolo di tratteggio all&apos;estremità.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: viene ignorato l&apos;allineamento giustificato</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: viene ignorato il peso custom (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: risulta attivato la spaziatura caratteri custom, la sua implementazione non corrisponde ancora al comportamento di OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: viene ignorato la spaziatura custom delle parole (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: viene ignorato l&apos;indentazione custom (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Durante l&apos;importazione del simbolo testo %1: viene ignorato l&apos;incorniciatura (modo %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Impossibile caricare l&apos;oggetto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Impossibile importare l&apos;oggetto rettangolo</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Importazione del simbolo testo non avvenuta, imposibile immaginare il percorso (npts=%1):%2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Impossibile importare il template: sfondo &quot;%1&quot; non sembra che sia una immagine raster</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Tentativo di importazone di un oggetto testo avente formato delle coordinate sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Id colore non trovato: %1, questo colore verrà ignorato</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Testo</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Nel simbolo %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Nei simboli testol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Le informazioni sul colore di calamaio sono state ignorate.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Impossibile importare i simboli %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Tipo non supprtato &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Impossibile importare il template/sfondo: &quot;%1&quot; non è un tipo supportato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Stile di linea non supportato &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Lunghezze differenti per i terminali appuntiti di inizio (%1 mm) e di fine (%2 mm) non sono supportate. Viene usato %3.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Lo schema di tratteggio non può essere importato correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>La lunghezza finale del motivo di tratteggio (%1 mm) non può essere importata correttamente. Verrà usato %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>La lunghezza finale della spaziatura di tratteggio (%1 mm) non può essere importata correttamente. Verrà usato %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Stile di incorniciatura linea non supportato &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Simbolo punto secondario Saltato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Soppressione dei simboli tratteggio alle estremità della linea.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Allineamento giustificato non supportato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>L&apos;allineamento verticale &apos;%1&apos; non è supportato.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Pesatura custom ignorata (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>La spaziatura custom dei caratteri potrebbe non essere corretta.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>La paziatura custom delle parole viene ignorata (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>L&apos;indentazione custom viene ignorata (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>L&apos;incorniciatura del testo viene ignorata (modo %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>I simboli &quot;line text&quot; non sono supportati. Il simbolo viene marcato come nascosto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Impossibile caricare l&apos;oggetto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Impossibile importare l&apos;oggetto rettangolo</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Simboli testo non importati, impossibile immaginare il percorso (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Tentativo di importare un oggetto testo con formato delle coordinate sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Dati non validi.</translation>
     </message>
@@ -5186,59 +5200,59 @@ se disponibile si può zoomare con la rotella del mouse.</translation>
         <translation type="vanished">Importatore per il formato OCD %1 non testato</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>I files OCD di versione %1 non sono supportati!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation type="unfinished">Id colore non trovato: %1, questo colore verrà ignorato</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation type="unfinished">Punto</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation type="unfinished">Linea</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation type="unfinished">Area</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation type="unfinished">Testo</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5246,652 +5260,639 @@ se disponibile si può zoomare con la rotella del mouse.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Selezionare il tempalte su cui disegnare</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Disegna</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Click e Trascina&lt;/b&gt;: Riempie(dipinge). &lt;b&gt;Click destro e Trascina&lt;/b&gt;: Elimina/Cancella. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Selezione colore</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove la mappa. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Aggiunge una coordinata. &lt;b&gt;%1+Click&lt;/b&gt;: Cambia la coordinata selezionata. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Sempre orientato a Nord (non ruotabile)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Area</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centra tutti gli elementi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Elemento corrente</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diametro &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Colore dell&apos;interno:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Spessore esterno &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Colore esterno:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Spessore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Colore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Cappello della linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>piatto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>arrotondato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>quadrato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>giunto della linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>Spigolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>spizza</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Linea chiusa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Colore Area:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Coordinate:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Inizio curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centra sulla media delle coordinate</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[punto medio]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Simbolo puntiforme</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished">Stampa in corso</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove la mappa, l&apos;area di stampa i bordi dell&apos;area. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muova l&apos;area di stampa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove la mappa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove il bordo dell&apos;area di stampa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove i bordi dell&apos;area di stampa. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Mostra i templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Mostra la griglia</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientamento della pagina:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Stampante:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Ritratto (Portrite)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Paesaggio (Landscape)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Formato pagina:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Copie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Sinistra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Alto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>LArghezza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Anteprima...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Pagina singola</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Area custom</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Area della mappa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centra l&apos;area di stampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Sovrapposizione di pagina:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Risoluzione:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Stampa in scala differente:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>L&apos;aspetto del template può differire.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simola la sovrastampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Esporta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Esporta PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Esporta immagine</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Salva su PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Non supportato su Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Progresso anteprima di stampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Una visualizzazione non standard è attiva. Sei sicuro di stampare / esportare la mappa in questo modo?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Esporta mappa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Tutti i files (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Progresso Stampa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Grafica
 vettoriale</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Grafica
 raster</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Separazione colori</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modalità:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Salvataggio dell&apos;immagine fallito. Esiste il percorso file? Possiedi diritti d&apos;accesso sufficienti?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Esportato con successo su %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Annullato.</translation>
     </message>
@@ -5900,176 +5901,176 @@ separations</source>
         <translation type="vanished">Stampa in corso</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Il lavoro di stampa non può essere interrotto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Lavoro di stampa creato con successo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>L&apos;area della mappa è vuota. Produzione annullata.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">Sistema di riferimento delle &amp;coordinate:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Ri-Apri template</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Trascinare gli elemeni dalla lista di sinistra nella zona (spot) desiderata della lista di destra per ricaricarli.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Templates chiusi:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Cancella lista</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Template attivi:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Mappa -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Rimpiazza l&apos;insieme dei simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Configura come e quali simboli vanno rimpiazzati.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importa tutti i simboli anche se non usati come rimpiazzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Cancella i simboli originali che restano inutilizzati dopo il rimpiazzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Cancella i colori che restano inutilizzati dopo il rimpiazzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Mappaggio (corrispondenza) dei simboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Mantiene lo stato di nascosto / protetto come nel veccio insieme di simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Corrispondi il rimpiazzo dei simboli usando il loro numero</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Originale</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Rimpiazzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6080,7 +6081,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6088,279 +6089,279 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Nessuno -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Scegli una mappa da cui caricare i simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Impossibile caricare il file della mappa, aborto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>L&apos;insiee dei simboli selezionato ha sacal 1:%1, mentre la scala della mappa è 1:%2. Vuoi veramente sceglier questo insieme simboli?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Ruota la mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Angolo (antiorario):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parameri della rotazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Ruota attorno a:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Origine del sistema di coordinate della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Punto di georeferenziazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Altro punto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Aggiusta il punto di riferimento della georefernziazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Aggiusta la declinazione della georeferenziazione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Ruota un template non georeferenziato</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Angolo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angoli fissati. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Imposta la direzione dei motivi di riempimento o degli oggetti di tipo punto. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotazione:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angoli fissati. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Imposta il centro di rotazione. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Ruota gli oggetti selezionati. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Cambia la scala della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Parametri di scalatura</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nuova scala:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Centro di scalatura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Origina del sistema di coordinate della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Punto di riferimento della georeferenziatura</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Altri punti,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Scala la dimensione dei simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Scala le posizioni degli oggetti nella mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Modifica il punto di riferimento della georeferenziatura</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Scala i template non georeferenziati</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Scalatura:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Imposta il centro della scalatura. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Scala gli oggetti selezionati. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Selziona il sistema di riferimento delle coordinate</translation>
     </message>
@@ -6369,17 +6370,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Lo stesso della mappa</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Locale</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Coordinate geografiche (WGS84)</translation>
     </message>
@@ -6400,175 +6401,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">Specificazione CRS:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Stato:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>valido</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- nulla -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Nulla -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Numero:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Descrizione:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Simbolo di aiuto (non visualizzato sulla mappa finita)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Per i simboli con descrizione, premere F1 mentre il tooltip è visibile per mostrarla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nuovo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linea</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Area</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Testo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Combinato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplica</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Scala...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
@@ -6581,12 +6582,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Riempi / Crea il bordo degli oggetti selezionati</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Seleziona simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,197 +6596,197 @@ Do you want to save your changes?</source>
         <translation type="vanished">Scala simbolo(i)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Errore interno, siamo spiacenti!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Non ci sono simboli nella clipboard da poter essere incollati!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Seleziona tutti gli oggetti con questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Aggiungi all selezione tutti gli oggetti con questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Rimuovi dalla selezione gli oggetti aventi questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Nascondi gli oggetti aventi questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Proteggi gli oggetti aventi questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Aggiungi alla selszioni tutti gli oggetti aventi questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Rimuovi dalla selszioni tutti gli oggetti aventi questo simbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Nascondi gli oggetti aventi il simbolo selezionato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Proteggi gli oggetti aventi il simbolo selezionato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Inverti la selezione</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Seleziona i non usati</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Ordina simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Ordina per numero</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Ordina per colore primario</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Ordina per colore primario e priorità</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Scalatura ad una percentuale:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>La mappa contiene oggetti con il simbolo &quot;%1&quot;. Cancellandolo verranno cancellati gli oggetti e la storia dei ripristini (ctrl-Z)! Veramente si vuole fare questo?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Seleziona tutti gli oggetti con il simbolo selezionato</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Impostazioni simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Template:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(nulla)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Apri...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centra il template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>Origie del rettangolo di contenimento</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>centro di gravità sull&apos;origine</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Seleziona il colore dello sfondo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6795,58 +6796,58 @@ to jump over the lazy dog
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Nessuna descrizione!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished">Tasto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished">Valore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">Muovi Su</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">Muovi Giù</translation>
     </message>
@@ -6855,7 +6856,7 @@ to jump over the lazy dog
         <translation type="obsolete">Aiuto</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6863,70 +6864,70 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Tasto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Il tasto esiste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Il tasto &quot;%1&quot; esiste già e non può essere usato due volte.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Trova il file template (spostato?)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Tutti i files (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>File non trovato.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Il formato del file per questo template risulta corretto?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6936,134 +6937,134 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Aggiustamento Template</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Calcolo aggiustamento template fallito!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Imposta il punto corrispondenza sul template/sfondo. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Imposta il punto corrispondenza sulla mappa. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Elimina punti di corrispondenza. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Trascina&lt;/b&gt;: Muove punti di corrispondenza. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Punto di corrispondenza:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Template X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Template Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Mappa X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Mappa Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Applica punto di corrispondenza</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Applica e cancella tutto</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Azzera e cancella tutto</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Memoria libera insufficiente (immagine da %1x%2 pixels)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7072,120 +7073,120 @@ Salvataggio in formato GIF non supportato. Questo vuole dire che i disegni su qu
 In ogni caso, se non intendi disegnare su questo template, non ci sono problemi.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Selezionare il sistema di riferimento delle coordinate nelle coordinate del file mondo</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Apertura %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Dimensione immagine:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Specifica come posizionare o scalare l&apos;immagine:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>File mondo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nessuna infomazione di georeferenziazione</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferenziato</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>metri per pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Scansionato con</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Scala template:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Opacità</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Gruppo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nome flie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Schizzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Apri...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georefernziato: %1</translation>
     </message>
@@ -7194,100 +7195,100 @@ In ogni caso, se non intendi disegnare su questo template, non ci sono problemi.
         <translation type="vanished">Elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplica</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Aggiungi template...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Muovi Su</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Muovi Giù</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importa ed elimina</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Muovi manualmente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Apri immagine, traccia GPS o file DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Posizionamento...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>File templates</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Tutti i files</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Aggiusta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Inserire un numero intero per impostare un gruppo oppure lasciare vuoto il campo togliere il template dal gruppo!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Non scalare</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Scala del rapporto nominale di scala della mappa (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7296,204 +7297,204 @@ In ogni caso, se non intendi disegnare su questo template, non ci sono problemi.
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Formato del file non riconosciuto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Caricamento del template fallito. Il file esiste ed è valido?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Scala con il valore della scala del template (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Importa template</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Come devono essere scalati i simboli della mappa template importata?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mappa -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Drag&lt;/b&gt; per muovere il template corrente</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Posizionamento</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Scala-X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Scala-Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotazione:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Scalatura e posizionamento della traccia</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Sistema di coordinate</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Reale</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Mappa</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Una unità di coordinata equivale:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Posiziona il tracciato a coordinate data</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Posiziona il tracciato al centro della vista</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Selezionare il sistema di riferimento delle coordinate delle coordinate delle tracce</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Apertura tracce ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Caricamento delle tracce in modalità georeferenziata o non georeferenziata?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Posiziona la traccia tenendo conto delle impostazioni di georefernziazione della mappa.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Queste non sono state ancora configurate, quindi verranno mostrate al prossimo passo.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georefernziata</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Non georefernziata</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Proietta le tracce usando una proiezione ortografica con il centro posizionato nel punto menido fra tutte le coordinate. Permette l&apos;aggiustamento della trasformazione ed l&apos;impstazione della georeferenziazione usando la posizione corretta della traccia.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>La mappa è vuota, non c&apos;è nulla da importare!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Domanda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>I waypoints debbono essere importati come linee che vanno attraverso tutti i punti?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problemi di importazione</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n oggetti percorso non possono essere importati (motivo: coordinate mancanti).</numerusform>
@@ -7501,12 +7502,12 @@ In ogni caso, se non intendi disegnare su questo template, non ci sono problemi.
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Errore durante la lettura</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7515,38 +7516,38 @@ In ogni caso, se non intendi disegnare su questo template, non ci sono problemi.
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1: Non si tratta di un file OSM.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Il file OSM ha versione %1.
 La versione minima supportata è %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Il file OSM ha versione %1.
 La versione massima supportata è %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemi</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 nodi non possono essere elaborati correttamente.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Link Esterno: %1</translation>
@@ -7557,58 +7558,58 @@ La versione massima supportata è %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Allineamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Sinistra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Destra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Linea base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Basso</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Impostazioni testo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Famiglia Font:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Dimensone Font:</translation>
     </message>
@@ -7617,339 +7618,339 @@ La versione massima supportata è %2.</translation>
         <translation type="vanished">Determina la grandezza...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Colore testo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>grassetto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>corsivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>sottolineato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Stile testo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Spaziatura linee:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Spaziatura Paragrafi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Spaziatura caratteri:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Crenatura</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Testo icona simboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Cornice (framing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Impostazioni di compatibilità OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Colore della cornice (framing):</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Linea della cornice (framing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Larghezza:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Ombra della cornice (framing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Spostamento sinistra/destra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Spostamento Alto/Basso:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Compatibilità OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>attivato</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Larghezza linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Colore linea:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Posizione:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linea sotto i paragrafi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Distanza dalla baseline:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Posizioni dei tabulatori custom</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Aggiungi tabulatore custom</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Impossibile annullare perché l&apos;ultima mossa è diventata invalida. Capita per esempio se si cambia il simbolo di un oggetto e poi viene cancellato il vecchio simbolo.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>L&apos;anullamento di questo passo andrebbe oltre il punto in cui fu caricato il file. Sei sicuro?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Impossibile ripetere perché la mossa è diventata invalida. Può capitare se cancelli un simbolo di un oggetto che hai disegnato.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Impossibile trovare i file di Aiuto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Impossibile trovare il browser dell&apos;aiuto (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Impossibile Lanciare il browser dell&apos;aiuto (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Le versioni vecchie di Mapper non supportano parts di mappa multiple. Per salvare la mappa in modalità compatibile, prima fondere assieme tutte le parts della mappa.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elemento non supportato: %1 (linea %2 colonna %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Parti di questo file non possono venir lette da questa versione di Mapper. Versione minima richiesta: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Specifica di georeferenziazione non supportata o invalida &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Impossibile impostare la proprietà di foratura del colore &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Attesi %1 colori, trovati %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Colore di calamaio %1 non trovato durante l&apos;elaborazione %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Attesi %1 simboli, trovati %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Attese %1 parts di mappa, trovate %2.</translation>
     </message>

--- a/translations/OpenOrienteering_ja.ts
+++ b/translations/OpenOrienteering_ja.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ja_JP">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>オリエンテーリング地図</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>オリエンテーリングの地図を描画するためのソフトウェア</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>%1 について</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>このプログラムはフリー ソフトウェアです: フリー ソフトウェア財団によって公開される &lt;a %1&gt;GNU 一般公衆利用許諾書 (GPL)、バージョン&amp;nbsp;3&lt;/a&gt; の条件の下で再配布および/または変更することができます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>このプログラムは有用であることを願って頒布されますが、全くの無保証です。商業可能性の保証や特定目的への適合性は、言外に示されたものも 含め、全く存在しません。&lt;a %1&gt;詳細は&lt;/a&gt;GNU 一般公衆利用許諾書 (GPL)、バージョン&amp;nbsp;3 をご覧くださ い。</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;ライセンス、著作権通知、条件、および免責事項に関するすべて。&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>アルファベット順の OpenOrienteering 開発者:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(プロジェクト開始)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>オリエンテーリング地図作成のための自由なソフトウェア</translation>
@@ -50,7 +63,7 @@
         <translation type="vanished">デベロッパ (アルファベット順):</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>コントリビュータ:</translation>
     </message>
@@ -68,370 +81,370 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>直前に使用したファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>今日のヒントを表示する</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>残りのアイテムを表示</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>最小のサイズ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>フィル</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>ラインフィル</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>パターンフィル</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>シングルライン</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>平行線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>平行線の間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>シングルロウ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>パターン間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>パターンのオフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>ロウのオフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>平行ロウ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>ロウ間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>フィルの回転</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>角度:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>オブジェクトごとに調節可能</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>境界で描画する要素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>境界のクリップ要素。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>中心が境界の内部にある場合は、要素を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>任意のポイントが境界内にある場合に、要素を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>すべてのポイントが境界内にある場合に、要素を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>エリアの設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>パターンフィル %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>ラインフィル %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>フィルが選択されていません</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>エリアの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>ラインのオフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>ラインの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>ラインの幅:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>自動保存したファイル</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n バイト</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>ユーザーによって保存されたファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>ファイルの復元</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>ファイル %1 は正しく閉じられませんでした。現時点では、2 つのバージョンがあります:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>作業中のファイルを保存して、競合するバージョンを削除します。</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>色の編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>スポットカラーの定義:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>スポットカラーの混合(スクリーンとオーバープリント):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>ノックアウト(抜き): 下の色を消去</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>スポットカラーから計算</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>RGBカラーから計算</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>カスタム・プロセスカラー:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>シアン</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>マゼンダ</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>イエロー</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>ブラック</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>CMYKカラーから計算</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>カスタム・RGBカラー:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>赤</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>緑</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>青</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>デスクトップ</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>プロフェッショナル印刷</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- 無名 -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- none -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>名前</translation>
     </message>
@@ -452,7 +465,7 @@
         <translation type="obsolete">K</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
@@ -469,79 +482,79 @@
         <translation type="obsolete">B</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>スポットカラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>ノックアウト(抜き).</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>色をダブルクリックするとダイアログが開きます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>地図にこの色の記号が含まれています。削除するとそれらのオブジェクトからも色が削除されます。本当に削除しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (複製)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (複製)</translation>
     </message>
@@ -554,13 +567,13 @@
         <translation type="vanished">0%から100%の値を入力してください!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>ダブルクリックで色を定義します</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>名前をクリックで選択。もう一度クリックで編集。</translation>
     </message>
@@ -574,238 +587,238 @@
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>要素の数(&amp;N):</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- プライベート・ライン記号-</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- プライベート・エリア記号-</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>プライベート記号の編集...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>組み合わせの設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>従来の記号からプライベート記号を作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>選択中の記号からプライベート記号を作成しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>記号 %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>グリッド設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>グリッドを表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>グリッドにスナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>選択...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>全ての線</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>横線</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>縦線</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>アラインメント</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>磁北線に合わせる</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>グリッド北に合わせる</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>真北に合わせる</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>追加回転 (反時計回り):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>位置調整</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>テレイン内での距離 (m)</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>地図上での長さ (mm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>水平間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>垂直間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>水平オフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>垂直オフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>測定単位:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>ラインの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>表示:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>グリッド線の色を選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>原点の位置: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>ペーパー座標の原点</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>投影座標の原点</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line to split it into two, &lt;b&gt;Drag&lt;/b&gt; along a line to remove this line part, &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary to start drawing a split line</source>
         <translation type="obsolete">ライン上を&lt;b&gt;クリック&lt;/b&gt;でラインを分割、&lt;b&gt;ドラッグ&lt;/b&gt;でラインの部分を消去、エリアの輪郭上を&lt;b&gt;クリックまたはドラッグ&lt;/b&gt;でエリアの分割ラインを開始します</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;または&lt;b&gt;ドラッグ&lt;/b&gt;: 穴の描画を開始します。 </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>分割ラインはエリアの輪郭上で終わらせてください!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>分割ラインの始点と終点がオブジェクトの異なる部分にあります。</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>分割ラインの始点と終点が同じ場所にあります。</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>ライン上を&lt;b&gt;クリック&lt;/b&gt;: ラインを分割。ライン上を&lt;b&gt;ドラッグ&lt;/b&gt;: ラインの一部を消去。エリアの輪郭を&lt;b&gt;クリックまたはドラッグ&lt;/b&gt;: エリアの分割を開始。 </translation>
     </message>
@@ -814,56 +827,56 @@
         <translation type="obsolete">ライン上を&lt;b&gt;クリック&lt;/b&gt;でラインを分割、&lt;b&gt;ドラッグ&lt;/b&gt;でラインの部分を消去、エリアの輪郭上を&lt;b&gt;クリックまたはドラッグ&lt;/b&gt;でエリアの分割ラインを開始します</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>エリアへの穴あけは、まだサポートされていません。</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 地図全体をクリップします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+クリックまたはドラッグ&lt;/b&gt;: クリップするオブジェクトを選択します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 選択中のオブジェクトをクリップします。 </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>ファイルを開くことができませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>ファイルがDXFファイルではありません。</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">フォントサイズの決定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>文字:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -877,52 +890,52 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>高さ:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>コースに沿って均等にポイントを配布する</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>コースあたりのポイント数:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>線の終りのポイントにもオブジェクトを配置する</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>回転設定</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>線の方向でポイントを配置する</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>追加の回転角度 (反時計回りに):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to start a circle or ellipse, &lt;b&gt;Drag&lt;/b&gt; to draw a circle</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;で円または楕円の描画開始、&lt;b&gt;ドラッグ&lt;/b&gt;で円を描画します</translation>
@@ -932,92 +945,92 @@
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;で円を描画、&lt;b&gt;ドラッグ&lt;/b&gt;で楕円を描画、&lt;b&gt;Escキー&lt;/b&gt;で中止します</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>中心から</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 円または楕円の描画を開始します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 円を描画します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>%1 を保持して中心から描画を開始します。</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 円の描画を終了します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 楕円を描画します。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: コースを描画します。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;ダッシュ点を入力します。&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+クリック&lt;/b&gt;: 既存のオブジェクトにスナップ(吸着)またはアペンドします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+クリック&lt;/b&gt;: 既存のオブジェクトから方向をピック。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: セグメントの方位角と長さ。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+クリック&lt;/b&gt;: 既存のオブジェクトにスナップ(吸着)します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 一定角度ずつ回転。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 直前のポイントを元に戻す。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation type="obsolete">&lt;b&gt;ダッシュ点を入力します。&lt;/b&gt; </translation>
@@ -1031,131 +1044,131 @@
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;で折れ線、&lt;b&gt;ドラッグ&lt;/b&gt;で曲線を描画、&lt;b&gt;右クリックまたはダブルクリック&lt;/b&gt;でpath を終了、&lt;b&gt;Return キー&lt;/b&gt;でpath を閉じる、&lt;b&gt;Backspace キー&lt;/b&gt;で元に戻す。&lt;b&gt;Esc キー&lt;/b&gt;で中止します。&lt;b&gt;Space キー&lt;/b&gt;でさらに他の機能</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>スナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>角度</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>情報</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>ダッシュ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;長さ:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 直線を開始。&lt;b&gt;ドラッグ&lt;/b&gt;: 曲線を開始。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+ドラッグ&lt;/b&gt;: 既存のオブジェクトをフォローします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 直線を描く。 &lt;b&gt;ドラッグ&lt;/b&gt;: 曲線を描く。 &lt;b&gt;右クリック/ダブルクリック&lt;/b&gt;: コースを終了。 &lt;b&gt;%1&lt;/b&gt;: コースを閉じる。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>地図をタッチすると平均化を終了します</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: オブジェクトの設定を終了します。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set a point object, &lt;b&gt;Drag&lt;/b&gt; to set its rotation if the symbol is rotatable</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でポイントオブジェクトを配置、&lt;b&gt;ドラッグ&lt;/b&gt;で回転可能なポイントオブジェクトを回転して配置します</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>スナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>角度</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>リセット</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;角度:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 一定角度ずつ回転。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: ポイントオブジェクトを作成します。</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: オブジェクトを作成して、方向を設定します。</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: 回転をリセットします。</translation>
     </message>
@@ -1165,7 +1178,7 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation type="obsolete">&lt;b&gt;ダッシュ点を入力します。&lt;/b&gt; </translation>
@@ -1183,78 +1196,78 @@
         <translation type="obsolete">&lt;b&gt;Space キー&lt;/b&gt;で、コーナー点とダッシュ点を切り替えます</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>スナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>線のスナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>ダッシュ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;クリックまたはドラッグ&lt;/b&gt;: 矩形の描画を開始します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 既存のラインにスナップ(吸着)します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: コーナー点を配置します。&lt;b&gt;右クリックまたはダブルクリック&lt;/b&gt;: 矩形の描画を終了します。 </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to write text with a single anchor, &lt;b&gt;Drag&lt;/b&gt; to create a text box</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でアンカーポイントを基準にテキストを入力、&lt;b&gt;ドラッグ&lt;/b&gt;でテキストボックスを作成します</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>既存のオブジェクトにスナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 編集を終了します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: 編集をキャンセルします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: シングルアンカーを基準にテキストオブジェクトを作成します。&lt;b&gt;ドラッグ&lt;/b&gt;: テキストボックスを作成します。 </translation>
     </message>
@@ -1264,7 +1277,7 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to select an object, &lt;b&gt;Drag&lt;/b&gt; for box selection, &lt;b&gt;Shift&lt;/b&gt; to toggle selection</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でオブジェクトを選択、&lt;b&gt;ドラッグ&lt;/b&gt;で矩形選択、&lt;b&gt;Shiftキー&lt;/b&gt;で選択を切り替え</translation>
@@ -1278,30 +1291,30 @@
         <translation type="obsolete">、&lt;u&gt;Ctrl キー&lt;/u&gt;でさらに他の機能</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>スナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>曲線を切り替え</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 自由に移動します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>セグメント上を&lt;b&gt;%1+クリック&lt;/b&gt; で、直線と曲線を切り替えます。 </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to select an object, &lt;b&gt;Drag&lt;/b&gt; for box selection, &lt;b&gt;Shift&lt;/b&gt; to toggle selection</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でオブジェクトを選択、&lt;b&gt;ドラッグ&lt;/b&gt;で矩形選択、&lt;b&gt;Shiftキー&lt;/b&gt;で選択を切り替え</translation>
@@ -1315,52 +1328,52 @@
         <translation type="obsolete">&lt;b&gt;Ctrl キー&lt;/b&gt;を押しながら、ポイントを&lt;b&gt;クリック&lt;/b&gt;で削除、path を&lt;b&gt;クリック&lt;/b&gt;で新しいポイントの追加、さらに&lt;b&gt;Space キー&lt;/b&gt;を押しながらpath を&lt;b&gt;クリック&lt;/b&gt;でダッシュ点を追加します</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>スナップ(吸着)</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>ポイント / 角度</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>ダッシュを切り替え</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 編集を終了します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 反対側の方向線(ハンドル)の位置を維持。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+クリック&lt;/b&gt; ポイント上: 削除; コース上: ダッシュポイントを追加; &lt;b&gt;%2&lt;/b&gt;と: 通常の点を追加。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+クリック&lt;/b&gt; ポイント上: 削除; コース上: ポイントを追加; &lt;b&gt;%2&lt;/b&gt;と: ダッシュ点を追加。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>ポイント上で&lt;b&gt;%1+クリック&lt;/b&gt;: ダッシュ点と通常の点を切り換え。 </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
         <source>&lt;b&gt;Coordinate offset [mm]:&lt;/b&gt; %1, %2  &lt;b&gt;Distance [m]:&lt;/b&gt; %3</source>
         <translation type="obsolete">&lt;b&gt;座標のオフセット [mm]:&lt;/b&gt; %1, %2  &lt;b&gt;距離 [m]:&lt;/b&gt; %3</translation>
@@ -1382,56 +1395,56 @@
         <translation type="obsolete">、&lt;u&gt;Ctrl キー&lt;/u&gt;でさらに他の機能</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;座標のオフセット:&lt;/b&gt; %1, %2 mm  &lt;b&gt;距離:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 一定の角度上で移動。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 既存のオブジェクトにスナップ(吸着)します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: オブジェクトを選択。 &lt;b&gt;ドラッグ&lt;/b&gt;: 複数のオブジェクトを選択。 &lt;b&gt;%1+クリック&lt;/b&gt;: 選択を切り替え。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 選択中のオブジェクトを削除します。 </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>高品質な地図表示 (アンチエイリアス処理)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>アンチエイリアス処理によって地図の外観が滑らかになりますが、表示速度が遅くなります</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>高品質なテキスト表示 (アンチエイリアス処理)、(表示速度が遅くなります)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>クリックの許容誤差:</translation>
     </message>
@@ -1440,310 +1453,310 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>スナップ（吸着）が有効になる既存オブジェクトからの距離 (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>一定角度ずつ回転時のステップ角(%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>記号アイコンサイズ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>オブジェクトを選択する際、同時に記号も選択する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>カーソルの位置でズームアウトする</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>描画ツール: 右クリックによる終了で最終点をセットする</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>テンプレート: 閉じたテンプレートの設定を維持する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>編集ツール:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>以前の形状を保つ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>方向線(ハンドル)をリセット</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>方向線(ハンドル)を維持</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>%1 でカーブ点を削除したときのふるまい:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>矩形ツール:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>十字の補助線の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>線の太さを十字の補助線でプレビューする</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>エディター</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>新規ファイルの作成に失敗しました: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>形式 (%1) はエクスポートをサポートしていません</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>地図エリアが大きいです。塗りつぶしツールの使用は非常に遅くなることがあります。それでも使用しますか?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>クリックしたエリアは、線またはエリアで閉じられていません、このエリアを塗りつぶしできません。</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>クリックした位置は空いていません。塗りつぶしツールを使用できません。</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>塗りつぶしオブジェクトを作成できませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: アクティブな記号でエリアを塗りつぶします。塗りつぶすエリアは、線またはエリアで閉じられている必要があります、他の記号は考慮しません。 </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>デバイスの設定で GPS は無効です。今すぐ設定を開きますか?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>GDAL/OGR でインポート:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>パラメーター</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>外観</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>言語:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>画面</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>インチあたりのピクセル数:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>起動時の表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>保存するファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Mapper %1 と互換性を維持する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>元に戻す/やり直しの履歴を保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>自動回復の情報を保存する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>回復情報の保存間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>分</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>ファイルのインポートとエクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8ビットエンコーディング:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>さらに表示...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>新しい OCD importer でもバージョン8のファイルを使用する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>通知</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>言語の変更を有効にするには、OpenOrienteering Mapper を再起動する必要があります。</translation>
     </message>
@@ -1752,58 +1765,58 @@
         <translation type="vanished">翻訳ファイルを使用...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>翻訳ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>翻訳ファイル(*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>選択されたファイルは有効な翻訳ファイルではありません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>プライマリ画面解像度 (ピクセル):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>プライマリ画面サイズ インチ (対角):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>全般</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>ローカル座標</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM座標</translation>
     </message>
@@ -1812,87 +1825,87 @@
         <translation type="vanished">UTMゾーン (数字 North/South 例: &quot;32 N&quot;、&quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM ゾーン (番号 北/南)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>ガウス・クリューゲル座標系</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>ガウス・クリューゲル座標</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>ゾーン番号 (1～119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>EPSG コードで</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ 座標</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG コード</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>カスタム PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>規程</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>地図縮尺規程が無効または見つかりません。</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>無効なグリッド尺度: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>不明な CRS 規程言語: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>地理 CRS 仕様はサポートされていません: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>ローカル</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>マップ ジオリファレンシング</translation>
     </message>
@@ -1901,8 +1914,8 @@
         <translation type="obsolete">�</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>調べる...</translation>
     </message>
@@ -1919,8 +1932,8 @@
         <translation type="obsolete">投影パラメータを編集...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
@@ -1933,7 +1946,7 @@
         <translation type="obsolete">地図の縮尺:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>磁気偏角:</translation>
     </message>
@@ -1942,13 +1955,13 @@
         <translation type="obsolete">基準点:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>投影座標</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>座標参照系 (&amp;C) :</translation>
     </message>
@@ -1957,7 +1970,7 @@
         <translation type="obsolete">&amp;Zone:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>状態:</translation>
     </message>
@@ -1978,7 +1991,7 @@
         <translation type="obsolete">グリッド偏差(&amp;G):</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>地理座標</translation>
     </message>
@@ -1995,7 +2008,7 @@
         <translation type="obsolete">基準点の経度:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>参照点を表示:</translation>
     </message>
@@ -2004,18 +2017,18 @@
         <translation type="obsolete">%1 %2 (mm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>オンラインで磁気偏角を調べる</translation>
     </message>
@@ -2024,7 +2037,7 @@
         <translation type="obsolete">基準点 %1� %2� の磁気偏角を &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt; から検索します。続行しますか？</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>地図の座標参照系</translation>
     </message>
@@ -2037,117 +2050,117 @@
         <translation type="vanished">- Proj.4 仕様から -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- local -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>グリッド尺度係数:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>参照点</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>地図から選択(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(データム: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>地図上の北の向き</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>地図上の座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>地理座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>座標参照系の変更時に維持する座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>グリッド偏差:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>参照点 &quot;%1&quot; &quot;%2&quot; の磁気偏角を &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt; から検索します。続行しますか？</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>赤緯の変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>赤緯が変更されました。地図コンテンツもしたがって回転しますか?</translation>
     </message>
@@ -2156,39 +2169,39 @@
         <translation type="vanished">投影座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>ローカル座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>読み込み...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>ロック済</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>データを解析できませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>磁気偏角の値が見つかりませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>オンラインで磁気偏角を調べることに失敗しました:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
@@ -2199,7 +2212,7 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Left click&lt;/b&gt; to set the reference point, another button to cancel</source>
         <translation type="obsolete">&lt;b&gt;左クリック&lt;/b&gt;で参照点をセット、右クリックでキャンセルします</translation>
@@ -2209,28 +2222,28 @@
         <translation type="vanished">&lt;b&gt;クリック&lt;/b&gt;: 参照点をセットします。他のボタンでキャンセルします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 参照点を設定します。&lt;b&gt;右クリック&lt;/b&gt;: キャンセルします。</translation>
     </message>
 </context>
 <context>
-    <name>Global</name>
+    <name>OpenOrienteering::Global</name>
     <message>
         <source>OpenOrienteering Mapper</source>
         <translation type="obsolete">OpenOrienteering Mapper</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>OpenOrienteering Mapper へようこそ！</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Clear list</source>
         <translation type="vanished">リストをクリア</translation>
@@ -2306,118 +2319,118 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>アクティビティ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>新しい地図を作成 ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>地図を開く ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>%1 について</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>最近開いた地図</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>直前に使用したファイルを起動時に開く</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>リストをクリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>今日のヒント</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>今日のヒントを表示する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>前へ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>次へ</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>例</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Mapper について</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>ファイルリスト</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>地図ファイルが見つかりません!&lt;br/&gt;&lt;br/&gt;デバイスやメモリカードの &apos;OOMapper&apos; という名前の最上位フォルダーに地図ファイルをコピーしてください。</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>%2 行目 %3 列目で、タイプ %1 の記号を読み込み中にエラー。</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>%2 行目 %3 列目で、記号 ID &apos;%1&apos; は一意ではありません。</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>%2 行目 %3 列目で、タイプ %1 の記号を読み込み中にエラー: %4</translation>
     </message>
@@ -2426,274 +2439,274 @@
         <translation type="vanished">記号を読み込む際にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>タイプ %1 のオブジェクトを読み込み中にエラー。</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>%2:%3 で、タイプ %1 のオブジェクトを読み込み中にエラー: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>%1:%2 で、オブジェクトの記号を見つけることができません。</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>%1:%2 で、定義されていないか間違った記号のポイントオブジェクト。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD バージョン 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>座標を解析できませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>%1 の座標が必要ですが、%2 が見つかりました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>%1:%2 で、印刷の設定を読み込み中にエラー: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>%1:%2 で、ステップを元に戻す/繰り返しを読み込み中にエラー: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>そのようなオプションはありません: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>空間ベクトル データ</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>記号のないオブジェクトが見つかりました。</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>不規則な %n のオブジェクトを削除します。</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>記号の後処理中にエラー。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>テンプレート&quot;%1&quot;は、以前あった地図ファイルへの相対的な位置ではなく、地図のディレクトリから読み込まれています。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>テンプレート &apos;%1&apos; の読み込みに失敗しました。理由: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>テンプレート &apos;%1&apos; の読み込み時に警告:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>テンプレート ファイルが少なくとも 1 つ見つかりませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>テンプレート -&gt; テンプレートウィンドウで、赤のテンプレート名をクリックして、テンプレートファイル名を設定します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>このファイルは、古いバージョンの形式を使用します。この形式のサポートは間もなくこのプログラムから削除されます。今後、ファイルを開くようにするには、再度保存してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>無効なバージョンのファイル形式です。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>サポートされていない古いファイル形式のバージョンです。ファイルの読み込みと更新には古いバージョンのプログラムを使用してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>サポートされていない新しいファイル形式のバージョンです。このバージョンのプログラムでは、いくつかの地図機能を読み込めないか、保存されません。更新をご検討ください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>この地図の地理座標参照系は &quot;%1&quot; です。この地理座標参照系はサポートされていません。&quot;%2&quot; を使用してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>%2 のタイプの記号を読み込む際にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>記号を読み込む際にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>アンドゥ履歴を読み込む際にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>地図の要素数を読み取り中にエラー。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>地図の要素 %2 を読み込み中にエラー。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>ファイルの読み込みに失敗しました: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>サポートされていないファイル形式です。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>サポートされていない新しいファイル形式のバージョンです。このバージョンのプログラムでは、いくつかの地図機能を読み込めないか、保存されません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>形式 (%1) はインポートをサポートしていません</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>&apos;%1&apos; を読み込みできません: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>ライン記号の設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>ラインの幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>ラインの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>最小のラインの長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>ラインのキャップ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>平ら(flat)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>丸型(round)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>突出線端(square)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>三角(pointed)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>角の形状:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>マイター結合(miter)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>ベベル結合(bevel)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>キャップの長さ:</translation>
     </message>
@@ -2703,178 +2716,178 @@
         <translation>ラインを破線にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>中間記号を一つ以上表示する</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>最小の中間記号数:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>ラインを閉じる場合の、最小の中間記号数:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>実線部分の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>破線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>空白部分の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>破線のグループ化:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>none</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>グループ内の空白部分の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>両端の実線部分の長さを半分にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>中間記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>中間記号のスポットごとの数:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>中間記号間の距離:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>輪郭線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>左右で異なる輪郭線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>左輪郭線:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>右輪郭線:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>線の開始と終了でダッシュ記号を抑制する</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>角にダッシュ記号のスケール</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>開始記号</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>中間記号</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>終了記号</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>ダッシュ記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>輪郭線を有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>スポットの間の距離:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>ラインの端からの距離:</translation>
     </message>
@@ -2883,86 +2896,86 @@
         <translation type="obsolete">輪郭線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>輪郭線の幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>輪郭線の色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>輪郭線のシフト距離:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>輪郭線を破線にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>輪郭線の実線部分の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>輪郭線の空白部分の長さ:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>新規(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>新しい地図を作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>開く(&amp;O)...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>既存のファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>最近開いたファイル(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>上書き保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>名前を付けて保存(&amp;A)...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>設定...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
@@ -2971,91 +2984,92 @@
         <translation type="obsolete">Ctrl+W</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>ファイルを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>終了(&amp;X)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>アプリケーションを終了</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>マニュアルを開く(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>このアプリケーションのヘルプファイルを表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>%1 について(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>このアプリケーションについての情報を表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>QT について(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Qtについての情報を表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>自動保存したバージョンを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>ファイルが変更されています。
 変更を保存しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>未保存のファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -3063,60 +3077,60 @@ Do you want to scale the symbols to the selected scale?</source>
 記号の縮尺を地図の縮尺に合わせますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>クラッシュ警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>最後にこのファイルを開いた時に %1 はクラッシュしたようです:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;もう一度開いてもよろしいですか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>自動保存中...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>自動保存に失敗しました!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>すべての地図ファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>すべてのファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>別のファイルを開く前に、現在のファイルを閉じる必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>%1 を開きます</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -3127,19 +3141,19 @@ File format not recognized.</source>
 ファイル形式を認識できません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>ファイルが変更されています。
 変更を破棄しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -3150,22 +3164,22 @@ Yesを押してこの形式で保存します。
 Noを押して形式を変更します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>ファイルを保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>ファイルを保存することができません:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>ファイル形式を決定するときに問題が発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>この問題をバグとして報告してください。</translation>
     </message>
@@ -3203,27 +3217,27 @@ Noを押して形式を変更します。</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
         <source>default layer</source>
         <translation type="obsolete">規定のレイヤー</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3232,7 +3246,7 @@ because saving as %2 (.%3) is not supported.</source>
 %2 (%3)はサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3247,25 +3261,25 @@ because the format is unknown.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>地図のエクスポート時に警告が発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>保存の際に内部エラーが発生しました:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3274,13 +3288,13 @@ because the format is unknown.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>地図のインポート時に警告が発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3289,12 +3303,12 @@ for reading.</source>
 を読み込むことができません。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>無効なファイル形式です。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3315,17 +3329,17 @@ Error during symbol post-processing.</source>
 記号のポストプロセッシング時にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>インポートするものがありません。</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>質問</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3334,23 +3348,23 @@ Rescale the imported data?</source>
 インポートされた地図の縮尺を変更しますか?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>デフォルトの要素</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>新しい色</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>インポート...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>記号の置換がキャンセルされました。
@@ -3358,176 +3372,176 @@ Import the data anyway?</source>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>レジストレーションブラック (すべて印刷色)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>座標は範囲外です。</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
         <source>One or more templates could not be loaded. Use the Templates -&gt; Template setup window to resolve the issue(s) by clicking on the red template file name(s).</source>
         <translation type="obsolete">一つ以上のテンプレートを読み込むことができませんでした。メニューバーの「テンプレート」から「テンプレートウィンドウ」を開いて、赤く表示されているテンプレートのファイル名をクリックし、問題を解決してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>印刷...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>画像(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>PDF(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>一つ前の操作を元に戻す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>やり直す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>一つ前の操作をやり直す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>切り取り(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>コピー(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>貼り付け(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>すべて選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>何も選択しない</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>選択を反転</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>元に戻す/やり直すの履歴をクリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>元に戻す/やり直すの履歴をクリアし、地図のファイルサイズを縮小します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>グリッドを表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>グリッド設定...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>画面移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>拡大</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>縮小</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>フルスクリーン</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>ズーム率を指定(x)...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>面のハッチ表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>ベースライン表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>すべてのテンプレートを非表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>オーバープリントをシミュレート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>記号ウィンドウ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>記号ウィンドウを表示/隠す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>色ウィンドウ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>色ウィンドウを表示/隠す</translation>
     </message>
@@ -3536,7 +3550,7 @@ Import the data anyway?</source>
         <translation type="obsolete">記号を読み込み...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>他の地図ファイルの記号と置換え</translation>
     </message>
@@ -3549,52 +3563,52 @@ Import the data anyway?</source>
         <translation type="obsolete">色を他の地図ファイルのものと置き換え</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>すべての記号のスケールを変更...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>記号セットすべての縮尺を変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>地図の縮尺の変更...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>地図の縮尺の変更と、オブジェクトサイズと記号サイズの調節</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>地図の回転...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>地図全体を回転します</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>ノート...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>テンプレートウィンドウ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>テンプレートウィンドウを表示/隠す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>テンプレートを開く...</translation>
     </message>
@@ -3603,102 +3617,102 @@ Import the data anyway?</source>
         <translation type="obsolete">投影パラメータの編集...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>地図全体を表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>記号セットを置換...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>テンプレートを開きなおす...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>タグ エディター</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>タグ エディター ウィンドウの表示/非表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>オブジェクトの編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>ラインの編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>ポイントオブジェクトを配置</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>コースを描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>円と楕円を描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>フリーハンドで描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>閉じたエリアの塗りつぶし</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>テキストを挿入</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>記号を置換</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>塗りつぶし/縁取り</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>記号の向きの反転</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>コースを接続</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>オブジェクトの切り取り</translation>
     </message>
@@ -3711,172 +3725,172 @@ Import the data anyway?</source>
         <translation type="vanished">オブジェクトの回転</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>長さと面積の測定</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>エリアから切り取り</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>エリアの穴をマージ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>曲線に変換</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>コースを単純化</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>切り抜き</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>コースに沿ってポイントを配布する</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>テンプレート設定に書き込み</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>タッチ カーソルを有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>GPS 表示を有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>GPS 距離リングを有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>GPS の位置でポイント オブジェクトを設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>GPS の位置で一時的なマーカーを設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>GPS の位置で一時的なコースを作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>一時的な GPS マーカーをクリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>コンパスの表示を有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>地図を北に合わせる</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>新しい要素を追加...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>現在の要素の名前を変更...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>現在の要素を削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>すべての要素をマージ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>インポート...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>位置をコピー</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>位置をクリップボードにコピーします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>編集(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>表示(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>ツール(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>記号(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>地図(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>編集の処理中</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>地図は現在編集中です。保存する前に編集操作を終了してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>テンプレート(&amp;T)</translation>
     </message>
@@ -3885,17 +3899,17 @@ Import the data anyway?</source>
         <translation type="obsolete">GPS(&amp;G)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>テンプレート上に書き込み</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>ジオリファレンシング...</translation>
     </message>
@@ -3904,27 +3918,27 @@ Import the data anyway?</source>
         <translation type="obsolete">円を描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>矩形を描画</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>自由な形で穴あけ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>円形で穴あけ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>矩形の穴あけ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>パターンの回転</translation>
     </message>
@@ -3933,12 +3947,12 @@ Import the data anyway?</source>
         <translation type="vanished">オブジェクトのスケール変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>エリアの論理和</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>エリアの論理積</translation>
     </message>
@@ -3947,7 +3961,7 @@ Import the data anyway?</source>
         <translation type="vanished">エリアの論理差</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>エリアの排他的論理和</translation>
     </message>
@@ -3956,37 +3970,37 @@ Import the data anyway?</source>
         <translation type="obsolete">インポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>マップ座標</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>投影座標</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>緯度/経度 (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>緯度/経度 (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>座標の表示方法...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>形式を指定してエクスポート(&amp;E)...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>穴あけ</translation>
     </message>
@@ -3995,22 +4009,22 @@ Import the data anyway?</source>
         <translation type="vanished">ダミー</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>テンプレートの選択...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>高度な編集</translation>
     </message>
@@ -4019,28 +4033,28 @@ Import the data anyway?</source>
         <translation type="obsolete">プリント/エクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>印刷 / エクスポートはこのバージョンのプログラムで利用できません!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>元に戻すことのできる操作がありません。</translation>
     </message>
@@ -4050,8 +4064,8 @@ Import the data anyway?</source>
         <translation type="vanished">%1 個のオブジェクトを切り取りました</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>内部エラーが発生しました。</translation>
     </message>
@@ -4060,7 +4074,7 @@ Import the data anyway?</source>
         <translation type="vanished">%1 個のオブジェクトをコピーしました</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>貼り付けのできるオブジェクトがクリップボードにありません。</translation>
     </message>
@@ -4069,67 +4083,67 @@ Import the data anyway?</source>
         <translation type="vanished">%1 個のオブジェクトを貼り付けました</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>ズーム率を指定</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>ズーム:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>色</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>記号セット ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>記号セット ID を編集:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>すべての記号のスケールを変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>パーセントでスケール変更:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>ノート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>テンプレート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>タグ エディター</translation>
     </message>
@@ -4138,7 +4152,7 @@ Import the data anyway?</source>
         <translation type="vanished">タグ セレクター</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4148,7 +4162,7 @@ selected</source>
 いません</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4158,41 +4172,41 @@ selected</source>
 選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>地図上にポイントオブジェクトを配置します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>このツールを有効にするには、ポイント記号を選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>折れ線と曲線を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>このツールを有効にするには、ライン記号/エリア記号/組み合わせ記号を選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>円と楕円を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>フリーハンドでコースを描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>閉じられたエリアを塗りつぶします。</translation>
     </message>
@@ -4201,114 +4215,114 @@ selected</source>
         <translation type="vanished">選択したオブジェクトを削除します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>エリアフィルパターンまたはポイントオブジェクトの方向をセットします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>このツールを有効にするには、回転可能なフィルパターンをもったエリアオブジェクト、または回転可能なポイントオブジェクトを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>結果の記号: %1 %2。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>少なくとも 2 つのエリアまたはコース オブジェクトを選択して、このツールを有効にします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>重なり合ったオブジェクトを結合します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>最初に選択したオブジェクトと重ならない要素をすべて削除します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>最初に選択したオブジェクトと重なった要素を削除します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>最初に選択したオブジェクトと重なった要素をすべて削除します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>エリアの穴を一緒にマージ、またはオブジェクトの境界と穴をマージして、この要素を切り取ります。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>穴のあるエリア オブジェクトを 1 つ選択して、このツールを有効にします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>穴のマージに失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>一時的なマーカーをクリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>一時的な GPS マーカーをすべて削除してもよろしいですか? これは元に戻すことができません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>この要素をマージ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>選択したオブジェクトを移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>地図の要素の名前を入力:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>地図の要素 &apos;%1&apos; に切り替えました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>地図の要素をマージ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>すべてのオブジェクトを地図の要素 &quot;%1&quot; から &quot;%2&quot; に移動して、&quot;%1&quot; を削除しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>すべてのオブジェクトを地図の要素 &quot;%1&quot; に移動して、他の地図の要素をすべて削除しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>%1、GPX、OSM、DXFファイルをインポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>選択された地図はインポートできません。このファイルを読み込むことができませんでした。</translation>
     </message>
@@ -4317,17 +4331,17 @@ selected</source>
         <translation type="obsolete">円を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>矩形を描画します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>地図上にテキストを挿入します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>このツールを有効にするには、テキスト記号を選択してください。</translation>
     </message>
@@ -4336,160 +4350,160 @@ selected</source>
         <translation type="vanished">選択中のオブジェクトを複製します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>このツールを有効にするには、一つ以上のオブジェクトを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>地図を保存しました</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>記号セット ID...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>記号セット ID を編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>CRT ファイルを読み込む...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>相互参照テーブルで、新しい記号を割り当てる</translation>
     </message>
@@ -4502,41 +4516,41 @@ selected</source>
         <translation type="vanished">タグ選択ウィンドウの表示/非表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>地図の要素</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>記号を選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>上部のバーを非表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>上部のバーを表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>ラインオブジェクト上の記号の向きを反転します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>このツールを有効にするには、一つ以上のラインオブジェクトを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>近接しているコースの終点を接続します。</translation>
     </message>
@@ -4545,17 +4559,17 @@ selected</source>
         <translation type="vanished">選択中のオブジェクトを分割します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>このツールを有効にするには、一つ以上のラインオブジェクトまたはエリアオブジェクトを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>選択中のエリアオブジェクトに穴をあけます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>このツールを有効にするには、エリアオブジェクトを一つ選択してください。</translation>
     </message>
@@ -4592,34 +4606,34 @@ selected</source>
         <translation type="vanished">重なったエリアを取り除きます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>直線のpathをスムーズなベジエ曲線に変えます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>このツールを有効にするには、コースオブジェクトを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>コースオブジェクト内のポイントを(コースの形が変わらない範囲で)減らします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>いくつかのオブジェクトまたは地図全体の切り抜きを作成します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>切り抜きの形状として閉じられたコース オブジェクトを選択して、このツールを有効にします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>限定したエリアのいくつかのオブジェクトまたはすべてを切り取ります。</translation>
     </message>
@@ -4628,8 +4642,8 @@ selected</source>
         <translation type="vanished">選択中のオブジェクトの記号を、選択中の記号に置き換えます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>このツールを有効にするには、一つ以上のオブジェクトと、それと置き換え可能な別の記号を選択してください。</translation>
     </message>
@@ -4638,12 +4652,12 @@ selected</source>
         <translation type="vanished">選択中のラインオブジェクトを塗りつぶし、または選択中のエリアオブジェクトを縁取りします。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>既存のコースオブジェクトに沿って、均等に間隔をあけてポイントオブジェクトを配置</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>少なくとも 1 つのコース オブジェクトと単一のポイント記号を選択して、このツールを有効にします。</translation>
     </message>
@@ -4652,7 +4666,7 @@ selected</source>
         <translation type="vanished">%1 個のオブジェクトが複製されました</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>オブジェクトの選択</translation>
     </message>
@@ -4661,42 +4675,42 @@ selected</source>
         <translation type="vanished">オブジェクトは選択されませんでした。選択中の記号を使用したオブジェクトがありません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>測定</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>エリアの論理和が失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>エリアの論理積が失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>エリアの論理差が失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>エリアの排他的論理和が失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>地図の要素「%1」と、そのすべてのオブジェクトを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>テンプレート上にフリーハンドで書き込みをします</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>テンプレート上にフリーハンドで書き込みをします。書き込み可能なテンプレートを読み込んで、このボタンを有効にしてください</translation>
     </message>
@@ -4705,12 +4719,12 @@ selected</source>
         <translation type="obsolete">DXFファイル、GBXファイルをインポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>インポート可能なファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>すべてのファイル</translation>
     </message>
@@ -4719,22 +4733,22 @@ selected</source>
         <translation type="obsolete">OMAP, OCD, GPX, OSM or DXF ファイルをインポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>ファイルをインポートできません。このファイル形式はサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>オブジェクトの回転</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>オブジェクトの拡大縮小</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4742,238 +4756,238 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>%n オブジェクトをコピーしました</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>%n オブジェクトを貼り付けました</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>選択したオブジェクトを削除します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>選択したオブジェクトを複製します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>選択したオブジェクトを回転します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>選択したオブジェクトを拡大縮小します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>選択したオブジェクトを小さな要素に切り取ります。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>選択したオブジェクトの記号を選択した記号に切り替えます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>選択した線の塗りつぶし、または選択した領域の枠線を作成します。</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>%n オブジェクトを複製しました</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>選択した記号を持つオブジェクトがないため、オブジェクトは選択されませんでした。</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 中止します。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>もっと表示: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>もっと表示: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>もっと表示: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>検索(&amp;F)...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>次を検索(&amp;n)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>オブジェクトを検索</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>次を検索(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>すべて検索(&amp;a)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>クエリ エディター</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- 地図 -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>ページ %1 のセパレーションを処理中...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>ページ %1 を処理中...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>キャンセルされました</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>終了しました</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>テキストソース:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>地図 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>未定義の言語</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>翻訳 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>編集する前に、格納されたテキストは現在の翻訳に置き換えられます。続行しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>格納されたテキストを変更した後、翻訳が見られなくなるかもしれません。続行しますか?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
         <source>Zoom: %1x</source>
         <translation type="obsolete">ズーム: %1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4987,7 +5001,7 @@ define the colors there.</source>
 色ダイアログを開き、色を定義してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -5001,7 +5015,7 @@ to create one.</source>
 記号を作成してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -5014,7 +5028,7 @@ Templates -&gt; Open template...</source>
 「テンプレートを開く...」を選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>ヒント: マウスのホイールドラッグで地図を移動できます。
@@ -5022,7 +5036,7 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
         <source>No objects selected.</source>
         <translation type="obsolete">オブジェクトが選択されていません。</translation>
@@ -5032,88 +5046,88 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">オブジェクトが選択されていません。&lt;br/&gt;測定する path を描画または選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>輪郭線の長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>長さ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>面積:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>オブジェクトが選択されていません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 オブジェクトが選択されています。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>選択中のオブジェクトがコースではありません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>オブジェクトが小さすぎます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>最小の面積は %1 %2 です。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>注意: エリアオブジェクトの輪郭線の長さと面積は、交差や穴あけがあると正しく測定されません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>ラインが短すぎます。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>最小の長さは %1 %2 です。</translation>
     </message>
@@ -5130,7 +5144,7 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">長さ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
@@ -5148,29 +5162,29 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>新しい地図を作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>新しい地図の縮尺と記号セットを選択してください。</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>縮尺:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>記号セット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>選択中の縮尺に一致する記号セットのみ表示する</translation>
     </message>
@@ -5179,237 +5193,237 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>空白の記号セット</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>ファイルから記号セットを読み込む...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>すべての記号セットファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>すべてのファイル</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>地図に256以上の色が含まれています。ocd バージョン 8 ではサポートされません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad が %1 を返しました</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>レジストレーションブラックは、標準色としてエクスポートされます。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>エリアオブジェクトの塗りつぶしパターンのシフトをエクスポートできません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>&quot;%1&quot; 形式のテンプレートのエクスポートは、まだサポートされていません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>座標は、OCAD 8 描画領域に収まるように調整されます (-2 m ... 2 m)。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>一部の座標が OCAD 8 描画領域外に残っています。 OCAD で到達できない可能性があります。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>線の記号「%1」で、キャップ/結合の組み合わせを表すことはできません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>線の記号「%1」で、ダッシュ グループを無視します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>線の記号「%1」で、グループの破線の数を 2 に減らしました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>線の記号「%1」で、境界線を正しくエクスポートできません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>エリア記号「%1」で、塗りつぶしパターンをスキップします。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>エリア記号「%1」に「シフト行」ポイントパターンを想定します。これは正しくない可能性もあります。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>テキスト記号 %1 で: カスタムの文字間隔を設定しました。その実装では OCAD の動作はまだ一致しません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>テキスト記号 %1 で: 下線を無視しています</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>テキスト記号 %1 で: カーニングを無視しています</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>文字列を切り捨てました (切り捨てマークは 3 つの &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>バッファーを割り当てできませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad が %1 を返しました</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD %1 のファイルはサポートされていません。</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n 色セパレーションをスキップしました。理由: インポートが無効です。</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>スポットカラーの定義を読み込むことができません。エラー: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>色「レジストレーションブラック」は、特別色としてインポートされます。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>記号 &quot;%3&quot; をインポートできません (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCADインポートレイヤー</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>破線のライン記号 %1 で、三角のキャップの長さが、始点と終点で異なっています (%2 と %3)。%4 を使用してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>破線のライン記号 %1 で、末端の長さを正しくインポートできません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>破線のライン記号 %1 で、末端のギャップを正しくインポートできません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>破線のライン記号 %1 で、本体と末端の長さが異なっています (%2 と %3)。%4 を使用してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>破線のライン記号 %1 で、キャップ D と E が異なっています (%2 と %3)。%4 を使用してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>線記号 %1: 線の終点のダッシュ記号を抑制します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>テキスト記号 %1 をインポートする際、テキストの均等割付を無視します</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>テキスト記号 %1 をインポートする際、文字の太さ (weight) を無視します (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>テキスト記号 %1 をインポートする際、カスタムの文字間隔が設定されていますが、この実装はまだ OCAD の動作と一致しません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>テキスト記号 %1 をインポートする際、カスタムの語間隔 (%2%) を無視します</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>テキスト記号 %1 をインポートする際、カスタムの字下げ (%2/%3) を無視します</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>テキスト記号 %1 をインポートする際、テキストフレーム (モード %2) を無視します</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>オブジェクトを読み込むことができません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>矩形オブジェクトを読み込むことができません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>テキスト記号をインポートしません。コースを把握できませんでした (npts=%1): %2</translation>
     </message>
@@ -5418,418 +5432,405 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">テンプレートをインポートすることができません: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>テンプレートをインポートできません: 背景「%1」はラスター画像ではないようです</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>不明な座標形式でテキスト オブジェクトをインポートしようとしています</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>色 ID が見つかりませんでした %1 。この色を無視します</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>＝</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>≠</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>含む</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>テキスト</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>かつ</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>または</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>記号</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>無効</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>線の記号 %1 &apos;%2&apos; で: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>テキスト記号 %1 &apos;%2&apos; で: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>座標参照系 &apos;%1&apos; を読み込みできませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>スポット カラー情報は無視されました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>記号 %1.%2 &quot;%3&quot; をインポートできません: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>サポートされていない種類 &quot;%1&quot;。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>テンプレートをインポートすることができません: &quot;%1&quot; はサポートされているテンプレートの種類ではありません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>サポートされていない線の修飾 &apos;%1&apos;。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>始点 (%1 mm) と終点 (%2 mm) で異なる長さの三角のキャップはサポートされていません。%3 mm を使用しています。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>破線パターンを正しくインポートできません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>破線パターンの終点の長さ (%1 mm) を正しくインポートできません。%2 mm を使用しています。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>破線パターンの終点のギャップ (%1 mm) を正しくインポートできません。%2 mm を使用しています。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>サポートされていないフレームの線の修飾 &apos;%1&apos; です。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>セカンダリ ポイント記号をスキップしました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>線の終点のダッシュ記号を抑制します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>この記号は、再度適切な OCD 記号として保存できません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>両端揃えはサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>縦方向の割り付け &apos;%1&apos; はサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>カスタム ウェイト (%1) を無視します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>カスタムの文字間隔が正しくない可能性があります。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>カスタムの単語間隔 (%1 %) を無視します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>カスタムの字下げ (%1/%2) を無視します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>テキスト フレーム (モード %1) を無視します。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>ラインテキスト記号はまだサポートされていません。非表示として記号をマークします。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>エンコード &apos;%1&apos; は使用できません。設定を確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>エリア記号 %1 &apos;%2&apos; で: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>オブジェクトを読み込むことができません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>矩形オブジェクトを読み込むことができません</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>テキスト記号をインポートしません。コースを把握できませんでした (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>不明な座標形式でテキスト オブジェクトをインポートしようとしています</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>無効なデータ。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>バージョン %1 の OCD ファイルはサポートされていません!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>色 ID が見つかりませんでした: %1。この色を無視します</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>GDAL の &quot;%1&quot; SRS をセットアップできません: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>紫</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>ポイント</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>線</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>エリア</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>テキスト</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>レイヤー %1 を読み込みできません。</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>%n オブジェクトを読み込みできません。 理由: %1</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>空のジオメトリ。</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>座標変換を決定できません: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>座標の変換に失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>不明なまたはサポートされていないジオメトリタイプ。</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>座標が不足しています。</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>この空間参照は使用できません:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>地理空間データに、適切な空間参照がありません。</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>オリエンテーリング地図</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>オリエンテーリングの地図を描画するためのソフトウェア</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>書き込むテンプレートを選択</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>書き込む</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
         <source>&lt;b&gt;Left mouse click and drag&lt;/b&gt; to paint, &lt;b&gt;Right mouse click and drag&lt;/b&gt; to erase</source>
         <translation type="obsolete">&lt;b&gt;左クリックしながらドラッグ&lt;/b&gt;で書き込み、&lt;b&gt;右クリックしながらドラッグ&lt;/b&gt;で消去します</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;左クリックしながらドラッグ&lt;/b&gt;: ペイントします。&lt;b&gt;右クリックしながらドラッグ&lt;/b&gt;: 消去します。 </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>色を選択</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 地図を移動します。 </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to add a coordinate, &lt;b&gt;Ctrl+Click&lt;/b&gt; to change the selected coordinate</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;で座標を追加、&lt;b&gt;Ctrl キーを押しながらクリック&lt;/b&gt;で、選択中の座標を変更します</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 座標を追加します。&lt;b&gt;%1 + クリック&lt;/b&gt;: 選択中の座標を変更します。 </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
         <source>Point editor</source>
         <translation type="obsolete">ポイントエディタ</translation>
@@ -5843,164 +5844,164 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">要素:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>常に北に向けて正置 (回転禁止)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>要素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>ポイント</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>ライン</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>エリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>すべての要素を中央寄せ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>現在の要素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>直径 &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>インナーの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>アウター &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>アウターの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>ラインの幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>ラインの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>ラインのキャップ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>平ら</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>ラウンド結合</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>突出線端</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>角の形状:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>マイター結合</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>ベベル結合</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>ラインを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>エリアの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>座標:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>曲線を開始</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>座標平均に中心を置く</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[中間点]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
         <source>Point settings</source>
         <translation type="obsolete">ポイント記号の設定</translation>
@@ -6010,63 +6011,63 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">常に北に向けて正置 (回転禁止)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>ポイント記号</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>印刷中</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>処理中にエラーが発生しました。</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the print area</source>
         <translation type="obsolete">&lt;b&gt;ドラッグ&lt;/b&gt;で印刷領域を移動します</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 地図、プリントエリア、エリアの縁を移動します。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: プリントエリアを移動します。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 地図を移動します。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: プリントエリアの縁を移動します。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: プリントエリアの縁を移動します。 </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Printer or exporter:</source>
         <translation type="obsolete">プリンタまたはエクスポータの選択:</translation>
@@ -6080,37 +6081,37 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">イメージをエクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>テンプレートを表示する</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>グリッドを表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>ページの方向:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>プリンター:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>縦</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>横</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>印刷のサイズ:</translation>
     </message>
@@ -6119,7 +6120,7 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">ドット/インチ(dpi):</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>印刷部数:</translation>
     </message>
@@ -6128,22 +6129,22 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">印刷領域</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>左:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>上:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>高さ:</translation>
     </message>
@@ -6152,7 +6153,7 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">地図の中心領域を印刷</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>プレビュー...</translation>
     </message>
@@ -6161,43 +6162,43 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">エクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>単一ページ</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>カスタムエリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>マップエリア:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>地図の中心を印刷</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>ページのオーバーラップ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
@@ -6210,248 +6211,248 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">色分解</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>解像度:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>縮尺を変更して印刷:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>テンプレートの外観が異なる場合があります。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>オーバープリントをシミュレートする</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>デバイス CMYK (実験的)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>カラーモード:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>印刷</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>エクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDFをエクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>イメージをエクスポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>PDFに保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Android ではサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>プレビューの準備に失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>印刷プレビューの進行状況</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>非標準の表示モードが有効です。地図をこのように印刷 / エクスポートしてもよろしいですか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>PDF エクスポートの準備に失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>印刷中にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>地図のエクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>すべてのファイル (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>印刷の準備に失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>印刷の進行状況</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>プロパティ</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>ベクター
 グラフィック</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>ラスター
 グラフィック</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>色
 分版</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>モード:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>画像の準備に失敗しました。メモリが不足しています。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>画像の保存に失敗しました。コースは存在しますか?　十分な権利はもっていますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>%1 へのエクスポートは成功しました</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>PDF エクスポートを完了できませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>キャンセルされました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>プリントジョブを停止できません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>プリントジョブの作成は成功しました</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>マップエリアが空白です。出力はキャンセルされました。</translation>
     </message>
@@ -6505,153 +6506,153 @@ separations</source>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">座標参照系 (&amp;C) :</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>テンプレートを開きなおす</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>アイテムを左のリストから右のリストの任意の場所にドラッグで再ロードします。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>閉じたテンプレート:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>リストをクリア</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>アクティブなテンプレート:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- 地図 -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>記号セットを置き換え</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>記号の置き換え方法を構成します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>置き換えとして使用しない場合でも、すべての新しい記号をインポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>置き換え後、使用されない元の記号を削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>置き換え後、未使用の色を削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>記号マッピング:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>記号の非表示 / 古い記号セットの保護された状態を保持</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>記号番号で一致する記号を置き換え</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>元</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>記号セット ID を編集:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>置き換え</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>記号名で一致</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>新しい記号を割り当て</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>パターン</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>置き換えをクリア</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>CRT ファイルを開く...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>CRT ファイルを保存...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>記号マッピング</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT ファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>記号 %1 に複数の置換があります。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6662,7 +6663,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6673,153 +6674,153 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>相互参照テーブルは変更されています。
 変更内容を保存しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- None -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>記号をロードする地図を選択してください</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>地図ファイルをロードできません、中断します。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>選択した記号セットの縮尺は 1:%1 ですが、地図の縮尺は 1:%2 です。このセットを選択しますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>CRT ファイルを読み込みできません。中止します。</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>地図を回転</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>角度 (反時計回り):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>回転パラメータ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>回転の軸:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>地図座標系の原点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>ジオリファレンスの参照点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>その他の座標、</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>ジオリファレンスの参照点を調節</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>ジオリファレンスの磁気偏角を調節</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>ジオリファレンスされていないテンプレートを回転</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;角度:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 一定角度ずつ回転。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: エリアフィルパターンまたはポイントオブジェクトの方向をセットします。 </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1</source>
         <translation type="obsolete">&lt;b&gt;回転:&lt;/b&gt; %1</translation>
@@ -6833,106 +6834,106 @@ Do you want to save your changes?</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;で回転の軸をセット、&lt;b&gt;ドラッグ&lt;/b&gt;で選択中のオブジェクトを回転します</translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;回転:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: 一定角度ずつ回転。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: 回転の軸をセットします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 選択中のオブジェクトを回転します。 </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>地図の縮尺の変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>縮尺変更のパラメータ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>新しい縮尺: 1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>縮尺変更の中心:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>地図座標系の原点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>ジオリファレンスの参照点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>その他の座標、</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>記号サイズの縮尺の変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>オブジェクトの位置を縮尺に合わせて変更</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>ジオリファレンスの参照点を調節</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>ジオリファレンスされていないテンプレートを縮尺変更</translation>
     </message>
@@ -6946,19 +6947,19 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;拡大・縮小率:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: スケール変更の中心点をセットします。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: 選択中のオブジェクトのスケールを変更します。 </translation>
     </message>
@@ -6972,24 +6973,24 @@ Do you want to save your changes?</source>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>座標参照系を選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>地図と同じ</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>ローカル</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>地理座標 (WGS84)</translation>
     </message>
@@ -6998,175 +6999,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">(local)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>ステータス:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>有効</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; は、通常の場所に格納されます。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; は、アプリ ストレージにあります。アプリをアンインストールするときにファイルは削除されます。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; は書き込み可能ではありません。変更を保存できません。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; は有効な格納場所ではありません。</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- none -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- None -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>番号:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>名前:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>説明:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>補助記号 (完成地図には非表示)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>説明</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>説明つきの記号では、ツールチップが表示されている間にF1キーを押すと説明を表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>新しい記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>ポイント記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>ライン記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>エリア記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>テキスト記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>組み合わせ記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>縮尺...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
@@ -7179,12 +7180,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">塗りつぶし/選択中のオブジェクトの輪郭線を作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>選択中の記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>ドラッグ＆ドロップを有効にする</translation>
     </message>
@@ -7197,108 +7198,108 @@ Do you want to save your changes?</source>
         <translation type="obsolete">未使用</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>内部エラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>貼り付けのできる記号がクリップボードにありません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>この記号のオブジェクトをすべて選択する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>この記号のオブジェクトをすべて選択に追加する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>選択範囲から、この記号のすべてのオブジェクトを削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>この記号のオブジェクトを隠す</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>この記号のオブジェクトを保護</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>選択中の記号のオブジェクトをすべて選択に追加する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>選択範囲から、選択された記号のすべてのオブジェクトを削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>選択中のオブジェクトを隠す</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>選択中のオブジェクトを保護する</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>すべてを選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>未使用の記号を選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>選択を反転</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>記号を並び替え</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>番号で並べ替え</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>色で並べ替え</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>色の優先度で並べ替え</translation>
     </message>
@@ -7307,7 +7308,7 @@ Do you want to save your changes?</source>
         <translation type="obsolete">記号のスケール %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>パーセントでスケール変更:</translation>
     </message>
@@ -7316,12 +7317,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">縮尺記号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>地図にこの記号 &quot;%1&quot; を使用したオブジェクトが含まれています。削除するとそれらのオブジェクトも削除され、また、アンドゥ履歴も消去されて元に戻すことができなくなります。本当に削除しますか?</translation>
     </message>
@@ -7330,29 +7331,29 @@ Do you want to save your changes?</source>
         <translation type="obsolete">&quot;%1&quot;の記号のオブジェクトを選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>選択中の記号のオブジェクトを選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>選択したオブジェクトの記号を切り替える</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>選択したオブジェクトの塗りつぶし / 枠線を作成</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>縮尺記号</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
         <source>General</source>
         <translation type="obsolete">一般</translation>
@@ -7382,52 +7383,52 @@ Do you want to save your changes?</source>
         <translation type="obsolete">OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>記号設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>テンプレート:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;テンプレート:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(none)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>開く...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>テンプレートの中心...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>元の閉じたボックス</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>原点の重心</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>背景色の選択</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -7439,7 +7440,7 @@ to jump over the lazy dog
 △Aaあぁアァ亜字◎</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- 無名 -</translation>
     </message>
@@ -7453,52 +7454,52 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>説明なし</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>関係</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>キー</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>比較</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>行を追加</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>行を削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
@@ -7511,21 +7512,21 @@ to jump over the lazy dog
         <translation type="vanished">ヘルプ</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n オブジェクト選択済</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>無効なクエリ</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Add</source>
         <translation type="vanished">追加</translation>
@@ -7544,63 +7545,63 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>キー</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>キーが存在</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>キー &quot;%1&quot; は既に存在します。二度は使用しないでください。</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>移動されたテンプレートを探す</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>すべてのファイル (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>そのようなファイルはありません。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>ファイルの形式は、このテンプレートの種類として正しいですか?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>メモリが足りません。</translation>
     </message>
@@ -7610,25 +7611,25 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>テンプレートの調節</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>調節の計算に失敗しました。</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set the template position of the pass point</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でパスポイントのテンプレート位置をセットします</translation>
@@ -7638,110 +7639,110 @@ to jump over the lazy dog
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でパスポイントのマップ位置をセット、&lt;b&gt;Escキー&lt;/b&gt;で中止します</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: パスポイントのテンプレート上の位置をセットします。 </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: パスポイントのマップ上の位置をセットします。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to delete pass points</source>
         <translation type="obsolete">&lt;b&gt;クリック&lt;/b&gt;でパスポイントを削除します</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;クリック&lt;/b&gt;: パスポイントを削除します。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move pass points</source>
         <translation type="obsolete">&lt;b&gt;ドラッグ&lt;/b&gt;でパスポイントを移動します</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;: パスポイントを移動します。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>パスポイント:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>テンプレート-X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>テンプレート-Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>マップ X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>マップ Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>パスポイントを適用</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>適用 &amp;&amp; すべて消去</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>すべて消去</translation>
     </message>
 </context>
 <context>
-    <name>TemplateGPS</name>
+    <name>OpenOrienteering::TemplateGPS</name>
     <message>
         <source>Error</source>
         <translation type="obsolete">エラー</translation>
@@ -7760,19 +7761,19 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>十分な空きメモリがありません (画像サイズ: %1x%2 ピクセル)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7781,69 +7782,69 @@ GIFファイルの保存はサポートされていません。
 テンプレート上へ書き込みを行った場合、保存されず終了時に破棄されることになります。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>ワールドファイル内の座標の座標参照系を選択してください</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
         <source>Open image template</source>
         <translation type="obsolete">画像テンプレートを開く</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>%1 を開きます</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>画像のサイズ:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>画像の位置やサイズの調節方法を指定してください:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>ワールドファイル</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>ジオリファレンス情報がありません</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>ジオリファレンス済</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>メートル/pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>テンプレートの縮尺: 1:</translation>
     </message>
@@ -7852,35 +7853,35 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">異なったテンプレートのスケール 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>グループ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>ファイル名</translation>
     </message>
@@ -7889,24 +7890,24 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">作成...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>スケッチ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>開く...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>ジオリファレンス: %1</translation>
     </message>
@@ -7915,42 +7916,42 @@ GIFファイルの保存はサポートされていません。
         <translation type="vanished">削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>テンプレートを追加...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>インポートと削除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
@@ -7959,12 +7960,12 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">選択中のテンプレート</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>ドラッグで移動</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>イメージ、GPSトラック、DXFファイルを開く</translation>
     </message>
@@ -7973,17 +7974,17 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">ジオリファレンス...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>位置調整...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>テンプレートファイル</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>すべてのファイル</translation>
     </message>
@@ -7992,7 +7993,7 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">もっと表示...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>調節...</translation>
     </message>
@@ -8013,9 +8014,9 @@ GIFファイルの保存はサポートされていません。
         <translation type="obsolete">画像を開く、またはGPSトラック...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -8044,23 +8045,23 @@ Failed to load template. Does the file exist and is it valid?</source>
         <translation type="obsolete">0 から 1 の有効な数字を入力してください。または 0 から 100 のパーセントで指定してください！</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>有効な整数値を入力してテンプレートのグループをセットするか、空白のままにしてテンプレートのグループを解除してください！</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>縮尺を変えない</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>公称地図縮尺比 (%1 %) によって縮尺</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -8069,38 +8070,38 @@ Failed to load template. Does the file exist and is it valid?</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>ファイル形式を認識できません。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>テンプレートを読み込めませんでした。ファイルが存在して、有効ですか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>現在テンプレートの縮尺 (%1 %) で縮尺</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>テンプレートをインポート</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>インポートされたテンプレート地図の記号の縮尺方法は?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>テンプレートは、重ね印刷のシミュレーションでは表示されません。標準表示に切り替えますか?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- 地図 -</translation>
     </message>
@@ -8118,174 +8119,174 @@ Failed to load template. Does the file exist and is it valid?</source>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;ドラッグ&lt;/b&gt;で選択中のテンプレートを水平移動します</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>位置調整</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X縮尺:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y縮尺:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>回転:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>トラックの縮尺と測位</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>座標系</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>実際</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>地図</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>1 座標単位に等しい:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>指定した座標でトラックを配置</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>表示の中心でトラックを配置</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>このテンプレートは GDAL/OGR で読み込む必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>トラック座標の座標参照系を選択</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>トラックを開いています ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>ジオリファレンスまたは非ジオリファレンスモードでトラックを読み込みますか?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>地図のジオリファレンス設定に従ってトラックを配置します。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>これらはまだ構成されていません。次のステップとして表示されます。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>ジオリファレンス</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>非ジオリファレンス</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>トラックの座標の平均で中心とした正射影を使用してトラックを投影します。調整後のトラックの位置を使用して、変換の調整と地図ジオリファレンスの設定を可能にします。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>コースが空です、インポートするものが何もありません!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>質問</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>ウェイポイントを、すべてのポイントを通過しているラインとしてインポートしますか？</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>インポートの問題</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n コース オブジェクトをインポートできませんでした (理由: 座標が見つかりません)。</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>読み込みエラー</translation>
     </message>
@@ -8298,7 +8299,7 @@ Failed to load template. Does the file exist and is it valid?</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -8307,39 +8308,39 @@ Failed to load template. Does the file exist and is it valid?</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 OSM ファイルではありません。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM ファイルのバージョンは %1 です。
 サポートされているバージョンは%2 以上です。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM ファイルのバージョンは %1 です。
 サポートされているバージョンは%2 以下です。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>問題</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 ノードを正しく処理できませんでした。</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">外部リンク: %1</translation>
@@ -8350,58 +8351,58 @@ The maximum supported version is %2.</source>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>整列</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>中央</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>ベースライン</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>底</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>テキスト設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>フォント名:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>フォントサイズ:</translation>
     </message>
@@ -8410,141 +8411,141 @@ The maximum supported version is %2.</source>
         <translation type="vanished">サイズの決定...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>テキストの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>太字</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>斜体</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>下線</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>文字の修飾:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>行間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>段落間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>文字間隔:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>文字間隔の自動調整 (カーニング)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>記号アイコンのテキスト:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>フレーミング</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD 互換の設定</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>フレーミングの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>ラインフレーミング</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>シャドーフレーミング</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>左/右のオフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>上/下のオフセット:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD 互換</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>ラインの幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>ラインの色:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>位置:</translation>
     </message>
@@ -8565,7 +8566,7 @@ The maximum supported version is %2.</source>
         <translation type="obsolete">OCAD互換の設定の表示</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>下線</translation>
     </message>
@@ -8574,22 +8575,22 @@ The maximum supported version is %2.</source>
         <translation type="obsolete">有効にする</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>幅:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>文字のベースラインからの距離:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>カスタムタビュレータの位置</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>カスタムタビュレータの追加</translation>
     </message>
@@ -8599,132 +8600,132 @@ The maximum supported version is %2.</source>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>計算</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>直前の操作が無効なので、元に戻すことができません。これは例えば、オブジェクトの記号を変更した後で、前の記号を削除したような場合に起こります。</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>ファイルを開いた時点より前の操作を元に戻します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>直後の操作が無効なので、やり直すことができません。これは例えば、描画したオブジェクトの記号を削除したような場合に起こります。</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>ヘルプファイルを探すのに失敗しました。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>ヘルプブラウザを探すのに失敗しました (&quot;QT Assistant&quot;)。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>ヘルプブラウザの開始に失敗しました(&quot;Qt Assistant&quot;)。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>さらに表示...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Mapper の古いバージョンでは、複数の地図の要素はサポートしていません。互換モードで地図を保存するには、最初にすべての地図の要素をマージする必要があります。</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>サポートされていない要素: %1 (%2 行目 %3 列目)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>いくつかの座標は印刷範囲外でした。地図コンテンツを調整しました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>このバージョンの Mapper では、このファイルの要素を読み取ることができません。最低限必要なバージョン: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>%1 行目 %2 列目でエラー: %3</translation>
     </message>
@@ -8733,44 +8734,44 @@ The maximum supported version is %2.</source>
         <translation type="vanished">ノートを読み取ることができません。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>いくつかの無効な文字を削除する必要がありました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>サポートされていないか無効なジオリファレンス仕様 &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>色 &apos;%1&apos; のノックアウト プロパティを設定できませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>%1 の色が必要ですが、%2 が見つかりました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>%2 (%3) の処理中に、スポット カラー %1 が見つかりませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>%1 の記号を予期しましたが、%2 が見つかりました。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>%1 の地図の要素が必要ですが、%2 が見つかりました。</translation>
     </message>

--- a/translations/OpenOrienteering_lv.ts
+++ b/translations/OpenOrienteering_lv.ts
@@ -2,35 +2,48 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="lv_LV">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Par %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Šī ir brīvprogrammatūra: Jūs to varat rediģēt un/vai izplatīt tālāk, ievērojot &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt; nosacījumus, kā minēts Free Software Foundation publikācijā.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation type="unfinished">&lt;a %1&gt;Viss par licensēm, autortiesību paziņojumiem un atrunām.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>The OpenOrienteering izstrādātāji alfabētiskā secībā:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(projekta aizsācējs)</translation>
     </message>
@@ -40,7 +53,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Brīvpieejas programma orientēšanās karšu zīmēšanai</translation>
@@ -54,7 +67,7 @@
         <translation type="vanished">Veidotāji alfabētiskā secībā:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Pateicība par ieguldījumu:</translation>
     </message>
@@ -76,203 +89,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation type="unfinished">Atvērt nesen izmantoto datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation type="unfinished">Rādīt dienas padomu</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minimālais izmērs:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Pildījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Līnijas pildījums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Parauga pildījums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Vienkārša līnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Paralēlas līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Attālums starp līnijām:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Viena rinda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Intervāls starp paraugiem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Parauga nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Rindas nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Paralēlas rindas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Attālums starp rindām:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Pildījuma pagrieziens</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Leņķis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>pielāgojams pa objektiem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Laukuma iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Parauga pildījums %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Līnijas pildījums %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Pildījums nav izvēlēts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Laukuma krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Līnijas nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Līnijas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Līnijas platums:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -281,250 +294,250 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Kartes krāsas rediģēšana</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Rediģēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Speckrāsas iestatījums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Speckrāsu sajaukums (klājumi un virsdruka):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Nokauts: dzēš apakšējās krāsas</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Noteikt pēc speckrāsām</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Noteikt pēc RGB krāsas</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Izvēlēta procesa krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Ciāns</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Dzeltens</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Melns</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Noteikt pēc CMYK krāsas</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Izvēles RGB krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Sarkans</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Zaļš</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Zils</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Darbvirsma</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Profesionālā druka</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Nosaukums</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished">Brīdinājums</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- nekas -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nosaukums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Necaurspīdīgums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Speckrāsa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translatorcomment>Nokauts?</translatorcomment>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Jauns</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Dublicēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Pārvietot augstāk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Pārvietot zemāk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dubultklikšķis uz krāsas vērtību, lai atvērtu dialogu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Apstiprinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Karte satur šīs krāsas simbolus. To dzēšot, objektiem nebūs krāsa! Vai tiešām vēlies to darīt?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Dublicēt)</translation>
     </message>
@@ -537,300 +550,300 @@
         <translation type="vanished">Ievadi procentu vērtību no 0% līdz 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Dubultklikšķis, lai iestatītu krāsu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Daļu skaits:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>-Privāts līnijas simbols -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Privāts laukuma simbols -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Rediģēt privāto simbolu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Kombinācijas iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Nomainīt no publiskā uz privāto simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Vai izmantot veco simbolu kā šablonu privātajam simbolam?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Simbols %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Iestatīt režģi</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Rādīt režģi</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Pieķerties režģim</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Izvēle...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Visas līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Horizontālās līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Vertikālās līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Izlīdzinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Izlīdzināt ar magnētiskajiem ziemeļiem</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Izlīdzināt ar režģa ziemeļiem</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Izlīdzināt ar patiesajiem ziemeļiem</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Papildus rotācija (pretēji p.r.v.):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Pozicionējums</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>metri apvidū</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milimetri uz kartes</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Horizontālā atstarpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Vertikālā atstarpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horizontālā nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikālā nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>mērvienības:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Līnijas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Attēlojums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Izvēlēties režģa līniju krāsu</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Sākums uz: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>papīra koordināšu sākums</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>projekcijas koordināšu sākums</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klikšķis vai vilkt&lt;/b&gt;: Sākt zīmēt caurumu. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Sadalošajai līnijai jābeidzas uz laukuma robežas!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Sadalošās līnijas sākums un beigas ir dažādās objekta daļās!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Sadalošās līnijas sākums un beigas ir vienā vietā!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt; uz līnijas: Sadala to divās. &lt;b&gt;Vilkt&lt;/b&gt; gar līniju: Dzēš šo līnijas daļu. &lt;b&gt;Klikšķis vai vilkt&lt;/b&gt; pie laukuma robežas: Sāk sadalījuma līniju. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Laukuma objektu sadalošie caurumi pagaidām nav realizēti!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Apgriezt visu karti. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klikšķis vai vilkt&lt;/b&gt;: Izvēlēties objektus apgriešanai. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Apgriezt izvēlētos objektus. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Simbolu izmēra iestatījums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Burts:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -844,261 +857,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Augstums:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klikškis&lt;/b&gt;: Sākt riņķi vai elipsi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Zīmēt riņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Pabeigt riņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Vilkšana&lt;/b&gt;: Zīmēt elipsi. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Mezglu punkti ieslēgti.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikšķis&lt;/b&gt;: Pieķerties vai papildināt esošos objektus. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klikšķis&lt;/b&gt;: Izvēlēties virzienu no esošiem objektiem. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikšķis&lt;/b&gt;: Pieķerties esošiem objektiem. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksēti leņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Atcelt pēdējo punktu. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation type="unfinished">Aizvērt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation type="unfinished">Atsaukt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation type="unfinished">Pārtraukt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Garums:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Sākt taisnu līniju. &lt;b&gt;Vilkt&lt;/b&gt;: Sākt līkni. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Vilkt&lt;/b&gt;: Sekot esošiem objektiem. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klikškis&lt;/b&gt;: Zīmēt taisnu līniju. &lt;b&gt;Vilkt&lt;/b&gt;: Zīmēt līkni. &lt;b&gt;Labais vai dubultklikšķis&lt;/b&gt;: Pabeigt līniju. &lt;b&gt;%1&lt;/b&gt;: Noslēgt līniju. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation type="unfinished">Atsākt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Leņķis:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksēti leņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1108,76 +1121,76 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation type="unfinished">Atsaukt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation type="unfinished">Pārtraukt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klikškis vai Vilkt&lt;/b&gt;: Sākt zīmēt taisnstūri. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pieķerties iepriekšējām līnijām. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klikškis&lt;/b&gt;: Iestatīt stūra punktu. &lt;b&gt;Labais vai dubultklikšķis&lt;/b&gt;: Pabeigt taisnstūri. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Izveidot teksta objektu ar vienu enkuru. &lt;b&gt;Vilkt&lt;/b&gt;: Izveidot teksta rāmi. </translation>
     </message>
@@ -1187,130 +1200,130 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Brīva pārvietošana. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klikškis&lt;/b&gt; uz segmentu: Pārslēgt starp taisnu un līklīnijas. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Uzturēt punktu regulatorus opozīcijā. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klikšķis&lt;/b&gt; uz punktu: Dzēst to; uz līniju: Pievienot jaunu mezgla punktu; ar &lt;b&gt;%2&lt;/b&gt;: Pievienot normālu punktu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klikškis&lt;/b&gt; uz punktu: Dzēst to; uz līniju: Pievienot jaunu punktu; ar &lt;b&gt;%2&lt;/b&gt;: Pievienot mezgla punktu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klikškis&lt;/b&gt; uz punktu, lai pārslēgtu starp mezgla punktu un normālu. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinātu nobīde:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksēti leņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pieķerties esošiem objektiem. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klikškis&lt;/b&gt;: Atlasīt vienu objektu. &lt;b&gt;Vilkt&lt;/b&gt;: Atlasīt daudzus objektus. &lt;b&gt;%1+Klikškis&lt;/b&gt;: Pārslēgt izvēli uz pretējo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Dzēst atlasītos objektus. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Augstas kvalitātes kartes atspoguļojums (gludināšana)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Gludināšana dod iespēju apskatīt karti labākā kvalitātē, taču samazina attēlošanas ātrumu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Augstas kvalitātes teksta atspoguļojums kartē (antialiasing), lēni</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klikšķa jūtīgums:</translation>
     </message>
@@ -1319,315 +1332,315 @@
         <translation type="vanished">px</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Pieķeršanās distance (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Fiksētā leņķa režīma solis (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Atlasot objektu, automātiski tiek atlasīts tā simbols</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Attālinot skatu, attālināties no kursora</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Zīmēšanas rīki: iestatīt pēdējo punktu, pabeidzot ar labo klikšķi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Šabloni: saglabāt aizvērto šablonu iestatījumus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Rediģēšanas rīks:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Atgūt veco formu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Atstatīt ārējos līknes regulatorus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Saglabāt ārējos līknes regulatorus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Darbība, dzēšot līknes punktu ar %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Taisnstūra rīks:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Palīgkrustiņa rādiuss:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Līniju resnuma priekšskats ar palīgkrustiņu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Neizdevās izveidot jaunu datni: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation type="unfinished">Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation type="unfinished">Jā</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation type="unfinished">Nē</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation type="unfinished">Konfigurēšana</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished">Vērtība</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Izskats</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Valoda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Programmas starts</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation type="unfinished">Vispārīgi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Piezīme</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Lai valodas maiņa stātos spēkā, programma jāpārstartē!</translation>
     </message>
@@ -1636,47 +1649,47 @@
         <translation type="vanished">Lietot tulkošanas datni...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Atvērt tulkojumu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Tulkojuma datnes (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Izvēlētā datne nav tulkojums.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM koordinātes</translation>
     </message>
@@ -1685,80 +1698,80 @@
         <translation type="vanished">UTM Zona (skaitlis ziemeļi/dienvidi, piem., &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gausa-Krīgera koordinātu references sistēma</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gausa-Krīgera koordinātes</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Zonas numurs (1 līdz 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Kartes mēroga iestatījums ir nepareizs vai tas neeksistē.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Nezināma CRS iestatījumu valoda: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Neuzturēta ģeogrāfiskā CRS specifikācija: %1</translation>
     </message>
@@ -1767,7 +1780,7 @@
         <translation type="vanished">Tikai mērogs</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokāls</translation>
     </message>
@@ -1777,73 +1790,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Kartes ģeoreference</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Meklēt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Deklinācija:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Projicētās koordinātes</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Statuss:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Ģeogrāfiskās koordinātes</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Rādīt references punktu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>pieļaujams</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Deklinācijas meklēšana tiešsaistē</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Kartes koordinātu references sistēma</translation>
     </message>
@@ -1856,7 +1869,7 @@
         <translation type="vanished">- no Proj.4 specifikācijas -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokāls -</translation>
     </message>
@@ -1865,112 +1878,112 @@
         <translation type="vanished">CRS specifikācija:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>References punkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Paņemt kartē</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datums: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Kartes ziemeļi</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation type="unfinished">&amp;Koordinātu references sistēma:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Kartes koordinātes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Ģeogrāfiskās koordinātes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Mainot CRS, saglabāt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Magnētiskā novirze:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>References punkta %1° %2° magnētiskā deklinācija tiks iegūta no &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt; Vai vēlies turpināt?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Deklinācijas maiņa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Deklinācija ir mainīta. Vai vēlies arī attiecīgi pagriezt kartes saturu?</translation>
     </message>
@@ -1979,66 +1992,66 @@
         <translation type="vanished">Projicētās koordinātes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Lokālās koordinātes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Ielasa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Nevar atpazīt datus.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Deklinācijas vērtība nav atrasta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Deklinācijas meklēšana tiešsaistē bija nesekmīga:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klikšķis&lt;/b&gt;: Iestatīt references punktu. Cita poga atceļ.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Laipni lūdzam OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Settings</source>
         <translation type="vanished">Iestatījumi</translation>
@@ -2102,118 +2115,118 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation type="unfinished">Darbības</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation type="unfinished">Izveidot jaunu karti...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation type="unfinished">Atvērt karti...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation type="unfinished">Iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation type="unfinished">Par %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation type="unfinished">Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation type="unfinished">Iziet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation type="unfinished">Nesenās kartes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation type="unfinished">Startējot, atvērt nesen izmantoto datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished">Dzēst sarakstu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation type="unfinished">Dienas padoms</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation type="unfinished">Rādīt dienas padomu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation type="unfinished">Iepriekšējais</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation type="unfinished">Nākošais</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Kļūda, ielasot %1 tipa simbolu %2. rindā %3. ailē.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Simbola ID &apos;%1&apos; nav unikāls %2.rindā %3.ailē.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2222,84 +2235,84 @@
         <translation type="vanished">Kļūda, ielasot simbolu.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Kļūda, ielasot %1 tipa objektu.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Neizdevās atrast simbolu objektam pozīcijā %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Punktveida objekts ar nedefinētu vai nepareizu simbolu pozīcijā %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versijas 7,8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Atrasts objekts bez simbola.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2308,35 +2321,35 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Kļūda simbolu pēcapstrādes laikā.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Šablons &quot;%1&quot; tika ielasīts no kartes mapes, nevis no iepriekšējās tā atrašanās vietas attiecībā pret kartes datnes novietojumu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2345,173 +2358,173 @@
         <translation type="vanished">Vismaz viens šablons nav atrodams. Klikšķini uz šablonu nosaukumu(iem) sarkanā krāsā izvēlnē Šabloni -&gt; Šablona iestatījumu logs, lai noteiktu šablonu datņu nosaukumu(s).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Nepareiza datnes formāta versija.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Neatbalstīta veca datņu formāta versija. Lūdzu, lieto vecāku programmas versiju, lai ielasītu un aktualizētu datni.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Neatbalstīta jauna datnes formāta versija. Dažas kartes detaļas netiks ielasītas vai saglabātas šajā programmas versijā. Apsver atjaunināšanu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Kartes ģeogrāfisko koordinātu references sistēma bija &quot;%1&quot;. Šī KRS netiek atbalstīta. Lietojam &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Kļūda, ielasot simbolu, kura tips %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Kļūda, ielasot simbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Kļūda, ielasot atsaukuma soļus.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Kļūda, ielasot kartes daļu skaitu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Kļūda, ielasot kartes daļu %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Nevar ielasīt datni: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Neatbalstīts datnes formāts.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Neatbalstīta jauna datnes formāta versija. Dažas kartes detaļas netiks ielasītas vai saglabātas šajā programmas versijā.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Līnijas iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Līnijas platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Līnijas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minimālais līnijas garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Līnijas gals:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>plakans</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>apaļš</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>taisnstūra</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>ass</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Līnijas savienojums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>precīzs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>pārklājošs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Gala garums:</translation>
     </message>
@@ -2521,334 +2534,335 @@
         <translation>Līnija ir svītrdalīta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Rādīt vismaz vienu vidus simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Minimālais vidus simbolu skaits:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimālais vidus simbolu skaits, kad noslēgts:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Svītras garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Svītrlīnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Atstarpes garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Svītras grupētas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>nav</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Atkāpes garums grupā:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Pirmās un pēdējās svītras garuma puse</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Iekšējie simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Iekšējie simboli uz punktu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Iekšējā simbola distance:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Robežas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Atšķirīgas robežas kreisajā un labajā malā</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Kreisā robeža:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Labā robeža:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Neizmantot mezgla punktu līnijas sākumā un beigās</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Sākuma simbols</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Iekšējais simbols</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Gala simbols</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Svītras simbols</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Iespējot robežlīnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Attālums starp punktiem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Attālums no līnijas gala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Robežas platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Robežas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Robežas atkāpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Robeža ir svītrlīnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Robežas svītras garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Atkāpes starp svītrām robežā garums:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Jauns</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Izveidot jaunu karti</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Atvērt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Atvērt eksistējošu datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Atvērt &amp;nesen izmantoto</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Saglabāt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Saglabāt &amp;kā...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Iestatījumi...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Aizvērt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Aizvērt šo datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>I&amp;ziet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Iziet no programmas</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Datne</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Vispārīgi</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Atvērt &amp;Rokasgrāmatu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Parādīt palīdzības tekstu šai programmai</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Par %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Parādit informāciju par šo programmu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Par &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Parādit informāciju par Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Datne ir modificēta.
 Vai vēlies saglabāt izmaiņas?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Nesaglabāta datne</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2857,60 +2871,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Vai vēlies mērogot simbolus līdz atlasītajam mērogam?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Avārijas brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Izskatās, ka %1 avarēja, kad iepriekšējo reizi tika atvērts:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Vai tiešām vērsim vaļā?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Visas kartes</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Visas datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Atvērt datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Atver %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2921,18 +2935,18 @@ File format not recognized.</source>
 Datnes formāts ir neatpazīstams.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2943,44 +2957,44 @@ Spied Yes, lai saglabātu šajā formātā.
 Spied No, lai izvēlētos citu formātu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Saglabāt datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Datni nevar saglabāt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Radās problēma, nosakot datnes formātu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Lūdzam ziņot par to kā par kļūdu.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2989,7 +3003,7 @@ because saving as %2 (.%3) is not supported.</source>
 jo saglabāšana kā %2 (.%3) netiek atbalstīta.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3004,31 +3018,31 @@ jo formāts ir nezināms.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Kartes eksportā izveidotie brīdinājumi.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Iekšēja kļūda, saglabājot:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Kartes importā izveidotie brīdinājumi.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3037,12 +3051,12 @@ for reading.</source>
 lasīšanai.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Nepieļaujams datnes tips.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3053,24 +3067,24 @@ lasīšanai.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nav ko importēt.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Jautājums</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3079,243 +3093,243 @@ Rescale the imported data?</source>
 Mainīt importējamo datu mērogu?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>noklusējuma daļa</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Jauna krāsa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished">Importēt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Drukāt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Atsaukt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Atsaukt pēdējo soli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Izdarīt atkārtoti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Izdarīt atkārtoti pēdējo soli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Griez&amp;t</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>K&amp;opēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Ielīmēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation type="unfinished">Atlasīt visu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation type="unfinished">Invertēt atlasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Pietuvināt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Attālināt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Pārslēgt pilnekrāna režīmu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Uzstādīt izvēles tuvināšanas koeficientu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Simbolu logs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Rādīt/Slēpt simbolu logu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Krāsu logs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Rādīt/Slēpt krāsu logu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Aizvietot simbolus ar tiem, kas ir citā kartes datnē</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Mērogot visus simbolus...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Mērogot visu simbolu kopu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Mainīt kartes mērogu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Mainīt kartes mērogu un pielāgot kartes objektus un simbolu izmērus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Kartes piezīmes...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Šablona iestatījumu logs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Rādīt/Slēpt šablona logu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Atvērt šablonu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Rādīt visu karti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Rediģēt objektus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Uzstādīt punktu objektus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Zīmēt līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Zīmēt riņķus un elipses</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Rakstīt tekstu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Dublicēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Pārslēgt simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Aizpildīt / Izveidot robežu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Pārslēgt svītrlīnijas virzienu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Savienot līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Griezt objektu</translation>
     </message>
@@ -3324,126 +3338,126 @@ Import the data anyway?</source>
         <translation type="vanished">Pagriezt objektu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mērīt garumus un laukumus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importēt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>R&amp;ediģēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Skats</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Rīki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Si&amp;mboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>K&amp;arte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>Ša&amp;bloni</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Zīmējums</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Zīmēt uz šablona</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Rādīt režģi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Konfigurēt režģi...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Svītrlaukumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Bāzes līnijas skats</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Slēpt visus šablonus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Ģeoreferencēšana...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Pagriezt karti...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Pagriezt visu karti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Atkārtoti atvērt šablonu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Zīmēt taisnstūrus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Izgriezt brīvas formas caurumu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Izgriezt apaļu caurumu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Izgriezt taisnstūrveida caurumu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Pagriezt paraugu</translation>
     </message>
@@ -3452,12 +3466,12 @@ Import the data anyway?</source>
         <translation type="vanished">Mērogot objektu(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Apvienot laukumus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Izveidot laukumu šķēlumu</translation>
     </message>
@@ -3466,37 +3480,37 @@ Import the data anyway?</source>
         <translation type="vanished">Laukumu diference</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Laukumu XOR</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Kartes koordinātes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Projicētās koordinātes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Platums/Garums (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Platums/Garums (GMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Rādīt koordinātes kā...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Izgriezt caurumu</translation>
     </message>
@@ -3505,43 +3519,43 @@ Import the data anyway?</source>
         <translation type="vanished">Fiktīvs</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Skats</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Atlasīt šablonu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Rediģēšana</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Paplašināta rediģēšana</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Atsaukšanas soļi vairs nav.</translation>
     </message>
@@ -3551,8 +3565,8 @@ Import the data anyway?</source>
         <translation type="vanished">Griezt %1 objektu(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Radās iekšēja kļūda, atvainojamies!</translation>
     </message>
@@ -3561,7 +3575,7 @@ Import the data anyway?</source>
         <translation type="vanished">Kopēti %1 objekti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Starpliktuvē nav objekti, kurus varētu ielīmēt!</translation>
     </message>
@@ -3570,589 +3584,589 @@ Import the data anyway?</source>
         <translation type="vanished">Ielīmēti %1 objekti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Uzstādīt izvēles tuvināšanas koeficientu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Tuvināšanas koeficients:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Simboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Krāsas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Mērogot visus simbolus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Mērogot līdz procentiem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Kartes piezīmes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Šabloni</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Izvietot punkta objektus uz kartes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Atlasīt punkta objektu, lai to varētu lietot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Zīmēt lauztas vai līkas līnijas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Atlasīt līniju, laukumu vai kombinētu simbolu, lai to varētu lietot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Zīmēt riņķus un elipses.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Iestatīt laukuma aizpildījuma paraugu vai punktveida objektu virzienu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Atlasīt laukuma objektu ar pagriežamu aizpildījuma paraugu vai pagriežamu punktveida objektu, lai aktivizētu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Nevar importēt atlasīto kartes datni, jo to nevar ielasīt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Zīmēt taisnstūrus.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Notiek rediģēšana</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Karte tiek rediģēta. Lūdzu, pabeidz rediģēšanas operāciju, pirms saglabāt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Attēls</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Dzēst atsaukumu / atkārtojumu vēsturi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Dzēst atsaukumu / atkārtojumu vēsturi, lai samazinātu kartes datnes izmēru.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Pārvietošana</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Virsdrukas simulācija</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Aizvietot simbolu kopu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Rediģēt līnijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation type="unfinished">Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation type="unfinished">A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation type="unfinished">Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Konvertēt par līknēm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Vienkāršot līniju</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Izgriezums</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Izgriezt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Eksportēt kā...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4160,7 +4174,7 @@ selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4168,22 +4182,22 @@ selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Raksīt tekstu uz kartes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Atlasīt teksta simbolu, lai varētu lietot šo rīku.</translation>
     </message>
@@ -4192,26 +4206,26 @@ selected</source>
         <translation type="vanished">Dublicēt atlasīto(s) simbolu(s).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Atlasīt vismaz vienu simbolu, lai aktivizētu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Pārslēgt simbolu virzienu līniju objektos.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Atlasīt vismaz vienu simbolu, lai lietotu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Savienot līniju galus, kas ir tuvu kopā.</translation>
     </message>
@@ -4220,17 +4234,17 @@ selected</source>
         <translation type="vanished">Griezt atlasīto(s) objektu(s) sīkākās daļās.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Atlasīt vismaz vienu līnijas vai laukuma objektu, lai lietotu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Izgriezt caurumu atlasītajā laukuma objektā.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Atlasīt vienu laukuma objektu, lai lietotu šo rīku.</translation>
     </message>
@@ -4267,34 +4281,34 @@ selected</source>
         <translation type="vanished">Aprēķināt laukumu nepārklājošās daļas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Pārveidot līnijas, kuras veido taisni segmenti, par gludu līkņu posmiem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Atlasīt līnijveida objektu, lai aktivizētu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Samazināt punktu skaitu līnijveida objektos, mēģinot saglabāt to formu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Izveidot dažu objektu vai visas kartes izgriezumu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Atlasīt noslēgtu līnijveida objektu izgriezuma formai, lai aktivizētu šo rīku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Izgriezt dažus objektus vai visu ierobežotajā laukumā.</translation>
     </message>
@@ -4303,8 +4317,8 @@ selected</source>
         <translation type="vanished">Maina atlasīto objektu simbolu uz atlasīto simbolu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Atlasīt vismaz vienu objektu un atbilstošu citu simbolu, lai lietotu šo rīku.</translation>
     </message>
@@ -4313,12 +4327,12 @@ selected</source>
         <translation type="vanished">Aizpildīt atlasītās līnijas vai izveidot robežu atlasītajiem laukumiem.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4327,7 +4341,7 @@ selected</source>
         <translation type="vanished">%1 objekts(i) tika dublicēti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Objektu atlasīšana</translation>
     </message>
@@ -4336,77 +4350,77 @@ selected</source>
         <translation type="vanished">Neviens objekts netika atlasīts, jo objekti ar atlasīto simbolu(iem) neeksistē.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mērīt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Apvienojums bija nesekmīgs.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Šķēlums bija nesekmīgs.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Diference bija nesekmīga.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOR bija nesekmīga.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Zīmēt brīvrokā uz šablona</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Zīmēt brīvrokā uz šablona. Izveidot vai ielasīt šablonu, uz kura var zīmēt, lai lietotu šo rīku</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importēt %1, GPX, OSM vai DXF datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importējamās datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Visas datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Nevar importēt atlasīto datni, jo tās formāts netiek atbalstīts.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation type="unfinished">
@@ -4416,7 +4430,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4425,7 +4439,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4434,42 +4448,42 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4478,178 +4492,178 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Pārtraukt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Vairāk: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Vairāk: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Vairāk: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation type="unfinished">- Karte -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4664,7 +4678,7 @@ atvērtu krāsu dialogu un
 tur definētu krāsas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4679,7 +4693,7 @@ un atlasīt &quot;Jauns simbols&quot;,
 lai tādu izveidotu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4692,7 +4706,7 @@ Lai ielasītu pamatkarti, klikšķis uz
 Šabloni -&gt; Atvērt šablonu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Padoms: Turi peles vidējo pogu un velc, lai pārvietotu karti,
@@ -4700,123 +4714,123 @@ tuvini, lietojot peles riteni, ja pieejams.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Robežas garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Garums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Laukums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nav atlasīts neviens objekts.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>Atlasīti %1 objekti.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Atlasītais objekts nav līnijveida.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Objekts ir pārāk mazs.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Minimālais laukums ir %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Piezīme: Robežas garums un laukums ir pareizi noteikti, ja objekts nešķeļ sevi un nav lietoti caurumi.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Šī līnija ir pārāk īsa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimālais garums ir %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Izveidot jaunu karti</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Izvēlēties mērogu un simbolu kopu jaunajai kartei.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Mērogs:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Simbolu kopas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Rādīt tikai simbolu kopas, kas atbilst izvēlētajam mērogam</translation>
     </message>
@@ -4825,140 +4839,140 @@ tuvini, lietojot peles riteni, ja pieejams.</translation>
         <translation type="vanished">Atcelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Izveidot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Tukša simbolu kopa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Ielasīt simbolu kopu no datnes...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Visas simbolu kopu datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Visas datnes</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Karte satur vairāk kā 256 krāsas, kas netiek atbalstīts ocd 8.versijā.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad rezultāts ir %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Neizdevās eksportēt aizpildījuma parauga nobīdi laukuma objektam</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Nav iespējams eksportēt šablonu: datnes tips &quot;%1&quot; pagaidām netiek atbalstīts</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Līnijveida simbolā &quot;%1&quot; nevar attēlot gala/savienojuma kombināciju.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Līnijveida simbolā &quot;%1&quot; neņem vērā mezglu grupējumu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Līnijveida simbolā &quot;%1&quot; mezglu skaits grupā samazināts līdz 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Līnijveida simbolā &quot;%1&quot; neizdevās korekti eksportēt robežas.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Laukuma simbolā &quot;%1&quot; izlaiž pildījuma paraugu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Laukuma simbolā &quot;%1&quot; pieņem &quot;nobīdīto rindu&quot; punktveida paraugu. Tas var būt gan korekti, gan nekorekti.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Teksta simbolā &quot;%1&quot;: tiek lietota mainīta simbolu atkāpe, tās realizācija pagaidām neatbilst OCAD lietotajai</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Teksta simbolā %1: ignorē pasvītrojumu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Teksta simbolā %1: ignorē simbola nobīdi</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Simbolu virkne nogriezta (marķēts ar trīs &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Neizdevās rezervēt atmiņu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad rezultāts ir %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD datnes ar versiju %1 netiek atbalstītas!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4967,97 +4981,97 @@ tuvini, lietojot peles riteni, ja pieejams.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Nevar importēt simbolu &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD importa slānis</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Svītrlīnijas simbolam %1 asā gala garumi sākumam un beigām ir dažādi (%2 un %3). Lietojam %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Svītrlīnijas simbolam %1 nevar korekti importēt beigu garumu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Svītrlīnijas simbolam %1 nevar korekti importēt beigu atstarpi.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Svītrlīnijas simbolam %1 pamata un beigu līniju garumi ir atšķirīgi (%2 un %3). Lietojam %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Svītrlīnijas simbolam %1 atstarpes D un E ir atšķirīgas (%2 un %3). Lietojam %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Ignorē izlīdzinājumu teksta simbola %1 importā</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Ignorē izvēles lielumu (%2) teksta simbola %1 importā</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Simbola %1 importā ir noteikts simbolu izvēles atkāpinājums, tā realizācija patlaban neatbilst OCAD lietotajai</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Ignorē vārdu izvēles atstarpes (%2%) teksta simbola %1 importā</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Ignorē izvēles rindu atkāpes (%2/%3) teksta simbola %1 importā</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Ignorē teksta ierāmējumu (režīms %2) teksta simbola %1 importā</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Nav iespējams ielasīt objektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Nav iespējams ielasīt taisnstūrveida objektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Teksta simbols nav importēts, nav iespējams noskaidrot sekošanas līniju (npts=%1): %2</translation>
     </message>
@@ -5066,296 +5080,296 @@ tuvini, lietojot peles riteni, ja pieejams.</translation>
         <translation type="obsolete">Nav iespējams importēt šablonu: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Nav iespējams importēt šablonu: fons &quot;%1&quot; nav rastra zīmējums</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Mēģinājums importēt teksta objektu ar nezināmu koordinātu formātu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Krāsa %1 netika atrasta, ignorējam to</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Meklēt</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Teksts</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation type="unfinished">Nav iespējams ielasīt objektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation type="unfinished">Nav iespējams ielasīt taisnstūrveida objektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation type="unfinished">Teksta simbols nav importēts, nav iespējams noskaidrot sekošanas līniju (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation type="unfinished">Mēģinājums importēt teksta objektu ar nezināmu koordinātu formātu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation type="unfinished">Krāsa %1 netika atrasta, ignorējam to</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation type="unfinished">Punkts</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation type="unfinished">Līnija</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation type="unfinished">Laukums</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation type="unfinished">Teksts</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5364,832 +5378,819 @@ tuvini, lietojot peles riteni, ja pieejams.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Atlasīt šablonu, uz kura zīmēt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Zīmēt</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klikšķis un vilkt&lt;/b&gt;: Krāsot. &lt;b&gt;Labais klikšķis un vilkt&lt;/b&gt;: Dzēst. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Krāsu atlasīšana</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Pārvietot karti. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Pievienot koordināti. &lt;b&gt;%1+Klikšķis&lt;/b&gt;: Mainīt atlasīto koordināti. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Vienmēr orientēts uz ziemeļiem (nav pagriežams)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Līnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Laukums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centrēt visus elementus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Patreizējais elements</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diametrs &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Iekšējā krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Ārējais platums &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Ārējā krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Līnijas platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Līnijas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Līnijas gals:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>plakans</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>apaļš</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>taisnstūrveida</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Līniju savienojums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>precīzs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>pārklājošs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Līnija slēgta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Laukuma krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinātes:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Līknes sākums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centrēt pēc vidējām koordinātēm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Viduspunkts]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Nezināms</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Punkta simbols</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Vilkt&lt;/b&gt;: Pārvietot drukas lauku vai tā robežas. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation type="unfinished">&lt;b&gt;Vilkt&lt;/b&gt;: Pārvietot karti. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Eksportēt kā PDF vai PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Rādīt šablonus</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Rādīt režģi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Lapas orientācija:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Printeris:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Portrets</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Ainava</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Lapas formāts:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopijas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Kreisais:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Augša:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Augstums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Priekšskats...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Viena lapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Izvēles apgabals</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Kartes apgabals:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centrēt drukas apgabalu</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Lappušu pārklājums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opcijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Izšķirtspēja:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Drukāt citā mērogā:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simulēt virsdruku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Druka</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Eksports...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF eksports</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Attēla eksports</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Saglabāt uz PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Aktivizēts nestandarta skata veids. Vai tiešām gribi drukāt/eksportēt karti tādā veidā?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Kartes eksports...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Visas datnes (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Zīmējuma saglabāšana neveiksmīga. Vai vietne eksistē? Vai ir pietiekamas tiesības?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Sekmīgs eksports uz %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Drukas uzdevums izveidots sekmīgi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Nezināms</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Kartes apgabals ir tukšs. Izvads atcelts.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Koordinātu references sistēma:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Atkārtoti atvērt šablonu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Vilkt vienumus no kreisās puses saraksta uz izvēlēto vietu labās puses sarakstā, lai tos ielasītu atkārtoti.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Aizvērtie šabloni:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Dzēst sarakstu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktīvie šabloni:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Karte -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Aizvietot simbolu kopu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Konfigurēt, kā un kurus simbolus aizvietot.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importēt visus jaunos simbolus, pat ja netiek lietoti kā aizvietojums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Dzēst oriģinālos simbolus, kuri netiek lietoti pēc aizvietojuma</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Dzēst neizmantotās krāsas pēc aizvietojuma</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Simbolu atbilstība:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Salāgot aizvietojuma simbolus ar simbolu numuriem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Oriģināls</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Aizvietojums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6200,7 +6201,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6208,279 +6209,279 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Nekas -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Izvēlēties kartes datni, no kuras ielasīt simbolus</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Neizdevās ielasīt kartes datni, atceļ.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Izvēlētās simbolu kopas mērogs ir 1: %1, bet kartes mērogs ir 1:%2. Vai tiešām vēlies lietot šo kopu?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Kartes pagrieziens</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Leņķis (pretēji plkst.rād.virz.):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Pagrieziena parametri</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Pagriezt ap:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Kartes koordinātu sistēmas sākumpunkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Ģeoreferences references punkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Cits punkts,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opcijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Pielāgot ģeoreferencēšanas references punktu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Pielāgot ģeoreferencēšanas deklināciju</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Pagriezt neģeoreferencētos šablonus</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Leņķis:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksēti leņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Iestatīt laukuma aizpildījuma paraugu vai punktveida objektu virzienu. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Pagrieziens:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fiksēti leņķi. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Iestatīt pagrieziena centru. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Pagriezt atlasīto(s) objektu(s). </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Mainīt kartes mērogu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Mērogošanas parametri</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Jaunais mērogs:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Mērogošanas centrs:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Kartes koordinātu sistēmas sākums</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Ģeoreferencēšanas references punkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Cits punkts,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opcijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Mērogot simbolu izmērus</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Mērogot kartes objektu pozīcijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Pielāgot ģeoreferencēšanas references punktu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Mērogot neģeoreferencētos šablonus</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Mērogošana:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Iestatīt mērogošanas centru. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Mērogot atlasītos objektus. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Izvēlēties koordinātu references sistēmu</translation>
     </message>
@@ -6489,17 +6490,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Tā kā kartei</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokāls</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Ģeogrāfiskās koordinātes (WGS84)</translation>
     </message>
@@ -6520,175 +6521,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">CRS specifikācija:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Statuss:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>pieļaujams</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Iestatījumi</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- nekas -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Nekas -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Numurs:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Rediģēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nosaukums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Apraksts:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Palīgsimbols (netiek atspoguļots pabeigtā kartē)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Vispārīgi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Simboliem, kuriem ir apraksts, nospiežot F1, kad ir redzams paskaidrojums, apraksts tiks parādīts</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Jauns simbols</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Līnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Laukums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Teksts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Kombinēts</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Rediģēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Dublicēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Mērogot...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Ielīmēt</translation>
     </message>
@@ -6701,113 +6702,113 @@ Do you want to save your changes?</source>
         <translation type="vanished">Aizpildīt / Izveidot robežu atlasītajam objektam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Atlasīt simbolus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Atvainojiet, radās iekšēja kļūda!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Starpliktuvē nav simboli, kurus varētu ielīmēt!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Atlasīt visus objektus ar šo simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Slēpt objektus ar šo simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Aizsargāt objektus ar šo simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Pievienot atlasei visus objektus ar atlasītajiem simboliem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Slēpt objektus ar atlasītajiem simboliem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Aizsargāt objektus ar atlasītajiem simboliem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Invertēt atlasi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Atlasīt visu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Atlasīt neizmantotos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Sakārtot simbolus</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Sakārtot pēc numura</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Sakārtot pēc primārās krāsas</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Sakārtot pēc primārās krāsas prioritātes</translation>
     </message>
@@ -6816,96 +6817,96 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Mērogot simbolu %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Mērogot līdz procentiem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Apstiprinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Karte satur objektus ar simbolu &quot;%1&quot;. Dzēšot to, šie objekti un atsaukšanas vēsture tiks dzēsti! Vai tiešām to vēlies darit?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Pievienot atlasei visus objektus ar šo simbolu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Atlasīt visus objektus ar atlasītajiem simboliem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Simbola iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Šablons:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(nekas)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Atvērt...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centrēt šablonu...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>oriģinālu aptverošs rāmis</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>oriģināla smaguma centrs</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Atlasīt fona krāsu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6916,58 +6917,58 @@ to jump over the lazy dog
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Nav apraksts!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished">Vērtība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">Pārvietot augstāk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">Pārvietot zemāk</translation>
     </message>
@@ -6980,7 +6981,7 @@ to jump over the lazy dog
         <translation type="obsolete">Palīdzība</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6989,77 +6990,77 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Close</source>
         <translation type="obsolete">Aizvērt</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished">Vērtība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished">Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Atrast pārvietoto šablona datni</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Visas datnes (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7069,134 +7070,134 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Šablona pielāgošana</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Neizdevās aprēķināt pielāgojumu!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Iestatīt šablona pozīciju nobīdes punktam. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Iestatīt kartes pozīciju nobīdes punktam. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klikšķis&lt;/b&gt;: Dzēst nobīdes punktus. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Vilkt&lt;/b&gt;: Pārvietot nobīdes punktus. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Nobīdes punkti:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Jauns</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Pārvietot</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Šablona X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Šablona Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Kartes X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Kartes Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Pielietot nobīdes punktus</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Pielietot &amp;&amp; dzēst visu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Dzēst visu</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7205,98 +7206,98 @@ GIF datņu saglabāšana nav atbalstīta. Tas nozīmē, ka zīmējumi uz šī š
 Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Izvēlēties koordinātu references sistēmu globālajā datnē</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Atver %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Attēla izmērs:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Norādi, kā novietot vai mērogot attēlu:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Pasaules fails</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nav ģeoreferencēšanas informācija</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Ģeoreferencēts</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metri uz punktu:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Skenēts ar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Šablona mērogs:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Atvērt</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Rādīt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Necaurspīdīgums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Grupa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Datnes nosaukums</translation>
     </message>
@@ -7305,19 +7306,19 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
         <translation type="obsolete">Izveidot...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Skice</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Atvērt...</translation>
     </message>
@@ -7342,7 +7343,7 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
         <translation type="obsolete">nē</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Ģeoreferencēts: %1</translation>
     </message>
@@ -7351,89 +7352,89 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
         <translation type="vanished">Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Aizvērt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Dublicēt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished">Aizvākt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Pārvietot augstāk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Pārvietot zemāk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Pārvietot manuāli</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Atvērt zīmējumu, GPS ceļu vai DXF datni</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Pozicionēšana...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Šablonu datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Visas datnes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Pielāgot...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Datnes formāts nav atpazīts.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Neizdevās ielasīt šablonu. Vai datne eksistē un ir pieļaujama?</translation>
     </message>
@@ -7442,23 +7443,23 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
         <translation type="obsolete">Ievadiet pieļaujamu skaitli no 0 līdz 1 vai norādiet procentus no 0 līdz 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Ievadiet pieļaujamu veselu skaitli, lai norādītu grupu, vai atstājiet tukšu, lai atgrupētu šablonu!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7467,194 +7468,194 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Karte -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Velc&lt;/b&gt;, lai pārvietotu patreizējo šablonu</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Pozicionējums</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Mērogs:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Mērogs:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Pagrieziens:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Treka mērogošana un novietojums</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Viena koordinātes vienība vienāda ar:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Novietot treku norādītajās koordinātēs</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Novietot treku skata vidū</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Izvēlēties koordinātu references sistēmu treka koordinātēm</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Atver treku...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Ielasīt treku ģeoreferencētā vai neģeoreferencetā veidā?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Novieto treku saskaņā ar kartes ģeoreferences iestatījumiem.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Šie vēl nav konfigurēti, tiks parādīti kā nākošais solis.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Ģeoreferencēts</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Neģeoreferencēts</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projicē treku, lietojot ortogrāfisko projekciju ar centru treka vidējotās koordinātēs. Pieļauj transformācijas pielāgojumu un kartes ģeoreferences iestatījumu, lietojot pielāgoto treka novietojumu.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Vietne ir tukša, nav ko importēt!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Jautājums</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Vai pieturpunkti ir importējami kā līnija, kas iet caur visiem punktiem?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Importa problēmas</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n līnijveida objektu neizdevās importēt (cēlonis: trūkstošas koordinātes).</numerusform>
@@ -7663,7 +7664,7 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Ielasīšanas kļūda</translation>
     </message>
@@ -7676,7 +7677,7 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7685,89 +7686,89 @@ Ja uz šī šablona netiks zīmēts, tā nav problēma.</translation>
 %2 {1:?}</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM datnes versija ir %1.
 Minimālā atbalstītā versija ir %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM datnes versija ir %1.
 Maksimālā atbalstītā versija ir %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problēmas</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 vienumus nevar korekti apstrādāt.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Izlīdzinājums</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Kreisais</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Labais</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Augšā</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Pamatlīnija</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Apakšā</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Teksta iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Fonta veids:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Fonta izmērs:</translation>
     </message>
@@ -7776,339 +7777,339 @@ Maksimālā atbalstītā versija ir %2.</translation>
         <translation type="vanished">Noteikt izmēru...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Teksta krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>treknraksts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>slīpraksts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>pasvītrots</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Teksta stils:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Rindu atstarpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Rindkopu atstarpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Simbolu atstarpe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Simbolu nobīde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Simbolu piktogrammu teksts:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Rāmējums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>OCAD saderības iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Rāmējuma krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Rindu rāmējums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Ēnojuma rāmējums</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Kreisā/Labā nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Augšas/Apakšas nobīde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD saderība</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>iespējots</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Līnijas platums:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Līnijas krāsa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Pozīcija:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Līnija zem rindkopām</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Attālums no pamatlīnijas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Izvēles tabulatoru pozīcijas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Pievienot izvēles tabulatoru</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Nevar atsaukt, jo pēdējais atsaukuma solis nav korekts. Tas var notikt, piemēram, ja tiek mainīts objekta simbols uz citu, un pēc tam vecais simbols tiek dzēsts.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Apstiprinājums</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Atsaucot šo soli, nonākam vietā, kur tika ielasīta datne. Vai esi pārliecināts?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Nevar izdarīt atkārtoti, jo pirmais darbības solis kļuvis nekorekts. Tas, piemēram, var notikt, ja tiek dzēsts uzzīmētā objekta simbols.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished">Neizdevās atrast palīdzības datni.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished">Neizdevās atrast palīdzības pārlūku (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished">Neizdevās palaist palīdzības pārlūku (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Neatbalstīts elements: %1 (rinda %2 aile %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished">nezināms</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished">Nezināma kļūda</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Jābūt %1 krāsām, atrastas %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Speckrāsa %1 nav atrasta, apstrādājot %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Jābūt %1 simboliem, atrasti %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Jābūt %1 kartes daļām, atrastas %2.</translation>
     </message>

--- a/translations/OpenOrienteering_nb.ts
+++ b/translations/OpenOrienteering_nb.ts
@@ -2,30 +2,43 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nb_NO">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Orienteringskart</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Programvare for å tegne orienteringskart</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Dette programmet er fri programvare: du kan distribuere det videre og/eller endre det iht. betingelsene i &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Dette programmet er distribuert i håp om at det vil være nyttig, men UTEN NOEN GARANTI; selv uten en garanti om SALGBARHET eller EGNETHET FOR ET VISST FORMÅL. Se GNU General Public License (GPL), versjon&amp;nbsp;3, for &lt;a %1&gt;flere detaljer&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Alt om lisenser, copyright info, betingelser og fraskrivningsklausul.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>OpenOrienteering-utviklere i alfabetisk rekkefølge:</translation>
     </message>
@@ -38,13 +51,13 @@
         <translation type="vanished">Tilleggsinformasjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(prosjektets initiativtaker)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Fri programvare for tegning av orienteringskart</translation>
@@ -59,7 +72,7 @@
         <translation type="vanished">Utviklere i alfabetisk rekkefølge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>For bidrag, takk til:</translation>
     </message>
@@ -77,203 +90,203 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Åpne siste brukte fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Vis dagens tips</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Vis gjenstående elementer</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minimumsstørrelse:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Fyllmønster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Fyllmønster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Enkelt linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Parallelle linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Linjeavstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Enkelt rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Mønsterintervall:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Mønsterforskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Radforskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Parallelle rader</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Radavstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Fyllretning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Vinkel:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>justerbar per objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Tegn elementer på kanten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Beskjær elementer på kanten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Tegn elementer hvis senteret er på innsiden av grensen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Tegn elementer hvis noe punkt er på innsiden av kanten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Tegn elementer hvis alle punkter er på innsiden av kanten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Flateinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Fyllmønster %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Linje %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Ingen fyll er valgt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Flatefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Linjeforskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Linjefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Linjebredde:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automatisk lagret fil</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -281,253 +294,253 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Fil lagret av bruker</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Filgjenoppretting</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Fil %1 ble ikke riktig lukket. For øyeblikket finnes to versjoner av filen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Lagre den aktive filen for å fjerne konflikt med annen versjon.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Endre kartfarge</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definerer en spotfarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translatorcomment>usikker på skjermer</translatorcomment>
         <translation>Blanding av spotfarger (skjermer og overtrykk):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translatorcomment>meget usikker på denne</translatorcomment>
         <translation>Knockout: fjern lavere farger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Beregn fra spotfarger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Beregn fra RGB-farge</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translatorcomment>prosessfarge er neppe korrekt</translatorcomment>
         <translation>Egendefinert prosessfarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Svart</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Beregn fra CMYK-farger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Egendefinert RGB-farge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Rød</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Grønn</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Skrivebord</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Profesjonell utskrift</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- ikke navngitt -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- ingen -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translatorcomment>Alternativt Ugjennomsiktighet</translatorcomment>
         <translation>Opasitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Spotfarge</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Dupliser</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Flytt opp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Flytt ned</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dobbelklikk på en fargeverdi for å åpne en dialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Bekreft</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Kartet inneholder symboler med denne fargen. Sletting vil fjerne fargen fra disse symbolene. Vi du virkelig gjøre dette?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (duplikat)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Dupliser)</translation>
     </message>
@@ -540,300 +553,300 @@
         <translation type="vanished">Skriv inn et prosenttall fra 0% til 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Dobbeltklikk for å definere fargen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klikk for å velge navn og klikk igjen for å redigere.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Antall deler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>Spesielt linjesymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Spesielt flatesymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Rediger spesielt symbol...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Kombinasjonsinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Endre fra felles til spesielt symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Bruk eksisterende symbol som mal for spesielt symbol?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbol %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Konfigurer rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Vis rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Fest til rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Velg...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Alle linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Horisontale linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Vertikale linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Tekstjustering</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Tilpass med magnetisk nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Tilpass med rutenettsnord</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Tilpass med sann nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Tilleggsrotering (mot klokken):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Plassering</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>meter i terrenget</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>millimeter på kartet</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Horisontalt mellomrom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Vertikalt mellomrom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horisontal forskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikal forskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Enhet:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Linjefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Vis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Velg farge på rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origo i:%1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>origo for papirkoordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>projiserte origokoordinater</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klikk eller dra&lt;/b&gt;: Start tegning av hullet. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Delelinjen må ende på flategrensen!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Start og ende på delelinjen er på forskjellige deler av objektet!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Start og ende på delelinjen er på samme sted!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt; på en linje for å dele den i to, &lt;b&gt;Dra&lt;/b&gt; langs en linje for å fjerne denne delen, &lt;b&gt;Klikk eller dra&lt;/b&gt; på en områdegrense for å tegne en delelinje. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Hull i flateobjekter er ikke støttet ennå!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klipp hele kartet. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klikk eller dra&lt;/b&gt;: Velg objekter som skal klippes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klipp valgte objekter. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Kan ikke åpne filen.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Filen er ikke en DXF-fil.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Velg fontstørrelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Bokstav:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -847,262 +860,262 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Høyde:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Fordel punkter likt langs linjen</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Antall punkter langs linjen:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Plasser i tillegg objekter i linjens endepunkter</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Roteringsinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Tilpass punkter med linjens retning</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Tilleggsroteringsvinkel (mot klokken):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Tegn sirkel med start i sentrum</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Start en sirkel eller ellipse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Tegn en sirkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Hold %1 for å starte tegning fra sentrum.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Avslutt sirkelen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Tegn en ellipse. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Dra en linje. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Styrepunkter på.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt;: Fest eller legg til eksisterende objekter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt;: Velg retning fra eksisterende objekter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished">&lt;b&gt;%1+%2&lt;/b&gt;: Segmentets retning og lengde. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt;: Fest til eksisterende objekter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Angre siste punkt. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Slutt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Lukk</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Tilknytt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Styrepunkt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Angre</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Lengde:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;:Start en rett linje.&lt;b&gt;Dra&lt;/b&gt;: Start en kurve. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Dra&lt;/b&gt;: Følg eksisterende objekter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translatorcomment>Lukke linjen betyr at linjen avsluttes i startpunktet</translatorcomment>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Tegn en rett linje. &lt;b&gt;Dra&lt;/b&gt;: Tegn en kurve. &lt;b&gt;Høyre- eller dobbeltklikk&lt;/b&gt;: Avslutt linjen. &lt;b&gt;%1&lt;/b&gt;:Lukk linjen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Klikk på kartet for å avslutte midling</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Avslutt plassering av objektet. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Tilknytt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Resett</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Lag et punktobjekt.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Lag et objekt og angi objektets retning.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Resett retning.</translation>
     </message>
@@ -1112,76 +1125,76 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Avslutt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Tilknytt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Tilknytt linje</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Styrepunkt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Angre</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klikk eller dra&lt;/b&gt;: Start tegning av rektangel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fest til tidligere linjer. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Angi et hjørnepunkt, &lt;b&gt;Høyre- eller dobbelklikk&lt;/b&gt;: Avslutt rektangelet. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Tilknytt eksisterende objekt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Avslutt redigering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Avbryt redigering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt; Lag tekstobjekt med et enkelt anker, &lt;b&gt;Dra&lt;/b&gt;: Lag tekstboks. </translation>
     </message>
@@ -1191,131 +1204,131 @@
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Tilknytt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Veksle mellom kurver</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fri bevegelse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt; på segment: Veksle mellom rett og buet. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Tilknytt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punkt / Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Veksle mellom styrepunkter</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Avslutt redigering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translatorcomment>meget usikker på denne</translatorcomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Behold motsatte innstillinger. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt; på punkt: Slett det; på linje: Legg til nytt styrepunkt; med &lt;b&gt;%2&lt;/b&gt;: Legg til normalpunkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt; på punkt: Slett det; på linje: Legg til nytt punkt; med &lt;b&gt;%2&lt;/b&gt;: Legg til styringspunkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klikk&lt;/b&gt; på punkt for å bytte mellom styre- og normalpunkt. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinatforskyvning:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Avstand:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fest til eksisterende objekter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Velg et enkelt objekt. &lt;b&gt;Dra&lt;/b&gt;: Velg flere objekter. &lt;b&gt;%1+Klikk&lt;/b&gt;: Bytt mellom valgene. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Slett valgte objekter. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Høykvalitets kartvisning (antialiasering)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasering bedrer kartets utseende, men senker kartvisningshastigheten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Høykvalitets tekstvisning på kart (antialiasering), treg</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Toleranse for museklikk:</translation>
     </message>
@@ -1324,315 +1337,315 @@
         <translation type="vanished">piksler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Festeavstand (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Trinnvis eller fast vinkelmodus (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Symbolikonstørrelse:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Ved valg av objekt velges også objektets symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Zoom vekk fra markør ved zooming ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Tegneverktøy: set siste punkt med høyreklikk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Bakgrunnskart: behold innstillinger for lukkede bakgrunnsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Redigeringsverktøy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Behold eksisterende form</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Tilbakestill innstillinger for ytterlinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Behold innstillinger for ytterlinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Handling ved sletting av kurvepunkt med %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Rektangelverktøy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Radius til hjelpekryss:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Forhåndsvis linjetykkelser med hjelpekryss</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Redigeringsverktøy</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Kunne ikke lage ny fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Format (%1) støtter ikke eksport</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Kartområdet er for stort. Bruk av fyll-verktøy kan bli svært tregt. Vil du likevel bruke det?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Valgt område er ikke lukket av linjer eller områder, kan ikke fylle område.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Valgt posisjon er ikke fri, kan ikke bruke fyll-verktøy her.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Klarte ikke å lage fyll-objekt.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Fyll område med valgt symbol. Området som skal fylles må være lukket av linjer eller arealer, andre symboler blir ikke hensyntatt. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS er avslått i innstillingene. Åpne innstillinger nå?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nei</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importer med GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Konfigurasjon</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Verdi</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Utseende</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Skjerm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Piksler per tomme:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Programstart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Lagrer filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Bevare kompabilitet med Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Lagre angre / gjør på nytt-historikken</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Lagre informasjon for automatisk gjenoppretting</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervall for lagring for gjenoppretting:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Filimport og -eksport</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8 bits koding:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Mer...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Bruk den nye OCD-importfunksjonen også for versjon 8-filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Merk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Programmet må startes på nytt for at endringen av språk skal tre i kraft!</translation>
     </message>
@@ -1641,47 +1654,47 @@
         <translation type="vanished">Bruk oversettelsesfil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Åpne oversettelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Oversettelsesfiler (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Valgte fil er ikke en gyldig oversettelse.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Primærskjerms oppløsning i piksler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Primærskjerms størrelse i tommer (diagonalt):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM-koordinater</translation>
     </message>
@@ -1690,80 +1703,80 @@
         <translation type="vanished">UTM-sone (nummer nord/syd, f.eks. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM-sone (nummer nord/syd)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krüger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krüger-koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Sonenummer (1 til 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>med EPSG-kode</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Lokale koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG-kode</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Egen PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Spesifikasjon</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Kartskalaangivelsen er feil eller mangler.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Feil skaleringsfaktor for rutenett: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Ukjent CRS-spesifikasjonsspråk: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Ikke støttet geografisk CRS-spesifikasjon: %1</translation>
     </message>
@@ -1772,7 +1785,7 @@
         <translation type="vanished">Kun skala</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
@@ -1782,73 +1795,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georeferering</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Slå opp...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Misvisning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Projiserte koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Skaleringsfaktor for rutenett:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Geografiske koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Vis referansepunkt i:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>gyldig</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Slå opp misvisning online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Kartets koordinatreferansesystem</translation>
     </message>
@@ -1861,7 +1874,7 @@
         <translation type="vanished">- fra Proj.4-spesifikasjon -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokal-</translation>
     </message>
@@ -1870,114 +1883,114 @@
         <translation type="vanished">CRS-spesifikasjon:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Referansepunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Velg på kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>Ø</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translatorcomment>N</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>Ø</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Kartets nord</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translatorcomment>&amp;Referansesystem:</translatorcomment>
         <translation>&amp;Referansesystem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Kartkoordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Geografiske koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Ved CRS-endringer, behold:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Misvisning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Misvisning for referansepunktet  %1° %2° vil nå hentes fra &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Vil du fortsette?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Misvisningsendring</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Misvisningen  er endret. Vil du rotere kartinnholdet tilsvarende?</translation>
     </message>
@@ -1986,66 +1999,66 @@
         <translation type="vanished">Projiserte koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Lokale koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Laster...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Kan ikke behandle data.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Misvisning ikke funnet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Onlineoppslag av misvisning mislyktes:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klikk&lt;/b&gt;Angi referansepunkt. En annen knapp for å avbryte.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;Angi referansepunkt. &lt;b&gt;Høyreklikk&lt;/b&gt;: Avbryt.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Velkommen til OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Clear list</source>
         <translation type="vanished">Tøm liste</translation>
@@ -2109,90 +2122,90 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Aktiviteter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Nytt kart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Åpne kart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Avslutt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Nyeste kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Åpne nylige brukte filer ved oppstart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Tøm liste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Dagens tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Vis dagens tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Neste</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Eksempler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Om Mapper</translation>
     </message>
@@ -2201,12 +2214,12 @@
         <translation type="vanished">Om Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Filliste</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Ingen kartfiler funnet!&lt;br/&gt;&lt;br/&gt;Kopier kartfiler til en toppnivåkatalog med navn &apos;OOMapper&apos; på enheten eller et minnekort.</translation>
     </message>
@@ -2216,19 +2229,19 @@
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Feil ved lasting av symboltype %1 ved linje %2 kolonne %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symbol-ID &apos;%1&apos; er ikke unik ved linje %2 kolonne %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Feil under opplasting av et symbol av type %1 på linje %2 kolonne %3: %4</translation>
     </message>
@@ -2237,38 +2250,38 @@
         <translation type="vanished">Feil ved lasting av symbol.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Feil ved lasting av objekttype %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Feil ved lasting av objekt av typen %1 ved %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Ikke i stand til å finne symbol for objekt ved %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Punktobjekt med udefinert eller galt symbol ved %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD versjon 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2277,48 +2290,48 @@
         <translation type="vanished">Kunne ikke behandle dataene.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Kunne ikke behandle koordinatene.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Forventet %1 koordinater, fant %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Feil ved lasting av skriverkonfigurasjonen ved %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Feil ved lasting av angre/gjenta-trinn ved %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Intet slikt valg: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Vektordata</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Funnet et objekt uten symbol.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Utelot %n ikke-regelbundne objekt.</numerusform>
@@ -2326,36 +2339,36 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Feil ved etter-prosessering for symbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Bakgrunnsbilde &quot;%1&quot; har blitt lastet fra kartets katalog i stedet for den relative plasseringen der kartet var tidligere.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Klarte ikke å laste bakgrunnsbilde &apos;%1&apos;, årsak: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Advarsler under lasting av bakgrunnsbilde &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Minst en malfil ble ikke funnet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klikk på rød(e) malnavn i malene -&gt; Maloppsettsmeny for å sinne navn på malfiler.</translation>
     </message>
@@ -2364,173 +2377,173 @@
         <translation type="vanished">Minst et bakgrunnsbilde ble ikke funnet. Klikk rød(e) bakgrunnsbildenavn i Bakgrunnsbilder -&gt; Innstillinger for å finne riktig bakgrunnsbildefilnavn.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Denne filen bruker et utdatert format. Støtte for dette formatet vil snart bli fjernet fra dette programmet. For å kunne åpne denne filen i fremtiden, lagre den på nytt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Feil versjon av filformatet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Ikke støttet gammelt filformat. Vennligst bruk en tidligere versjon av programmet for å oppdatere filen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Ikke støttet nytt filformat. Noen kartegenskaper vil ikke bli lastet eller lagret med denne versjonen av programmet. Vurdér oppgradering.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Det geografiske koordinatsystemet for kartet var &quot;%1&quot;. Denne CRS støttes ikke. Bruk &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Feil ved lasting av symboltype %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Feil ved lasting av symbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Feil ved angring.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Feil under lesing av kartdel teller.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Feil ved lasting av kartdel %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Kan ikke lese filen: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Ikke støttet filformat.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Ikke støttet nytt filformat. Noen kartegenskaper vil ikke bli lastet eller lagret med denne versjonen av programmet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Format (%1) støtter ikke import</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Kan ikke lese &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Linjeinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Linjebredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Linjefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minimum linjelengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Linjeavslutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>flat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>kvadratisk</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>spiss</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Linjeknekk:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>rett</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>skrå</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Avslutningslengde:</translation>
     </message>
@@ -2540,335 +2553,336 @@
         <translation>Linje er stiplet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Vis minst ett mellomsymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Mimimumsantall mellomsymboler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimumsantall mellomsymboler ved lukking:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Streklengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Stiplet linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Strekavstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Styrepunkter gruppert sammen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>ingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translatorcomment>&quot;skudd i blinde&quot;, må sjekkes i programmet</translatorcomment>
         <translation>Gruppert bruddlengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Halvlengde for første og siste strek</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Mellomsymboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Mellomsymboler per punkt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Avstand mellom mellomsymboler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Kanter</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Forskjellige kanter på venstre og høyre side</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Venstre kant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Høyre kant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Fjern styresymbol ved linjestart og linjeslutt</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Startsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Mellomsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Endesymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Styresymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Aktiver kantlinjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Avstand mellom punkter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Avstand fra linjeende:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Skaler streklinjesymbolet ved hjørnene</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Kantbredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Kantfarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Kantskifte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Kant er stiplet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Kantstreklengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Bruddlengde for kantlinje:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Lage et nytt kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Åpne...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Åpne en eksisterende fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Åpne sist &amp;brukte</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Lagre</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Lagre &amp;som...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Innstillinger...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Lukk</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Lukk denne filen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>A&amp;vslutt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Avslutt programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Åpne &amp;manual</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Vis hjelp for dette programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Vis info om dette programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Om &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Vis info om Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Vil du fjerne autolagringsversjonen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Filen er endret.
 Vil du lagre endringene?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Ulagret fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2877,12 +2891,12 @@ Do you want to scale the symbols to the selected scale?</source>
 Vil du tilpasse symbolemene til den valgte målestokken?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Kræsj-melding</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Det ser ut som %1 kræsjet forrige gang filen ble åpnet:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Skal du virkelig åpne filen på nytt?</translation>
     </message>
@@ -2895,50 +2909,50 @@ Vil du tilpasse symbolemene til den valgte målestokken?</translation>
         <translation type="vanished">Det er en automatisk lagret versjon av &lt;br /&gt;&lt;tt&gt;%1&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Last inn denne versjonen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Autolagring...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Feil ved autolagring!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Alle kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Alle filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Åpne fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Du må lukke gjeldende fil før du kan åpne en ny.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Åpner %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2949,18 +2963,18 @@ File format not recognized.</source>
 Filfomatet er ukjent.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Filen har blitt endret. Vil du fjerne endringene?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2971,44 +2985,44 @@ Velg Ja for å lagre i dette formatet.
 Velg Nei for å velge et annet format.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Lagre fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Fil kan ikke lagres:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Det var et problem med bestemmelse av filformatet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Vennligst rapporter denne feilen.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3017,7 +3031,7 @@ because saving as %2 (.%3) is not supported.</source>
 da lagring av %2 (.%3) ikke er støttet.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3032,31 +3046,31 @@ da formatet ikke gjenkjennes.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Karteksporteringen genererte advarsler.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Intern feil ved lagring:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Kartimporteringen genererte advarsler.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3065,12 +3079,12 @@ for reading.</source>
 for lesing.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Feil filtype.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3081,7 +3095,7 @@ for lesing.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3090,17 +3104,17 @@ for lesing.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Ingenting å importere.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Spørsmål</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3109,23 +3123,23 @@ Rescale the imported data?</source>
 Skal de importerte dataene omskaleres?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>standarddel</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Ny farge</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Symbolerstatning ble avvist.
@@ -3133,310 +3147,310 @@ Importer data likevel?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Ekte svart (alle utskriftsfarger)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Koordinatene er utenfor området.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Skriv ut...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Angre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Angre siste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Gjør om</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Gjør om siste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>Lim inn</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Velg alle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Velg ingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Invertér valg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Zoom inn</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Zoom ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Veksle fullskjermvisning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Angi zoomverdi...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Symbolvindu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Vis/Skjul symbolvinduet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Fargevindu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Vis/Skjul fargevinduet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Erstatt symboler med symboler fra en annen kartfil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Skalér alle symboler...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Skalér hele symbolsettet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Endre kartmålestokk...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Endre kartets målestokk og tilpass kartobjekter og symbolstørrelser</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Kartnotater...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Vis/Skjul bakgrunnsbildevindu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Åpne bakgrunnsbilde...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Vis hele kartet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>Ø</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Symbolsett-ID...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Rediger symbolsett-ID-en</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Last CRT-fil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished">Tildel nye symboler med kryssreferansetabell</translation>
     </message>
@@ -3449,57 +3463,57 @@ Importer data likevel?</translation>
         <translation type="vanished">Vis/skjul merkevalgvinduet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Rediger objekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Plasser punktobjekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Tegn linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Tegn sirkler og ellipser</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Skriv tekst</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Dupliser</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Bytt symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Fyll/Lag kantlinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Speilvend</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Forbind linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Klipp objekt</translation>
     </message>
@@ -3508,137 +3522,137 @@ Importer data likevel?</translation>
         <translation type="vanished">Roter objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mål lengder og flater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Kopier posisjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Kopier posisjon til utklippstavle.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>Vis</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>Verktøy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>Kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>Bakgrunnsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Tegning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Tegn på bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Vis rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Konfigurer rutenett...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Rasterflater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translatorcomment>Usikker på denne</translatorcomment>
         <translation>Standard visning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Skjul alle bakgrunnsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferering...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Roter kart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Roter hele kartet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Åpne bakgrunnskart på ny...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Tegn rektangler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Klipp frihåndshull</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Klipp rundt hull</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Klipp rektangulært hull</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Roter mønster</translation>
     </message>
@@ -3647,12 +3661,12 @@ Importer data likevel?</translation>
         <translation type="vanished">Skaler objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Samle flater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Snitt mellom flater</translation>
     </message>
@@ -3661,37 +3675,37 @@ Importer data likevel?</translation>
         <translation type="vanished">Fjern overlapp mellom flater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Fjern snitt mellom flater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Kartkoordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Projiserte koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Breddegrad/Lengdegrad (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Breddegrad/Lengdegrad (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Vis koordinater som...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Klipp hull</translation>
     </message>
@@ -3700,43 +3714,43 @@ Importer data likevel?</translation>
         <translation type="vanished">Modell</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Vis</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Velg bakgrunnsbilde...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Redigering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Avansert redigering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Angring er ikke mulig.</translation>
     </message>
@@ -3746,8 +3760,8 @@ Importer data likevel?</translation>
         <translation type="vanished">Klipp %1 objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>En intern feil har oppstått, beklager!</translation>
     </message>
@@ -3756,7 +3770,7 @@ Importer data likevel?</translation>
         <translation type="vanished">Kopiert %1 objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Det er ingen objekter å lime inn fra oppslagstavlen!</translation>
     </message>
@@ -3765,62 +3779,62 @@ Importer data likevel?</translation>
         <translation type="vanished">Limt inn %1 objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Angi zoomverdi</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Zoomverdi:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Farger</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Symbolsett-ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Rediger symbolsett-ID-en:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Skalér alle symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Skaler i prosent:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Kartnotater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Bakgrunnsbilder</translation>
     </message>
@@ -3829,112 +3843,112 @@ Importer data likevel?</translation>
         <translation type="vanished">Merkevelger</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Plasser punktobjekt på kart.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Velg et punktsymbol for å kunne bruke dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Tegn polygone og krumme linjer.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Velg linje-, flate- eller kombinert synbol for å kunne bruke dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Tegn sirkler og ellipser.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Velg retning på flatemønster eller punktobjekter.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Velg et flateobjekt med rotérbart mønster eller et rotérbart punktobjekt for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Resulterende symbol: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Velg minst to flate- eller linjeobjekter for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Forén overlappende flater.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Fjern alle deler som ikke overlapper det først valgte objektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Fjern deler som overlapper det først valgte objektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Fjern alle deler som overlapper det først valgte obektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Slå sammen flatehull, eller slå sammen hull med objektkanten for å klippe hull i denne delen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Velg ett flateobjekt med hull for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Feil ved sammenslåing av hull.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Tøm midlertidige merker</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Er du sikker på at du ønsker å slette alle midlertidige GPS-merker? Dette kan ikke angres.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Slå denne delen sammen med</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Flytt valgte objekter til</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Skriv inn navnet på kartdelen:</translation>
     </message>
@@ -3943,193 +3957,193 @@ Importer data likevel?</translation>
         <translation type="vanished">Vil du fjerne kartdelen &quot;%1&quot; og alle dens objekter? Dette kan ikke angres.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Slå sammen kartdeler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Vil du flytte alle objekter fra kartdel &quot;%1&quot; til &quot;%2&quot;, og å fjerne &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Vil du flytte alle objekter til kartdel &quot;%1&quot;, og fjerne alle andre kartdeler?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Valgt kartfil kan ikke importeres fordi den ikke kunne lastes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Tegn rektangler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Endring pågår</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Kartet blir for tiden endret. Vennligst avslutt endringen før lagring.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Kartet er lagret</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Bilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Tøm angre/gjenopprett-historikk</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Slett angre/gjenopprett-historikk for å redusere kartfilens størrelse.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Panorér</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Overprintsimulering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Erstatt symbolsett...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Tag-editor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Vis/Skjul tag-editorvinduet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Endre linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Tegn med frihånd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Fyll avgrensede områder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Klipp bort fra område</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Slå sammen hull i flate</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Konvertér til kurver</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Forenkle linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Utklipp</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Klipp bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Fordel punkter langs linjen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Tegn på bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Aktiver berøringsmarkør</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Aktiver GPS-visning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Aktver GPS-avstandssirkler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Sett punktobjekt ved GPS-posisjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Sett midlertidig merke ved GPS-posisjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Lag midlertidig linje ved GPS-posisjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Tøm midlertidige GPS-merker</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Aktiver kompassvisning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Tilpass kart med nord</translation>
     </message>
@@ -4138,68 +4152,68 @@ Importer data likevel?</translation>
         <translation type="vanished">Slå bakgrunnsbilde av/på</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Legg til ny del...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Gi nytt navn til valgt del...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Fjern valgt del</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Slå sammen alle deler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Eksporter som...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Kartdeler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Velg symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Skjul topplinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Vis topplinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Skriv ut/Eksporter er ikke tilgjengelig i denne programversjonen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Tag-editor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4209,7 +4223,7 @@ symboerl
 er valgt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4219,22 +4233,22 @@ symboler
 er valgt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Tegn linjer med frihånd.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Fyll avgrensede flater.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Skriv tekst på kartet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Velg et tekstsymbol for å kunne bruke dette verktøyet.</translation>
     </message>
@@ -4247,26 +4261,26 @@ er valgt</translation>
         <translation type="vanished">Dupliser valgt(e) objekt(er).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Velg minst ett objekt for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Bytt symbolretning på linjeobjekter.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Velg minst ett linjeobjekt for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Forbind endepunkter til linjer som er nær hverandre.</translation>
     </message>
@@ -4275,17 +4289,17 @@ er valgt</translation>
         <translation type="vanished">Klipp valgt(e) objekt(er) i mindre deler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Velg minst en linje- eller ett flateobjekt for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Klipp hull i valgt områdeobjekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Velg ett områdeobjekt for å aktivere dette verktøyet.</translation>
     </message>
@@ -4322,34 +4336,34 @@ er valgt</translation>
         <translation type="vanished">Beregn ikke-overlappende deler av flater.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Gjør om linjer fra rette segmenter til bezierkurver.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Velg et linjeobjekt for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Redusér antall punkter på linjeobjekter for å gjenskape formen deres.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Lag et utklipp av noen objekter eller hele kartet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Velg et lukket linjeobjekt som utklipp for å aktivere dette verktøyet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Klipp bort noen objekter eller alt i et avgrenset område.</translation>
     </message>
@@ -4358,8 +4372,8 @@ er valgt</translation>
         <translation type="vanished">Bytt symbol av valgt(e) objekt(er) til valgt symbol.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Velg minst ett objekt og et passende, forskjellig symbol for å aktivere dette verktøyet.</translation>
     </message>
@@ -4368,12 +4382,12 @@ er valgt</translation>
         <translation type="vanished">Fyll valgt(e) linje(r) eller lag kant for valgt(e) flate(r).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Plassér punktobjekter med jevn avstand langs eksisterende linjeobjekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Velg minst ett linjeobjekt og ett punktsymbol for å aktivere dette verktøyet.</translation>
     </message>
@@ -4382,7 +4396,7 @@ er valgt</translation>
         <translation type="vanished">%1 objekt(er) duplisert</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Objektvalg</translation>
     </message>
@@ -4391,82 +4405,82 @@ er valgt</translation>
         <translation type="vanished">Ingen objekter ble valgt fordi det ikke fins objekter med valgt(e) symbol(er).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Sammenslåing mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Snitt mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Forskjell mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Fjerning av snitt mellom flater mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Vil du fjerne kartdelen &quot;%1&quot; og alle dets objekter?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Byttet til kartdel «%1».</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Tegn med frihånd på et bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Tegn på frihånd på et bakgrunnsbilde. Lag eller last inn et bakgrunnsbilde som kan tegnes på for å aktivere denne knappen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importér %1, GPX-, OSM- eller DXF-fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Filer som kan importeres</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Alle filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Filen kan ikke importeres fordi filformatet ikke støttes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Roter objekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Skaler objekter</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4475,7 +4489,7 @@ er valgt</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Kopier %n objekt</numerusform>
@@ -4483,7 +4497,7 @@ er valgt</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Limte inn %n objekt</numerusform>
@@ -4491,42 +4505,42 @@ er valgt</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Sletter de valgte objektene.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Dupliser de valgte objektene.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Roter de valgte objektene.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Skaler de valgte objektene.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Klipp de valgte objektene i mindre deler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Bytter ut symbolet for de valgte objektene til det valgte symbolet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Fyll de valgte linjene eller lag en kant rundt de valgte områdene.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>%n objekt kopiert</numerusform>
@@ -4534,178 +4548,178 @@ er valgt</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Valgte ingen objekter da det ikke finnes noen objekter med de valgte symbolene.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Avbryt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Mer: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Mer: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Mer: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Finn…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Finn &amp;neste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Finn objekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Finn neste</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Finn &amp;alle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Avansert søk</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Kart -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Behandler separasjoner for side %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Behandler side %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Avbrutt</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Ferdig</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Tekstkilde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Kart (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>udefinert språk</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Oversettelse (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Før redigering, vil lagret tekst bli erstattet av gjeldende oversettelse. Ønsker du å fortsette?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Etter endring av lagret tekst, vil oversettelsen ikke lenger være å finne. Ønsker du å fortsette?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4720,7 +4734,7 @@ Velg Symboler -&gt; Fargevindu for å
 definér farger der.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4735,7 +4749,7 @@ og velg &quot;Nytt symbol#
 for å lage et.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4748,7 +4762,7 @@ For å laste inn grunnlag, klikk
 Bakgrunnsbilder -&gt; Åpne bakgrunnsbilde...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Hint: Hold musehjulet nede for å flytte kartet,
@@ -4756,123 +4770,123 @@ rull musehjulet for å zoome.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Grenselinjelengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Lengde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Flate:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Ingen objekter er valgt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objekter er valgt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Det valgte objektet er ikke en linje.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Objektet er for lite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Minimumsflaten er %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Merk: Omkrets og areal er kun korrekt om det ikke forekommer overlapp eller hull.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Linjen er for kort.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimumslengden er %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Lag nytt kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Velg målestokk og symbolsett for det nye kartet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Målestokk:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Symbolsett:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Vis bare symbolsett som passer med valgt målestokk</translation>
     </message>
@@ -4881,140 +4895,140 @@ rull musehjulet for å zoome.</translation>
         <translation type="vanished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Tomt symbolsett</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Last inn symbolsett fra fil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Alle symbolsettfiler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Alle filer</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Kartet inneholder mer enn 256 farger som ikke er støttet av OCAD 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad returnerte %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Ekte svart er eksportert som en vanlig farge.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Ikke i stand til å eksportere fyllmønsterendring for et flateobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Klrte ikke å eksportere bakgrunnsbilde: filtypen til &quot;%1&quot; er ikke støttet ennå</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished">Koordinater justeres for å passe i OCAD-8 -tegneområdet (-2 m … 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished">Noen koordinater er fremdeles utenfor OCAD-8 -tegneområdet. De kan kanskje ikke leses i OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>For linjesymbol &quot;%1&quot;, kan ikke vise ende/knekk-kombinasjon.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>For linjesymbol &quot;%1&quot;, kan ikke vise dash grouping.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>For linjesymbol &quot;%1&quot; har antallet styrepunkter i en gruppe blitt redusert til 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>For linjesymbol &quot;%1&quot; kan ikke kantlinjer eksporters korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>For flatesymbol &quot;%1&quot; er et fyllmønster utelatt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>For flatesymbol &quot;%1&quot; antas et &quot;shifted rows&quot; punktmønster. Dette kan både være korrekt og ikke korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>For tekstsymbol %1 er det angitt tegnavstand, denne funksjonen følger ikke OCADs håndtering ennå</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>For tekstsymbol %1: ignorerer understreking</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>For tekstsymbol %1: ignorerer kniping</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Tekststreng forkortet (forkortelsen merket med 3 &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Kunne ikke allokere buffer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad returnerte %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD-filer i versjon %1 er ikke støttet!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n fargeseparasjon ble droppet, årsak: Import deaktivert.</numerusform>
@@ -5022,97 +5036,97 @@ rull musehjulet for å zoome.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Kunne ikke laste spotfargedefinisjoner, feil %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Farge &quot;ekte svart&quot; er importert som en spesialfarge.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Kunne ikke importere symbol &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD-importert lag</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>I stiplet linjesymbol %1 er lengden for linjens start- og endepunktsavslutninger ulike (%2 og %3). Bruker %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>I stiplet linjesymbol %1 kan ikke lengden på linjeavslutningen importeres korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>I stiplet linjesymbol %1 kan ikke endeavstanden importeres korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>I stiplet linjesymbol %1 er hoved- og avslutningslengde ulike (%2 og %3). Bruker %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>I stiplet linjesymbol %1, avstandene D og E er ulike (%2 og %3). Bruker %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Linjesymbol %1: fjerner symbol i linjeender.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Ved import av tekstsymbol %1: ignorerer justering</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Ved import av tekstsymbol %1: ignorerer valgt weight (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Ved import av tekstsymbol %1: standard tegnavstand er valgt, denne funksjonen er ikke tilpasset OCADs håndtering ennå</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Ved import av tekstsymbol %1: ignorerer valgt ordavstand (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Ved import av tekstsymbol %1: ignorerer valgte innrykk (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Ved import av tekstsymbol %1: ignorerer tekstrammer (modus %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Klarte ikke å laste inn objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Klarte ikke å importere rektangelobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Importerte ikke tekstsymbol, kunne ikke få tak i filsti&apos; (ntps=%1): %2</translation>
     </message>
@@ -5121,240 +5135,240 @@ rull musehjulet for å zoome.</translation>
         <translation type="obsolete">Klarte ikke å importere bakgrunnsbilde: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Klarte ikke å importere bakgrunnsbilde &quot;%1&quot; ser ikke ut til å være et rasterbilde</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Forsøker å importere et tekstobjekt med ukjent koordinatformat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Farge-id ikke funnet: %1, fargen ignoreres</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>er</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>er ikke</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>inneholder</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Søk</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Tekst</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>og</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>eller</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>ugyldig</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>I linjesymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>I tekstsymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Kunne ikke laste koordinatreferansesystemet &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Spotfargeinformasjon ble utelatt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Kunne ikke importere symbol %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Ikke støttet type &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Klarte ikke å importere bakgrunnsbilde &quot;%1&quot; er ikke en støttet  bildetype.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Ikke støttet linjetype &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translatorcomment>FInner ikke oversettelse for pointed caps</translatorcomment>
         <translation>Ulike lengder for pointed caps i start (%1 mm) og slutt (%2 mm) er ikke støttet. Bruker %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Linjestilen kan ikke importeres korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Linjestilens endelengde (%1 mm) kan ikke importeres korrekt. Bruker %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Linjestilens endeavstand (%1 mm) kan ikke importeres korrekt. Bruker %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Ikke støttet rammestil &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Hoppet over sekundært punktsymbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Utelater streksymbol i lijeendene.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Dette symbolet kan ikke lagres som et riktig OCD-symbol igjen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Blokkjustering er ikke støttet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Vertikal tilpasning &apos;%1&apos; er ikke støttet.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ignorerer valgt strektykkelse (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Valgt bokstavmellomrom kan være feil.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ignorerer valgt ordmellomrom (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ignorerer valgte innrykk (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ignorerer tekstrammer (modus %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Linjetekstsymboler er ikke støttet ennå. Markerer symbolet som skjult.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Kode &apos;%1&apos; er ikke tilgjengelig. Sjekk innstillingene.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>I flatesymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Klarte ikke å laste inn objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Klarte ikke å importere rektangelobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Importerte ikke tekstsymbol, kunne ikke få tak i filsti&apos; (ntps=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Forsøker å importere et tekstobjekt med ukjent koordinatformat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Ugyldig verdi.</translation>
     </message>
@@ -5363,59 +5377,59 @@ rull musehjulet for å zoome.</translation>
         <translation type="vanished">Utestet filimport for format: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD-filer i versjon %1 er ikke støttet!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Fant ikke farge-id: %1, fargen ignoreres</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Klarte ikke å sette &quot;%1&quot; SRS for GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Lilla</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Område</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Klarte ikke å laste lag %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Klarte ikke å laste %n objekt(er), årsak: %1</numerusform>
@@ -5423,438 +5437,425 @@ rull musehjulet for å zoome.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Manglende geometri.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Kan ikke bestemme koordinattransformasjonen: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Feil ved transformering av koordinatene.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Ukjent eller ikke støttet geometritype.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Ikke nok koordinater.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished">Kan ikke bruke dette siktepunktet:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished">Geosiktedataen har ikke noe passende referansessytem.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Orienteringskart</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Programvare for å tegne orienteringskart</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Velg bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Tegn</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klikk og dra&lt;/b&gt;: Tegne. &lt;b&gt;Klikk på høyre musetast og dra&lt;/b&gt;: Slette. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Fargevalg</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt kartet. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Legg til en koordinat, &lt;b&gt;%1+Klikk&lt;/b&gt;: Endre valgt koordinat. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Alltid orientert mot nord (ikke roterbar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Område</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Sentrér alle elementer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Valgt element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diameter &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Farge innerst:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Bredde ytters &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Farge ytterst:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Linjebredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Linjefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Linjeavslutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>flat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>firkantet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Linjeknekk:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>rett</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>skrå</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Lukket linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Flatefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Kurvestart</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Sentrér med snittet av koordinatene</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Mellompunkt]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Ukjent</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Punktsymbol</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Skriver</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>En feil oppstod under kjøring.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Dra&lt;/b&gt;: Flytt utskriftsområdet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt kartet, utskriftsområdet eller utskriftsområdets kantlinjer. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt utskriftsområdet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt kartet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt utskriftsområdets kantlinje. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt utskriftsområdets kantlinjer. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Export to PDF or PS</source>
         <translation type="vanished">Eksportér til PDF eller PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Vis bakgrunnsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Vis rutenett</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Skriver:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Portrett</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Landskap</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Papirstørrelse:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopier:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Venstre:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Topp:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Bredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Høyde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Forhåndsvisning...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Enkelt side</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Valgt område</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Kartområde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Sentrér utskriftsområde</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Sideoverlapp:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Valg</translation>
     </message>
@@ -5867,223 +5868,223 @@ rull musehjulet for å zoome.</translation>
         <translation type="vanished">Fargeseparasjoner</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Oppløsning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Skriv ut i forskjellig skala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Malvisning kan variere.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simulér overprinting</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Standard CMYK (eksperimentelt)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Fargemodus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Skriv ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Eksportér...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF-eksport</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Bildeeksport</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Lagre som PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Ikke støttet i Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Forhåndsvisning mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Forhåndvisningsfremdrift</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>En ikke-standardisert visningsmodus er aktivert. Er du sikker på at du vil skrive ut/eksportere kartet slik?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>PDF-eksport mislyktes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>En feil oppstof under utskrift.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Eksportér kart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Alle filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Kunne ikke forberede utskrift.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Utskriftsfremdrift</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Egenskaper</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektorgrafikk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Rastergrafikk</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Fargeseparasjoner</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Kunne ikke vise bilde. Ikke nok minne.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Bildet kunne ikke lagres. Eksisterer katalogen? Har du tilstrekkelige rettigheter?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Vellykket eksportering til %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Kunne ikke fullføre PDF-eksport.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Avbrutt.</translation>
     </message>
@@ -6092,176 +6093,176 @@ separations</source>
         <translation type="vanished">Skriver</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Utskriftsjobben kunne ikke avbrytes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Utskriften ble vellykket</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Ukjent</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Kartområdet er tomt. Utskriften er avbrutt.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Referansesystem:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Åpne bakgrunnsbilde på nytt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Dra poster fra den venstre listen til ønsket plass i den høyrelisten for å laste dem på nytt.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Lukkede bakgrunnsbilder:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Tøm liste</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktivér bakgrunnsbilder:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Kart -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Erstatt symbolsett</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Konfigurér hvordan symbolene skal erstattes, og hvordan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importér alle nye symboler, selv om de ikke benyttes ved utskiftningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Slett ubrukte originale synboler etter utskiftningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Slett ubrukte farger etter utskiftningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Symboloversikt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Behold symbolene i&apos; skjult / beskyttet status for det tidligere symbolsettet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Sammenlign erstatningssymboler med symbolnumre</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished">Rediger symbolsett-ID-en:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Erstatning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished">Jamfør etter symbolnavn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Tildel nye symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Mønster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished">Tøm erstatninger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Åpne CRT-fil…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Lagre CRT-fil…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Symboltilknytning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT-fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Det er flere erstatninger for symbolet %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6272,7 +6273,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6283,280 +6284,280 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Kryssreferansetabellen har blitt endret.
 Ønsker du å lagre dine endringer?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Ingen -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Velg kartfil å laste symboler fra</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Kan ikke laste kartfil, avbryter.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Det valgte symbolsettet har skala 1:%1, mens kartskalaen er 1:%2. Vil du virkelig velge dette symbolsettet?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>Kan ikke laste CRT-fil, avbryter.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Rotér kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Vinkel (mot klokken):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Roteringsparametre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotér rundt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Kartkoordinatsystemets origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Georefereringens referansepunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Annet punkt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Valg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Justér referansepunkt for georeferanse</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Justér misvisning for georeferanse</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Rotér ikke-georefererte bakgrunnsbilder</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Angi retningen for områdefyllmønstre eller punktobjekter. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotering:&lt;/b&gt;%1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Faste vinkler. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt; Angi rotasjonssenter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Rotér valgte objekter. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Endre kartets målestokk</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Skaleringsparametre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Ny målestokk:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Skalingssentrum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Kartkoordinatsystemets origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Georefereringens referansepunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Annet punkt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Valg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Skalér symbolstørrelser</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skalér kartobjekters plasseringer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Justér referansepunkt for georeferanse</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skalér ikke-georefererte bakgrunnsbilder</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skalering:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Angi skaleringssenter. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Skalér valgte objekter. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Velg referansesytem for koordinater</translation>
     </message>
@@ -6565,17 +6566,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Samme som kartets</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Samme som kart</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Geografiske koordinater (WGS84)</translation>
     </message>
@@ -6596,175 +6597,175 @@ Do you want to save your changes?</source>
         <translation type="vanished">CRS-spesifikasjon:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>gyldig</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Innstillinger</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; er lagret på fast plass.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; er lagret i programminnet. Filene vil bli fjernet ved avinstallering av programmet.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>«%1&apos;» er ikke skrivebar.  Endringer kan ikke lagres.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; er ikke en tillatt lagringsplass.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- ingen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Ingen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nummer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Navn:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Beskrivelse:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Hjelpesymbol (ikke vist på det ferdige kartet)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Beskrivelse</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Trykk F1 for å vise beskrivelser for symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nytt symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Flate</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Kombinert</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplisér</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skalér...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Lim inn</translation>
     </message>
@@ -6777,12 +6778,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Fyll/Lag kant for valgt(e) objekt(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Velg symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Aktivér dra og slipp</translation>
     </message>
@@ -6791,103 +6792,103 @@ Do you want to save your changes?</source>
         <translation type="vanished">Skalér symbol(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>En intern feil har oppstått, beklager!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Det er ingen objekter å lime inn fra oppslagstavlen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Velg alle objekter med dette symbolet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Fjern alle objekter med dette symbolet fra utvalget</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Skjul objekter med dette symbolet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Beskytt objekter med dette symbolet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Legg til alle objekter med valgt symbol til utvalget</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Fjern alle objekter med valgte symboler fra utvalget</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Skjul objekter med valgte symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Beskytt objekter med valgte symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Invertér valg</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>Snarvei for å vise symbolbeskrivelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Velg alle</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Velg ubrukte</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Sortér symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Sortér etter verdi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Sortér etter primærfarge</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Sortér etter primærfargerekkefølge</translation>
     </message>
@@ -6896,96 +6897,96 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Skalér symbol %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skaler i prosent:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Bekreft</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Kartet inneholder objekter med symbolet &quot;%1&quot;. Sletting vil slette disse objektene og deres angrehistorie! Vil du virkelig gjøre dette?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Legg til alle objekter med dette symbolet til utvalget</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Velg alle objekter med valgte symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Bytt symbol for valgte objekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Fyll / Lag ramme for valgte objekter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Skaler symboler</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Symbolinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Bakgrunnsbilde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Bakgrunnsbilde:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(ingen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Åpne...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Sentrér bakgrunnsbilde...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>avgrensningsboks på kilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>tyngdepunkt på kilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Velg bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6997,58 +6998,58 @@ to jump over the lazy dog
 æøå1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- ikke navngitt -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Ingen beskrivelse!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Relasjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Nøkkel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Sammenligning</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Verdi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Legg til rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Fjern rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Flytt opp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Flytt ned</translation>
     </message>
@@ -7061,7 +7062,7 @@ to jump over the lazy dog
         <translation type="vanished">Hjelp</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n objekt(er) valgt</numerusform>
@@ -7069,14 +7070,14 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Ugyldig spørring</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Add</source>
         <translation type="vanished">Legg til</translation>
@@ -7107,63 +7108,63 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Tastekombinasjon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Verdi</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Tastekombinasjonen eksisterer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Tastekombinasjonen &quot;%1&quot; eksisterer allerede og må ikke benyttes to ganger.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Finn bakgrunnsbildet</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Alle filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Ingen slik fil.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Er filens format korrekt for denne maltypen?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Ikke nok ledig minne.</translation>
     </message>
@@ -7173,134 +7174,134 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Justering av bakgrunnsbilde</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Justeringsberegning mislyktes!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Angi bakgrunnsbildets passpunktposisjon. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Angi kartets passpunktposisjon. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klikk&lt;/b&gt;: Slett passpunkter. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytt passpunkter. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Passpunkter:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Flytt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Bakgrunnsbilde X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Bakgrunnsbilde Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Kart X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Kart Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Bruk passpunkter</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Bruk &amp;&amp; tøm alle</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Tøm alle</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Ikke nok fritt minne (bildestørrelse: %1x%2 piksler)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7309,98 +7310,98 @@ Lagring av GIF-filer er ikke støttet. Det betyr at endringer i denne malen ikke
 Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Velg koordinatsystem for koordinater i globalfil</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Åpner %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Bildestørrelse:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Angi hvordan bildet skal plasseres eller skaleres:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Globalfil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>ingen georeferanseinformasjon</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georeferert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Meter per piksel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Skannet med</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Bakgrunnsbildesala: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Åpne</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Vis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Opasitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Filnavn</translation>
     </message>
@@ -7409,19 +7410,19 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
         <translation type="obsolete">Lag...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Tegn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Åpne...</translation>
     </message>
@@ -7446,7 +7447,7 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
         <translation type="obsolete">nei</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georeferert:%1</translation>
     </message>
@@ -7455,89 +7456,89 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
         <translation type="vanished">Slett</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Lukk</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Dupliser</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Legg til bakgrunnsbilde...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Flytt opp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Flytt ned</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importér og fjern</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Flytt for hånd</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Åpne bilde, GPS-spor eller DXF-fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Plassering...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Bakgrunnsfiler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Alle filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Tilpass...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Filformatet er ikke gjenkjent.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Feil ved lasting av bakgrunnsbilde. Eksisterer filen og er den gyldig?</translation>
     </message>
@@ -7546,23 +7547,23 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
         <translation type="obsolete">Vennligst skriv inn et gyldig tall fra 0 til 1, eller angi en prosentverdi fra 0 til 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Vennligst skriv inn et gyldig heltall for å angi en gruppe eller la feltet være tomt for å fjerne bakgrunnsbildet fra gruppen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Ikke skalér</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Skalér med opprinnelig kartmålestokk (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7571,194 +7572,194 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Skelér med eksisterende bakgrunnsbildeskala (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Bakgrunnsbildeimport</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Hvordan skal symbolene i det importerte bakgrunnsbildet skaleres?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Dette bakgrunnsbildet vil ikke være synlig ved simulering av overprinting. Bytt til normal visning?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Kart -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Dra&lt;/b&gt; for å flytte aktivt bakgrunnsbilde</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Plassering</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-akse:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-akse:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotering:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Sporskalering og -posisjonering</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinatsystem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Virkelig</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Kart</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>En koordinatenhet tilsvarer:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Plassér spor ved gitte koordinater</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Plassér spor i visningssentrum</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Denne malen må lastes med GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Velg koordinatreferansesystem for sporingskoordinatene</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Åpner spor ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Last spor i georeferert eller i ikke-georeferert modus?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Plasser spor iht. kartes georeferanseinnstillinger.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Disse er ikke konfigurert ennå, så de vil ikke bli vist som neste steg.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georeferert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Ikke-georeferert</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Viser sporet mha. en ortografisk projeksjon med senter i sporets koordinatgjennomsnitt. Tillater justering av transformasjon og innstilling av kartgeoreferanse vha. justert sporposisjon.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Mappen er tom, det er ingenting å importere!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Spørsmål</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Skal stedspunkter bli importert som en linje som går gjennom alle punktene?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Importproblemer</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n linjeobjekt kunne ikke importeres (årsak: manglende koordinater).</numerusform>
@@ -7766,7 +7767,7 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Feil ved lesing</translation>
     </message>
@@ -7779,7 +7780,7 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7788,39 +7789,39 @@ Hvis du ikke har til hensikt å endre denne malen, er det ikke noe problem.</tra
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Ikke en OSM-fil.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM-filen har versjon %1.
 Laveste støttede versjon er %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM-filen har versjon %1.
 Høyeste støttede versjon er %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemer</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 knutepunkter kunne ikke prosesseres korrekt.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Ekstern lenke: %1</translation>
@@ -7831,58 +7832,58 @@ Høyeste støttede versjon er %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Tekstjustering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Venstre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Midtstilt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Høyre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Topp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Grunnlinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Bunn</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Tekstinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Skriftfamilie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Skriftstørrelse:</translation>
     </message>
@@ -7891,339 +7892,339 @@ Høyeste støttede versjon er %2.</translation>
         <translation type="vanished">Bestem størrelse...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Tekstfarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>uthevet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>kursiv</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>understreket</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Tekststil:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Linjeavstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Avsnittsavstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Bokstavmellomrom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kniping</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Symbolikontekst:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Innramming</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Innstillinger for OCAD-kompabilitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Rammefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Linjeinnramming</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Bredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Skyggeinnramming</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Venstre/Høyre-forskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Ovenfra og ned-forskyvning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD-kompabilitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>aktivert</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Linjebredde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Linjefarge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Plassering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Line under avsnitt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Avstand fra grunnlinje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Angitte tabulatorinnstillinger</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Legg till tabulatorinnstilling</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Beregn</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Kan ikke angre fordi siste angrenivå ble ugyldig. Dette kan f.eks. skje hvis du endrer et symbol for et objekt til et annet symbol og deretter sletter det gamle symbolet.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Bekreftelse</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Angring nå vil passere filens status ved siste innlasting. Er du sikker på at du vil angre?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Kan ikke gjøre om fordi første nivå ble ugyldig. Dette kan f.eks. skje hvis du sletter et symbol for et objekt du har tegnet.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Mislyktes i å finne hjelpefiler.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Klarte ikke å finne hjelpeprogrammet (&quot;Qt-Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Feil ved oppstart av hjelp (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Se mer...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Tidligere versjoner av Mapper støtter ikke multiple kartdeler. For lagring i kompabilitetsmodus, du må først slå sammen kartdelene.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Ikke støttet element: %1 (linje %2 kolonne %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Noen koordinater var utenfor utskriftsområdet. Kartinnholdet ble justert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>ukjent</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Deler av denne filen kan ikke leses av denne versjonen av Mapper. Det kreves minimum versjon: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Feil i linje %1 kolonne %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Måtte fjerne noen ugyldige tegn.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Ukjent feil</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Ustøttet eller ugyldig georeferansespesifikasjon &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Kunne ikke angi utslagsverdi for farge &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Forventet %1 farger, fant %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Spotfarge %1 ikke funnet under prosessering %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Forventet %1 symboler, fant %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Forventet %1 kartdeler, fant %2.</translation>
     </message>

--- a/translations/OpenOrienteering_nl.ts
+++ b/translations/OpenOrienteering_nl.ts
@@ -2,249 +2,262 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nl_NL">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Oriëntatiekaart</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Software voor het tekenen van oriëntatiekaarten</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Over %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Deze software is gratis: het mag gedistribueerd en/of aangepast worden onder de voorwaarden van de &lt;a %1&gt;GNU General Public License (GPL), Version&amp;nbsp;3&lt;/a&gt;, zoals gepubliceerd door de Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Dit programma wordt verspreid in de veronderstelling dat het nuttig zal zijn, maar ZONDER ENIGE GARANTIE; zelfs zonder de impliciete garantie van verkoopbaarheid of geschiktheid voor een bepaald doel. Voor &lt;a %1&gt;details&lt;/a&gt;, zie de GNU General Public License, Version&amp;nbsp;3.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Alles over licenties, auteursrechtduidingen, voorwaarden en disclaimers.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>De OpenOrienteering-ontwikkelaars in alfabetische volgorde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(initiatiefnemer)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Een gratis programma voor het tekenen van oriëntatieloop kaarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Dank voor bijdragen gaat uit naar:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Open laatst bewerkte kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Toon tip van de dag</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Toon overige elementen</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minimum afmeting:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Vullingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Lijn vulling</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Vulpatroon</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Enkele lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Parallele lijnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Lijn afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Enkele regel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Patroon interval:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Patroon verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Rij verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Parallelle rijen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Rij afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Oriëntatie vulling</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>instelbaar per object</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Gedrag voor tekenen van elementen op grensvalkken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Elementen afsnijden op de rand.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Teken de elementen als hun middelpunt binnen de grens valt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Teken de elementen als enig punt binnen de grens valt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Teken de elementen als alle punten binnen de grens vallen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Oppervlak instelling</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Vulpatroon %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Lijn vulling %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Geen vulling gekozen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Kleur oppervlak:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Lijn verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Lijn kleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Lijnbreedte:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Automatisch opgeslagen bestand</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -252,249 +265,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Bestand opgeslagen door de gebruiker</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Bestand herstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Bestand %1 werd niet correct afgesloten. Er zijn nu twee versies:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Sla het actieve bestand op, om zo de conflicterende versie te verwijderen.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Wijzig kleur kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Bepaalt een steunkleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mengkleur van steunkleuren (Raster en overdruk):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout: wist onderliggende kleuren</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Aangepaste proces kleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Geel</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Zwart</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- naamloos -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Uit steunkleuren berekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Uit RGB-kleuren berekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Uit CMYK-kleuren berekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Aangepaste RGB-kleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Rood</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Groen</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Blauw</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Bureaublad</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Professionele afdruk</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- geen -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Dekkingsgraad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Steunkleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.O.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Klonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Omhoog schuiven</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Omlaag schuiven</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dubbel-klik op een kleur om een dialoogvenster te openen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>De kaart bevat symbolen met deze kleur. Door deze kleur te wissen wordt deze ook verwijderd van de betreffende objecten. Weet je het zeker?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (duplicaat)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translatorcomment>Remove initial space from tr.</translatorcomment>
         <translation> (Kopie)</translation>
@@ -508,302 +521,302 @@
         <translation type="vanished">Voer een percentage in tussen 0% en 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Dubbelklikken om de kleur te bepalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klik, om de naam te selecteren, en klik nogmaals om te bewerken.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>Aa&amp;ntal onderdelen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Specifiek lijn symbool -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Specifiek oppervlak symbool -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Bewerk specifiek symbool...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translatorcomment>Replace original with &quot;Composition&quot;</translatorcomment>
         <translation>Samenstellingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Wijzig van algemen naar specifiek symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Gebruik oorspronkelijk symbool als sjabloon voor specifiek symbool?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbool %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Raster configureren</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Raster tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Kleef aan raster</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Kiezen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Alle lijnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Horizontale lijnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Vertikale lijnen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Uitlijning</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Uitlijnen naar magnetisch noorden</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Uitlijnen naar raster noorden</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Uitlijnen naar geografisch noorden</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Extra rotatie (tegen de klok in):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Positionering</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>Meters in werkelijkheid</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>Millimeters op de kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Horizontale afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Vertikale afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horizontale verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikale verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Eenheid:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Lijnkleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translatorcomment>Add explanation to tr()</translatorcomment>
         <translation>Weergave:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Kies kleur voor raster</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Nulpunt bij: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>nulpunt van papier-coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>nulpunt van geprojecteerde coördinaten</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klikken of slepen&lt;/b&gt;: Begin de uitsparing te tekenen. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>De snijlijn moet eindigen op de rand van het oppervlak!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Begin en eind van de snijlijn zijn op verschillende delen van het object!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Begin en eind van de snijlijn zijn op dezelfde plaats!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klikken&lt;/b&gt;op een lijn: Lijn splitsen. &lt;b&gt;Slepen&lt;/b&gt; van een lijn: Lijnstuk verwijderen. &lt;b&gt;Klik op of sleep&lt;/b&gt; de rand van een vlak: Begin een gesplitste lijn. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Het opsplitsen van uitsparingen van Objecten is nog niet ondersteen!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Maak uitsnede van de hele kaart. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klik of sleep&lt;/b&gt;: Selecteer de uit te snijden objecten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Maak uitsnede van geselecteerde objecten. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Het bestand kon niet geopend worden.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Dit is geen DXF-bestand.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Bepaal letterformaat</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Letter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -817,261 +830,261 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Verdeel punten evenredig langs pad</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Aantal punten per pad:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Plaats ook punten op uiteinden van pad</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Rotatie instellingen</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Lijn punten uit met lengterichting van lijn</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Extra rotatiehoek (tegen de klok in):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Vanaf middelpunt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Begin cirkel of ellips. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Sleep&lt;/b&gt;: Teken een cirkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>%1 vasthouden om vanuit het midden te tekenen.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Cirkel afmaken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Sleep&lt;/b&gt;: Teken een ellips. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Teken een vrije lijn. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Gestreepte lijn aan.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt;: Kleef aan of voeg toe aan bestaande objecten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt;: Neem richting van bestaande objecten over. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth en lengte. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt;: Kleef aan bestaande objecten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vaste hoeken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Laatste punt ongedaan maken. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Afmaken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Kleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Lijnstuk</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Lengte:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Start een rechte lijn. &lt;b&gt;Slepen&lt;/b&gt;: Start een kromme. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Slepen&lt;/b&gt;: Bestaande objecten volgen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Teken een rechte lijn. &lt;b&gt;Slepen&lt;/b&gt;: Kromme tekenen. &lt;b&gt;Rechts- of dubbelklikken&lt;/b&gt;: Pad afmaken. &lt;b&gt;%1&lt;/b&gt;: Pad afsluiten. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Raak de kaart aan om het middelen af te maken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klikken&lt;/b&gt;: Rond het bewerken van het object af. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Kleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Herstellen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Hoek:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vaste hoeken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Punt-object maken.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Maak een object en bepaal de uitlijning.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Drehung zurücksetzen.</translation>
     </message>
@@ -1081,187 +1094,187 @@
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Afmaken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Kleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Kleef aan voorgaande lijn</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Streep</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klik of sleep&lt;/b&gt;: Start rechthoek. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kleef aan vorige lijnen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Hoekpunt tekenen. &lt;b&gt;Rechts- of dubbelklikken&lt;/b&gt;: Rechthoek afmaken. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Vastkleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Maak de bewerking af. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Wijzigingen ongedaan maken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klikken&lt;/b&gt;: Maak een tekstobject met een enkel ankerpunt. &lt;b&gt;Slepen&lt;/b&gt;: Maak een tekstveld. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Kleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Wissel tussen kromme en rechte</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vrij bewegen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt; op segment: Wissel tussen rechte en kromme. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Kleven</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punt / Hoek</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Wissel streep</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Bewerken afmaken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Tegenoverliggende handvat posities behouden. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt; op punt: verwijderen; op lijn: lijnstuk toevoegen; met &lt;b&gt;%2&lt;/b&gt;: normaal punt toevoegen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt; op punt: verwijderen; op lijn: normaal punt toevoegen; met &lt;b&gt;%2&lt;/b&gt;: lijnstuk toevoegen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klik&lt;/b&gt; op punt: wisselen tussen lijnstuk en normaal punt. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Coördinaten verschuiving:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Afstand:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vaste hoeken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Kleef aan bestaande objecten. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;:Selecteer een enkel object. &lt;b&gt;Slepen&lt;/b&gt;: Selecteer meerdere objecten. &lt;b&gt;%1+Klik&lt;/b&gt;: Wissel selectie. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Verwijder geselecteerde objecten. </translation>
     </message>
 </context>
 <context>
-    <name>EditorPage</name>
+    <name>OpenOrienteering::EditorPage</name>
     <message>
         <source>High quality map display (antialiasing)</source>
         <translation type="obsolete">Hohe Darstellungsqualität (Antialiasing)</translation>
@@ -1350,244 +1363,244 @@
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Hoge kwaliteit kaartweergave (anti-aliasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Anti-aliasing verbetert de kaartweergave, maar maakt het ook trager</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Hoge kwaliteit weergave van tekst op kaart (anti-aliasing), traag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Symbool pictogram grootte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klik marge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Kleef afstand (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Stapgrootte van vaste-hoeken modus (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Automatisch het betreffende symbool selecteren bij selectie van object</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Kaart verkleinen vanuit cursor-middelpunt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Tekengereedschap: Laatste punt plaatsen bij afsluiten met rechter-muisknop</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Sjablonen: instellingen van gesloten sjablonen opslaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Bewerkings gereedschap:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Oude vorm behouden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Handvaten van buitenste kromme herstellen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Handvaten van buitenste kromme behouden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Actie bij het verwijderen van een punt van een kromme met %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Rechthoek-gereedschap:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Straal van hulp-kruis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Voorbeeld tonen van de breedte van lijnen met behulp van hulp-kruis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Bewerker</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Nieuw bestand creëren niet gelukt: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Exporteren naar bestandsformaat (%1) is niet mogelijk</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Het oppervlak van de kaart is groot. Het vul-gereedschap kan erg langzaam werken. Wilt u het toch gebruiken?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Het aangeklikte oppervlak is niet begrensd door lijnen of gebieden. Vullen is niet mogelijk.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>De aangeklikte positie is niet leeg; vullen is niet mogelijk.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Vul-object maken mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Oppervlakken met gekozen symbool vullen. Het te vullen oppervlak moet begrensd zijn met lijnen of gebieden. Andere symbolen worden niet meegenomen. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS staat uit in de apparaatinstellingen. Instellingen openen?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nee</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importeer met GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralPage</name>
+    <name>OpenOrienteering::GeneralPage</name>
     <message>
         <source>Appearance</source>
         <translation type="obsolete">Erscheinungsbild</translation>
@@ -1676,86 +1689,86 @@
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Weergave</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Taal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Beeldscherm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixel per inch:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Programma opstarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Opslaan van bestanden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Compatibiliteit met Mapper %1 behouden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Opslaan herstelgeschiedenis</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Informatie opslaan voor automatisch herstel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>minuten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Interval voor het automatisch opslaan voor herstelgegevens:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Bestands-invoer en -uitvoer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Meer...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-bits kleur-codering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Gebruik de nieuwe OCD-import functie ook voor versie 8 bestanden</translation>
     </message>
@@ -1764,62 +1777,62 @@
         <translation type="vanished">Gebruik de nieuwe OCD-invoer ook voor Versie 8 bestanden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Opmerking</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Het programma moet worden herstart om de gewijzigde taal te gebruiken!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Open taal-bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Taal-bestanden (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Geen geldig taal-bestand gekozen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Hoofdscherm resolutie in pixels:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Grootte (diagonaal) van hoofdscherm in inches:</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM-Coördinaten</translation>
     </message>
@@ -1828,80 +1841,80 @@
         <translation type="obsolete">UTM-Zone (Zahl Nord/Süd, z.B. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM zone (noord/zuid waarde)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krüger coördinaten, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krüger coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Zone nummer (1 tot 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>door de EPSG code</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG code</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Aangepaste PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Lokale coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>specificatie</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Ontbrekende of ongeldige kaartschaal specifictie.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Ongeldige radter schaal factor: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Onbekende coördinatensysteem taalkeuze: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Niet-ondersteund geografische coördinatensysteem: %1</translation>
     </message>
@@ -1910,7 +1923,7 @@
         <translation type="obsolete">Nur Maatstaaf</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokaal</translation>
     </message>
@@ -1920,73 +1933,73 @@
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Geografische uitlijning</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Opzoeken...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Declinatie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Geprojecteerde coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Schaalfactor van het raster:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Geografische coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Referentiepunt aanwijzen in:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>geldig</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Declinatie on-line opvragen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Kaart-coördinaten referentie systeem</translation>
     </message>
@@ -1999,7 +2012,7 @@
         <translation type="obsolete">- aus Proj.4-Spezifikation -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokaal -</translation>
     </message>
@@ -2008,112 +2021,112 @@
         <translation type="obsolete">Coördinatenbezugssystem-Spezifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Referentiepunt</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>Op de &amp;kaart kiezen</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Kaart-noorden</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Coördinatensysteem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Kaartcoördinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Geografische coördinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Bij wijzigen van coördinatensysteems, behoud:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Grivatie (hoek tussen magnetisch noorden en kaart-raster):</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>De magnetische declinatie van het referentiepunt %1° %2° wordt opgevraagd via &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Doorgaan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Declinatie wijziging</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>De declinatie is gewijzigd. Moet de kaart overeenkomstig gedraaid worden?</translation>
     </message>
@@ -2122,154 +2135,154 @@
         <translation type="obsolete">Projizierte Coördinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Lokale coördinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Laden...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>gesloten</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Gegevens konden niet worden doogegeven.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Declinatie niet gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>On-line opvragen van de declinatie is mislukt:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Klik&lt;/b&gt;: Referentiepunt kiezen. Andere knop annuleert.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Clik&lt;/b&gt;: Referentiepunt instellen. &lt;b&gt;Rechter knop&lt;/b&gt;: Ongedaan maken.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Welkom in OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Activiteiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Nieuwe kaart maken...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Open kaart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Over %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Onlangs geopend</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Open laatst bewerkte kaart bij opstarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Lijst wissen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Tip van de dag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Toon tip van de dag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Voorbeelden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Over Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Geen kaarten gevonden!&lt;br/&gt;&lt;br/&gt;Copiëer kaarten naar een top-level directory met naam &apos;OOMAPPER&apos; op het apparaat of geheugenkaart.</translation>
     </message>
@@ -2278,7 +2291,7 @@
         <translation type="vanished">Over Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Bestandslijst</translation>
     </message>
@@ -2288,19 +2301,19 @@
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Fout bij het inlezen van een symbool van type %1, op regel %2, kolom %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symbool-ID &apos;%1&apos; is niet uniek, op regel %2, kolom %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Fout bij inlezen van symbool van type %1, op regel %2, kolom %3: %4</translation>
     </message>
@@ -2309,38 +2322,38 @@
         <translation type="obsolete">Fout beIn Laden eines symbools.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Fout bij inlezen van object van type %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Fout bij inlezen van object van type %1, op %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Geen symbool gevonden voor object op %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Puntobject met ongedefinieerd of ongeldig symbool op %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versie 7/8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
@@ -2349,48 +2362,48 @@
         <translation type="obsolete">Konnte die Daten Niet auswerten.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Doorgeven van de coördinaten mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>%1 Coördinaten verwacht, %2 gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Fout bij het laden van de afdrukinstellingen op %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Fout bij het laden van de herstel-stappen op %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Een dergelijke optie bestaat niet: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Geografische vector informatie</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Object zonder symbool gevonden.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translatorcomment>What is meant with &apos;irregular&apos;? Not-normal? Or not-typical?</translatorcomment>
         <translation>
@@ -2399,18 +2412,18 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Fout bij nabewerken van symbool.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Het sjabloon &quot;%1&quot; is ingelezen uit de directory van de kaart, in plaats van de relatieve locatie ten opzichte van het kaartbestand, waar het eerst stond.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Het is niet gelukt om sjabloon &apos;%1&apos; te openen, om renden: %2</translation>
     </message>
@@ -2419,20 +2432,20 @@
         <translation type="vanished">Inlezen van sjabloon &apos;%1&apos; mislukt, met reden: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Waarschuwingen bij het inlezen van sjabloon &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Ten minste één sjabloon kon niet niet worden gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klik op de rode namen van sjablonen in het &apos;Sjablonen&apos; -&gt; &apos;Sjabloon instellingen&apos; scherm, om de sjabloon-bestanden toe te wijzen.</translation>
     </message>
@@ -2441,174 +2454,174 @@
         <translation type="obsolete">Eine oder mehrere Vorlagen konnten nicht gefunden werden. Klicken Sie die rot markierten Dateinamen unter Vorlagen -&gt; Vorlagen verwalten an, um die Datei(en) zu finden..</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Dit bestand gebruikt een achterhaald formaat. Ondersteuning van dit formaat wordt binnenkort uit het programma verwijderd. Sla het opnieuw op, om het in de toekomst te kunnen opnenen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Ongeldige bestands-formaat versie.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Niet-ondersteund oud bestands-formaat. Gebruik een oudere versie van dit programma om het bestand te openen en in een nieuw formaat op te slaan.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Niet-ondersteund nieuw bestands-formaat. Sommige elementen op de kaart kunnen niet worden gelezen of geschreven door deze versie van het programma. Update het programma, S.V.P.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Het geografisch coördinaten systeem van deze kaart was &quot;%1&quot;. Dit systeem wordt niet ondersteund. In plaats daar van zal &quot;%2&quot; worden gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Fout bij inlezen van een symbool van type %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Fout bij inlezen van een symbool.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Fout bij inlezen van herstelstappen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Fout bij inlezen van het aantal kaart-delen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Fout bij inlezen van kaart-deel %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Inlezen van bestand %1 niet gelukt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Bestands-formaat niet ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Niet-ondersteund nieuw bestands-formaat. Sommige elementen op de kaart kunnen niet worden gelezen of geschreven door deze versie van het programma.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Bestandsformaat (%1) wordt niet ondersteund</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Niet in staat om &apos;%1&apos;: %2 te lezen</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Lijn eigenschappen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Lijnkleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minimale lijnlengte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Lijn uiteinde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>vlak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translatorcomment>Context required: cap vs. join.</translatorcomment>
         <translation>rond</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>vierkant</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>puntig</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Lijnverbinding:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>puntig</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>gevouwen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Lengte van eind van lijn:</translation>
     </message>
@@ -2618,208 +2631,208 @@
         <translation>gestreepte lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Laat ten minste één middensymbool zien</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Minimaal aantal middensymbolen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimaal aantal middensymbolen wanneer gesloten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Streep lengte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Gestreepte lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Onderbrekings lengte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Lijnstrepen groeperen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>geen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Onderbreking binnen lijnstukken:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Halve lengte van de eerste en laatste streep</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Midden-symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translatorcomment>Must be improved.</translatorcomment>
         <translation>Midden-symbolen per punt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Midden-symbool afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Randen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Verschillende randen links en rechts</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Linker rand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Rechter rand:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Beginsymbool</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Middensymbool</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Eindsymbool</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Streep-symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Rand lijnen gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Afstand tussen punten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Afstand van eind van lijn:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Streep-symbool niet gebruiken aan begin en eind van lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Schaal het streep-symbool op de hoeken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Rand breedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Rand kleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translatorcomment>Re-check.</translatorcomment>
         <translation>Rand verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Gestreepte rand</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Lengte rand-strepen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Lengte onderpreking randen:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2830,122 +2843,122 @@ File format not recognized.</source>
 Onbekend bestandsformaat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nieuwe kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>U dient het huidige bestand af te sluiten alvorens een andere te openen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Maak een nieuw kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Openen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Open een bestaand bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Onlangs &amp;geopend</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>Op&amp;slaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Opslaan &amp;als...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Instellingen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Kaart sluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Bestand sluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translatorcomment>Ausführlicher</translatorcomment>
         <translation>De toepassing afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translatorcomment>Kürzer</translatorcomment>
         <translation>&amp;Handleiding</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Toon de handleiding van dit programma</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Over %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Informatie over Qt tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Wilt u de reservekopie erwijderen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Het bestand is gewijzigd.
 Wilt u de wijzigingen opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2954,18 +2967,18 @@ Do you want to scale the symbols to the selected scale?</source>
 Moeten de sybmolen geschaald worden naar de kaart?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>%1 wordt geopend</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Vastloper-waarschuwinging</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Het lijkt er op dat %1 de laatste keer is vastgelopen toen dit bestand werd geopend:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Werkelijk nogmaals proberen?</translation>
     </message>
@@ -2986,92 +2999,93 @@ Moeten de sybmolen geschaald worden naar de kaart?</translation>
         <translation type="obsolete">Automatisches opslaan fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Alle kaarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Bestand opslaan</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Bestand kon niet worden opgeslagen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Er was een probleem bij het bepalen van het bestandsformaat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Meld dit alstublieft als een fout in de toepassing.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Informatie over deze toepassing tonene</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Niet-opgeslagen bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Het bestand is gewijzigd.
 Wilt u de wijzigingen weggooien?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Reservekopie...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Reservekopie mislukt!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Alle gegevens</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translatorcomment>Niet zu übersetzen</translatorcomment>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -3083,23 +3097,23 @@ Kies Nee om een ander formaat te kiezen.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3108,7 +3122,7 @@ because saving as %2 (.%3) is not supported.</source>
 exporteren, omdat opslaan als %2 (.%3) niet wordt ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3123,31 +3137,31 @@ exporteren, omdat dat formaat onbekend is.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Mogelijke problemen bij het exporteren van de kaart.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Interne fout bij opslaan:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Mogelijke problemen bij het importeren van de kaart.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3156,12 +3170,12 @@ for reading.</source>
 om te lezen.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Ongeldig bestandstype.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3172,7 +3186,7 @@ om te lezen.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3181,17 +3195,17 @@ om te lezen.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Niets te importeren.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Vraag</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3200,23 +3214,23 @@ Rescale the imported data?</source>
 Geimporteerde gegevens schalen?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Standaard deel</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nieuwe kleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importeren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Vervangen van symbolen is ongedaan gemaakt.
@@ -3224,207 +3238,207 @@ Desondanks de gegevens importeren?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>CMYK-zwart (alle gedrukte kleuren)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Coordinaten vallen buiten bereik.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Afdrukken...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>De laatste bewerking ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Opnieuw uitvoeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>De laatste bewerking opnieuw uitvoeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>K&amp;nippen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>&amp;Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Plakken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Vergroot</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Verklein</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Wissel volledig scherm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Stel eigen vergrotings-factor in...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Symbolen venster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Symbolen-venster tonen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Kleuren venster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Kleuren-venster tonen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translatorcomment>Replace map file with either map or file</translatorcomment>
         <translation>Vervang de symbolen met die van een ander kaart-bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Alle symbolen schalen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>De complete verzameling symbolen schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Kaartschaal aanpassen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Kaartschaal aanpassen en alle objecten en symbolen mee-schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Aantekeningen bij kaart...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Sjabloon venster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Sjabloon-venster tonen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Sjabloon openen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Toon de hele kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Objecten bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Plaats punt-objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Krommen tekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Cirkels en ellipsen tekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Tekst schrijven</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Klonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Symbool wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translatorcomment>Consider two separate actions or change Tekst according to conTekst</translatorcomment>
         <translation>Vullen of rand maken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Streep-richting omkeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Krommen verbinden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Object afsnijden</translation>
     </message>
@@ -3433,67 +3447,67 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">Object(en) draaien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Lengte en oppervlak opmeten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Uit oppervlak snijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Gaten in oppervlak samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Instellingen voor het tekenen op sjablomen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Aanraak-cursor activeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>GPS-weergave aanzetten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>GPS-afstands-ringen aanzetten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Plaats punt-object op GPS-locatie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Plaats tijdelijke markering op GPS-locatie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Plaats tijdelijke kormme op GPS-locatie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Wis tijdelijke GPS markeringen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Kompas-weergave aanzetten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Kaart met het noorden uitlijnen</translation>
     </message>
@@ -3502,190 +3516,190 @@ Desondanks de gegevens importeren?</translation>
         <translation type="obsolete">Vorlagen-Sichtbarkeit umschalten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Nieuw kaart-deel toevoegen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Huige deel hernoemen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Huidge deel verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Alle delen samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Inlezen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>B&amp;ewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Weergave</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Gereedschappen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Sy&amp;mbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Kaarten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Sjablonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Tekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translatorcomment>To be checked</translatorcomment>
         <translation>Tekenen op sjabloon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Bewerking wordt uitgevoerd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>De kaart wordt momenteel bewerkt. Maak de bewerking af alvorens de kaart op te slaan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Kaart opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Raster tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Raster instellen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Vlakken gestreept weergeven</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Alleen omtrekken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Alle sjablonen verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Verzameling symbolen vervangen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Geografische uitlijning...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Kaart draaien...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>De hele kaart draaien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Sjabloon opnieuw openen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Labels bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Label-venster tonen/verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Rechthoeken tekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Vrij tekenen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Begrenste vlakken vullen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Gat lossnijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Rond gat uitsnijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Rechthoekig gat uitsnijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Patroon draaien</translation>
     </message>
@@ -3694,222 +3708,222 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">Object(en) schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Vlakken samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Overlappende gebieden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Non-equivalentie-operatie (XOR) voor vlakken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Uitsnede</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Wegsnijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Punten verdelen over kromme</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Kaart coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Geprojecteerde coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Lengte/Breedte (decimaal)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Lengte/Breedte (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Coördinaten weergeven als...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Gat snijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl-A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl-I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl-R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl-G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl-F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>NN</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl-M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Alle selecteren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Niets selecteren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Selecte omkeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>ID van de symbolenverzameling...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Bewerk het ID van de symbolenverzameling</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>CRT bestand laden...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Nieuwe symbolen toekennen met behulp van referentie tabel</translation>
     </message>
@@ -3922,81 +3936,81 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">Toon/verberg het label-keuze window</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Loctie copieren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Loctie copieren naar klembord.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Weergave</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Kaart-delen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Sjabloon kiezen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Bijzondere bewerking</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Symbool kiezen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Bovenste balk verbergen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Bovenste balk tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Afdrukken / opslaan is niet beschikbaar in deze versie van het programma!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Geen herstelstappen geschikbaar.</translation>
     </message>
@@ -4006,8 +4020,8 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">%1 object(en) wegsnijden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Er is een interne fout opgetreden. Het spijt ons verschrikkelijk!</translation>
     </message>
@@ -4016,7 +4030,7 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">%1 object(en) gecopieerd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Er zijn geen objecten op het klembord die ingevoegd kunnen worden!</translation>
     </message>
@@ -4025,68 +4039,68 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">%1 object(en) ingevoegd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Stel eigen vergrotings factor in</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Vergrotingsfactor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Kleuren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>ID van de symbolenverzameling</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Bewerk het ID van de symbolenverzameling:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Alle symbolen schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Schalen tot percentage:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Aantekeningen bij kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translatorcomment>FIXME: Ersetzen durch ButtonBox.</translatorcomment>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Sjablonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Labels bewerken</translation>
     </message>
@@ -4095,7 +4109,7 @@ Desondanks de gegevens importeren?</translation>
         <translation type="vanished">Label keuze</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4105,7 +4119,7 @@ symbool
 gekozen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4115,43 +4129,43 @@ symbolen
 gekozen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Plaats punt-objecten op kaart.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Selecteer een punt-symbool om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translatorcomment>More information</translatorcomment>
         <translation>Teken polygonen en krommen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translatorcomment>Distinction between line and combined symbool probably not relevant here.</translatorcomment>
         <translation>Selecteer een lijn, gebied, of gecombineerd symbool om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Cirkels en ellipsen tekenen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Vrije krommen tekenen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Begrenste vlakken vullen.</translation>
     </message>
@@ -4160,110 +4174,110 @@ gekozen</translation>
         <translation type="vanished">Verwijder geselecteerde object(en).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Kies de oriëntatie van vlakvullingen of punt-objecten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Selecteer een oppervlak met een draaibaar vul-patroon of een draaibaar punt-object om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Resulterend symbool: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Selecteer ten minste twee gebieden of lijnen om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Voeg overlappende objecten samen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Verwijder alle delen die niet overlappen met het eerste gekozen object.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Verwijder alle overlappende delen van het eerste gekozen object.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Verwijder alle delen die overlappen met het eerste gekozen object.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translatorcomment>Kromme zin</translatorcomment>
         <translation>Gaten in het vlak samenvoegen, of gaten samenvoegen met de rand van het object om dit deel uit te snijden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Selecteer een vlak met gaten om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Maak een uitsnede van sommige objecten of van de hele kaart.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Selecteer een gesloten lijn die als uitsnede dient, om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Snij sommige objecten weg, of alles in een beperkt gebied.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Plaats gelijkmatig verdeelde punt-objecten langs een bestaande lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Seletcteer ten minsten een lijn-object an een enkel punt-symbool, om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Samenvoegen van gaten is niet gelukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Tijdelijke mertekens verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Is het de bedoeling om alle tijdelijke GPS merktekens te verwijderen? Dit kan niet ongedaan worden gemaakt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Dit deel samenvoegen met</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Geselecteerde objecten verplaatsen naar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Voer de naam van het kaart-deel in:</translation>
     </message>
@@ -4272,88 +4286,88 @@ gekozen</translation>
         <translation type="obsolete">Wollen Sie Kartenteil &quot;%1&quot; mit allen seinen Objekten entfernen? Das kann nicht rückgangig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Kaartdelen samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Is het de bedoeling om alle objecten van kaartdeel &quot;%1&quot; naar &quot;%2&quot; te verplatsen, en deel &quot;%1&quot; te verwijderen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Is het de bedoeling om alle objecten naar kaartdeel &quot;%1&quot; te verplatsen, en alle andere kaartdelen te verwijderen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Het gekozen kaart-bestand kan niet worden geimporteerd omdat het bestand niet kan worden gelezen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Rechthoeken tekenen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>Afbeeld&amp;ing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Herstel/herhaal-geschiedenis wissen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Wis de herstel/herhaal-geschiedenis om de grootte van het kaart-bestand te reduceren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Verschuiven</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Overdrukken simuleren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Lijnen bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Verander in krommen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Pad vereenvoudigen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exporteren als...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Schrijf tekst op de kaart.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Selecteer een tekst symbool om dit gereedschap te kunnen gebruiken.</translation>
     </message>
@@ -4362,26 +4376,26 @@ gekozen</translation>
         <translation type="vanished">Dupliceer geselecteerde object(en).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Selecteer ten minste één object om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Wissel de richting van symbolen op lijn-objecten om.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Selecteer ten minste één lijn-object om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Verbind eindpunten van paden die dicht bij elkaar liggen.</translation>
     </message>
@@ -4390,17 +4404,17 @@ gekozen</translation>
         <translation type="vanished">Knip geslecteerde object(en) in kleinere delen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Kies ten minste één lijn of vlak object om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Knip een gat in het gekozen vlak.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Kies een enkel vlak om dit gereedschap te kunnen gebruiken.</translation>
     </message>
@@ -4413,18 +4427,18 @@ gekozen</translation>
         <translation type="vanished">Schaal gekozen object(en).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Verander paden van rechte lijnstukken in gladde Bezier krommen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Kies een pad om dit gereedschap te kunnen gebruiken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Verminder het aantal punten van pad-objecten met behoud van hun vorm.</translation>
     </message>
@@ -4433,8 +4447,8 @@ gekozen</translation>
         <translation type="vanished">Verander het symbool van gekozen object(en) in het gekozen symbool.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Kies ten minste een object en een passend, ander symbool, om dit gereedschap te kunnen gebruiken.</translation>
     </message>
@@ -4447,7 +4461,7 @@ gekozen</translation>
         <translation type="vanished">%1 objecten verdubbeld</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Object keuze</translation>
     </message>
@@ -4456,83 +4470,83 @@ gekozen</translation>
         <translation type="vanished">Er zijn geen objecten gekozen omdat er geen objecten zijn met het/de gekozen sybool/symbolen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Meten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Samenvoegings-operatie mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Doorsnijdings-operatie mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Verschil-operatie mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOR-operatie mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Is het de bedoeling om kaart-deel &quot;%1&quot; en all zijn objecten te verwijderen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Actief kaart-deel gewijzigd naar &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Vrij tekenen op een sjabloon</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translatorcomment>First part duplicated. Check punctuation.</translatorcomment>
         <translation>Vrij tekenen op een sjabloon. Maak een jabloon of lees er een in, waar op getekend kan worden, om dit gereedschap te kunnen gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>%1, GPX, OSM of DFX bestand importeren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importeerbare bestanden</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Alle gegevens</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Het gekozen bestand kan niet worden geimporteerd omdat het bestands-formaat niet wordt ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Draai objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Schaal objecten</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4541,7 +4555,7 @@ gekozen</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>%n object gekopieerd</numerusform>
@@ -4549,7 +4563,7 @@ gekozen</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>%n object geplakt</numerusform>
@@ -4557,42 +4571,42 @@ gekozen</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Verwijdert de gekozen objecten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Kloon de gekozen objecten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Draai de gekozen objecten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Schaal de gekozen objecten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Knip de gekozen objecten in kleinere stukken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Wijzig het symbool van de gekozen objecten naar het gekozen symbool.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Vul de gekozen lijnen of creëer een rand voor de gekozen gebieden.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>%n object gekloond</numerusform>
@@ -4600,178 +4614,178 @@ gekozen</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Er zijn geen objecten gekozen omdat er geen objecten zijn met de gekozen symbolen.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Afbreken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Meer: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Meer: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Meer: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Zoeken...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Zoeken &amp;volgende</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Zoek objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Zoek volgende</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Zoek &amp;alle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Zoek-vraag bewerken</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Kaart -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Verwerken van kleurscheidingen van pagina %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Verwerken van pagina %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Afgebroken</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Klaar</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Oorspronkelijke tekst:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Kaart (%!)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>onbekende taal</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Vertaling (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Voor het bewerken zal de opgeslagen tekst worden vervangen door de huidige vertaling. Doorgaan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Na het aanpassen van de opgeslagen tekst kan de vertaling eventueel niet meer teruggevonden worden. Doorgaan?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4786,7 +4800,7 @@ om de kleur-diagloog te openen
 en kies daar de kleuren.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4802,7 +4816,7 @@ in de symbolenlijst en kies
 om er een aan te maken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4815,7 +4829,7 @@ Om een sjabloon te kiezen, klik
 Sjablonen -&gt; Open sjabloon...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Aanwijzing: Gebruik de middelste muisknop om de kaart te verslepen,
@@ -4823,124 +4837,124 @@ en gebruik -indien beschikbaar- het muiswiel om uit te vergroten/verkleinen.</tr
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Lengte van omtrek:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Oppervlak:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Geen objecten geselecteerd.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objecten geselecteerd.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Het geselecteerde object is geen pad.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Dit object is te klein.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Het minimale oppervlak is %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Let op: Omtrek en oppervlak kloppen alleen als er geen zelf-doorsnijdingen zijn, en gaten als zodanig zijn gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Deze lijn is te kort.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>De minimum lengte is %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Nieuwe kaart maken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Kies de schaal en de verzameling symbolen voor de nieuwe kaart.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translatorcomment>Check spaces.</translatorcomment>
         <translation>Schaal:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Verzameling symbolen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Toon alleen verzamelingen symbolen die overeenkomen met de gekozen schaal</translation>
     </message>
@@ -4949,140 +4963,140 @@ en gebruik -indien beschikbaar- het muiswiel om uit te vergroten/verkleinen.</tr
         <translation type="vanished">Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Creëren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Lege verzameling symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Verzameling symbolen laden uit bestand...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Alle bestanden met verzamelingen symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Alle gegevens</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>De kaart bevat meer dan 256 kleuren, wat doro ocd-versie 8 niet wordt ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad-fout %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Process-zwart is als reguliere kleur opgeslagen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Het is niet mogelijk op vlak-vullings verschuiving voor een oppervlak-object te exporteren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Het is niet mogelijk om het sjabloon te exporteren: bestanden met type &quot;%1&quot; worden nog niet ondersteund</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Coördinaten zijn aangepast om binnen het OCAD 8 werkgebied te passen (-2 m ... 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Enkele coördinaten vallen nog buiten het OCAD 8 werkgebied. Deze zouden niet bereikbaar kunnen zijn in OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>De combinatie van uiteinde/knikpunt van lijn-symbool &quot;%1&quot; kan niet worden weergegeven.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Streep-groepering in lijn-symbool &quot;%1&quot; is weggelaten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Het aantal strepen in een groep in lijn-symbool &quot;%1&quot; is teruggebracht tot 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>De randen in lijn-symbool &quot;%1&quot; kunnen niet correct worden geëxporteerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Vulpatroon in vlak-symbool &quot;%1&quot; is weggelaten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Aangenomen werd dat een &quot;verschoven rijen&quot; punten-patroon werd bedoeld in vlak-symbool &quot;%1&quot;. Dan kan wel of niet juist zijn.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>In tekst-symbool &quot;%1&quot; is een aangepaste letter-afstand gebuikt. De implementatie daar van komt nog niet overeen met het gedrag van OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>De onderstreping van tekst-symbool &quot;%1&quot; is achterwege gelaten</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>De afspatiëring in tekst-symbool &quot;%1&quot; is niet toegepast</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Regel afgebroken (afbreekplaats is met drie &apos;|&apos; aangegeven): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Kan buffer niet alloceren.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad-fout %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD-bestanden in versie %1 worden niet ondersteund!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>Een kleurscheiding is overgeslagen, met reden: Importeren is uitgezet.</numerusform>
@@ -5090,334 +5104,334 @@ en gebruik -indien beschikbaar- het muiswiel om uit te vergroten/verkleinen.</tr
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Inlezen van steunkleur-definities mislukt, fout: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Kleur &quot;CMYK-zwart&quot; is als speciale kleur geimporteerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Kan symbool &quot;%3&quot; (%1.%2) niet importeren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD-import laag</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>In gestreept lijn-symbool %1 sind de lengtes voor de uiteinden aan het begin en eind verschillend (%2 and %3); %4 wordt gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>In gestreept lijn-symbool %1 kan de lengte van het eindpunt niet correct geimporteerd worden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>In gestreept lijn-symbool %1 kan de opening van het eindpunt niet correct geimporteerd worden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>In gestreept lijn-symbool %1 zijn de hoofd- en eind-lengte verschillend (%2 en %3); %4 wordt gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>In gestreept lijn-symbool %1 zijn de opengingen D en E verschillend (%2 and %3); %4 wordt bebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Lijn-symbool %1: het streep-symbool aan de uiteinden is weggelaten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Negeer uitvulling bij importeren van tekstsymbool %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Negeer aangepaste lettergrootte (%2) bij importeren van tekstsymbool %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Bij het importeren van tekstsymbool %1: een aangepaste letter-afstand gebuikt, waarvan de implementatie nog niet overeenkomt met het gedrag van OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Negeer aangepaste woord-afstand (%2%) bij het importeren van tekstsymbool %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Negeer aangepast inspringen (%2/%3) bij het importeren van tekstsymbool %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Negeer tekst-omlijning (modus %2) bij het importeren van tekstsymbool %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Kan object niet laden</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Kan rechthoekig object niet importeren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tekstsymbool niet geimporteerd: interpreteren van kromme niet gelukt (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Sjabloon importeren mislukt: achtergrond &quot;%1&quot; lijkt geen raster-afbeelding te zijn</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Poging tot importeren van tekstobject met onbekend coördinaten-formaat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Kleur-ID niet gevonden: %1; deze kleur wordt genegeerd</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>is</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>is niet</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>bevat</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>en</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>of</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symbool</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>ongeldig</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>In lijn-symbool %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>In tekst-symbool %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Laden van coördinatensysteem &apos;%1&apos; niet gelukt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Steunkleur informatie is genegeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Kan symbool %1.%2 &quot;%3&quot; niet importeren: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Niet-ondersteund type &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Kan sjabloon niet importeren: &quot;%1&quot; is geen ondersteund sjabloon type.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>DIt symbool kan niet (opnieuw) worden opgeslagen als een geldig OCAD symbool.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Niet-ondersteunde lijnstijl &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Verschillende lengtes voor de uiteinden aan het begin (%1 mm) en einde (%2 mm) worden niet onderstuend; daarom wordt %3 mm gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Het strepen-patroon kan niet correct worden geimporteerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>De eind-lengte van het strepen-patroon (%1 mm) kan niet correct worden geimporteerd; daarom wordt %2 mm gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>De eind-ruimte van het strepen-patroon (%1 mm) kan niet correct worden geimporteerd; daarom wordt %2 mm gebruikt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Niet-ondersteunde stijl van omlijnging &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Secundair punt-sybool is weggelaten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Streep-sybool aan de uiteinden van de lijn wordt weggelaten.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Uitvullen wordt niet ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Vertikale uitlijning &apos;%1&apos; wordt niet ondersteund.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Aangepast gewicht van letters (%1) is genegeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Aangepaste letterafstand kan onjuist zijn.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Aangepaste woord-afstand (%1 %) is genegeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Aangepast inspringen (%1/%2) is genegeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Aangepaste tekst-omlijning (Art %1) is genegeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Lijn-tekst symbolen worden nog niet onderstuend. Het symbool wordt nu als verborgen gemarkeerd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Coderen van &apos;%1&apos; is niet mogelijk. Controleer de instellingen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>In vlak-symbool %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Kan object niet laden</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Kan rechthoekig opject niet importeren</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Tekst-symbool niet geimporteerd: niet gelukt om kromme te interpreteren (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Poging tot importeren van tekst-object met onbekend coördinatenformaat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Ongeldige gegevens.</translation>
     </message>
@@ -5426,59 +5440,59 @@ en gebruik -indien beschikbaar- het muiswiel om uit te vergroten/verkleinen.</tr
         <translation type="obsolete">Ungetestete Importfunktion voor Gegevensformat OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD-bestanden van Version %1 worden niet ondersteund!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Kleur-ID niet gevonden: %1; deze kleur wordt genegeerd</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Niet in staat om &quot;%1&quot; SRS voor GDAL in te stellen: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Paars</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Oppervlak</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Niet in staat om laag %1 te laden.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Niet in staat om %n object te laden, vanwege %1</numerusform>
@@ -5486,460 +5500,447 @@ en gebruik -indien beschikbaar- het muiswiel om uit te vergroten/verkleinen.</tr
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Lege geometrie.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Kan de coördinatentransformatie niet bepalen: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Het is niet gelukt om de coördinaten te transformeren.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Onbekend of niet ondersteund geometrie type.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Niet voldoende coördinaten.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Ongeschikte ruimtelijke referentie:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>De geospatiale gegevens hebben geen geschikte referentie.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Oriëntatiekaart</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Software voor het tekenen van oriëntatiekaarten</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Kies sjabloon om op te tekenen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Annuleer</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Tekenen</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klikken en slepen&lt;/b&gt;: Tekenen. &lt;b&gt;Rechts-klikken en slepen&lt;/b&gt;: Wissen. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Kleurkeuze</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Sleep&lt;/b&gt;: Kaart verschuiven. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Coordinaat toevoegen. &lt;b&gt;%1+Klic&lt;/b&gt;: Gekozen coordinaat aanpassen. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Altijd naar het noorden uitlijnen (niet draaibaar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Oppervlak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Alle elemente centreren</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Huidige element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diameter &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Kleur binnenkant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Buitenste afmeting &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Kleur buitenkant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Lijnkleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Lijn uiteinde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>vlak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>rond</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>vierkant</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Lijn-verbinding:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>punt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>vlak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Gesloten lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Kleur vlak:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Coördinaten:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Begin van kormme</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centeren op zwaartepunt van coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Middelpunt]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Onbekend</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Punt symbool</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Afdrukken bezig</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Er is een fout opgetreden bij het verwerken.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Verschuif kaart, afdrukzone, of randen van de afdrukzone. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Verschuif afdrukzone. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Kaart verschuiven. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Verschuif rand van de afdrukzone. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Verschuif randen van de afdrukzone. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Sjablonen tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Raster tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Pagina oriëntatie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Printer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Staand</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Liggend</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Papierformaat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopieën:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Bovenzijde:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vector
 graphics</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Raster
 afbeelding</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Kleurscheidingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Voorbeeld...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Enkele pagina</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Gebied naar keuze</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Kaart oppervlak:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Afdruk centreren</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Pagina overlap:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
@@ -5952,193 +5953,193 @@ separations</source>
         <translation type="vanished">Kleurscheidingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Resolutie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Afdrukken op andere schaal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Sjabloon weergave kan afwijken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Overdrukken nabootsen</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Apparaat CMYK (Cyaan-Magenta-Geel-Zwart; experimenteel)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Kleurmodus:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exporteren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Opslaan als PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Opslaan als afbeelding</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Opslaan als PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Niet ondersteund onder Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Afdrukvoorbeeld maken mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Voortgang afdrukvoorbeeld</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Een niet-standaard weergave is gekozen. Is het de bedoeling om de kaart als zodanig te pringen of the exporteren?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Afbeelding voorbereiden mislukt. Niet genoeg geheugen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Export van PDF bestand mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Kaart exporteren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Alle bestanden (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translatorcomment>Check original.</translatorcomment>
         <translation>Afbeelding opslaan mislukt. Bestaad de directory wel? Heeft u daar schrijfrechten?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Exporteren naar %1 is gelukt</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>PDF export mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Afdruk voorbereiding mislukt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Afdruk voortgang</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translatorcomment>Check original</translatorcomment>
         <translation>Geannuleerd.</translation>
@@ -6148,181 +6149,181 @@ separations</source>
         <translation type="vanished">Afdrukken bezig</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>De adrukopdracht kon niet worden afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Afdrukopdracht succesvol aangemaakt</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Er is een fout opgetreden tijdens afdrukken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Onbekend</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>De kaart-zone is leeg. Uitvoer is afgebroken.</translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Coördinatensysteem:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Sjabloon opnieuw openen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Sleep items van de linker lijst naar de juiste plek in de rechter lijst om ze opnieuw te laden.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Afgesloten sjablonen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Lijst wissen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Actieve sjablonen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Kaart -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Vervant verzameling symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Instellen hoe de symbolen moeten worden vervangen, en welke.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Alle nieuwe symbolen importeren, zelfs als ze niet ter vervanging dienen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Oorspronkelijke symbolen, die na vervangen niet meer worden gebruikt, verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Kleuren löschen, die nach der Ersetzung ungenutzt sind</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Symbool-omzetting:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Behoud de verborgen/beschermd status van de oude verzameling symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Vind overeenkomende symbolen ter vervanging aan de hand van symbool-nummer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Origineel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Bewerkt het ID van de symbolenverzameling:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Vervanging</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Zoek overeenkomstige symbool namen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Nieuw symbolen toekennen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Patroon</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Wis vervangingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Open CRT bestand...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>CRT bestand opslaan...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Symbool omzetting</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT bestand</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Er is een veelvoud aan vervangingen voor symbool %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6333,7 +6334,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6344,281 +6345,281 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>De referentie tabel is aangepast.
 Wijzigingen opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Geen -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Kies kaart-bestand om sybolen van in te lezen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Inlezen kaart-bestand mislukt; afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>De gekozen verzameling symbolen heeft een schaal van 1:%1, terwijl de schaal van de kaart 1:%2 is. Is dit de bedoeling?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>CRT bestand laden mislukt. Actie afgebroken.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Kaart draaien</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Hoek (linksom):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parameters voor draaiing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Draaiings middelpunt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Oorsprong van het kaart-coördinatensysteem</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Referentiepunt van de geografische uitlijning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Ander punt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Referentiepunt voor geografische uitlijning aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Declinatie voor geografische uitlijning aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Niet-geografisch gerefereerd sjabloon draaien</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Hoek:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vaste hoeken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Kies de oriëntatie van vlakvullingen of punt-objecten. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotatie:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Vaste hoeken. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Draaiingsmiddelpunt kiezen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: De gekozen objecten draaien. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Kaartschaal aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Parameters voor schaling</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nieuwe schaal:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Schalings middelpunt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Oorsprong van het kaart-coördinatensysteem</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Referentiepunt van de geografische uitlijning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Ander punt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Symbolen schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Schalen van positie van kaart-objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Referentiepunt voor geografische uitlijning aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Niet-geografisch gerefereerd sjabloon schalen</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translatorcomment>TODO: Check proper % escaping.</translatorcomment>
         <translation>&lt;b&gt;Schaling:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Schalingsmiddelpunt kiezen. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Afmeting van de geselecteerde objecten aanpassen. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Kies coördinatensysteem</translation>
     </message>
@@ -6627,17 +6628,17 @@ Wijzigingen opslaan?</translation>
         <translation type="obsolete">Gleiches wie das der Kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Gelijk aan kaart</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokaal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Geografische coördinaten (WGS 84)</translation>
     </message>
@@ -6658,181 +6659,181 @@ Wijzigingen opslaan?</translation>
         <translation type="obsolete">Coördinatenbezugssystem-Spezifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>geldig</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; is opgeslagen op een standaard locatie.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; bevindt zich in de z.g. &quot;app storage&quot;. De bestanden zullen verdwijnen wanneer OOMapper wordt gedeïnstalleerd.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; is not beschrijfbaar. Wijzigingen kunnen niet worden gewaard.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; is geen geldige bestandslocatie.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- geen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Geen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nummer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Beschrijving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Hulpsymbool (niet zichtbaar op uiteindelijke kaart)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Beschrijving</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Voor symbolen met beschrijving, toon deze door op F1 te drukken zodra de &apos;tooltip&apos; zichtbaar is</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nieuw symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Oppervlak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Samengevoegd</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Bewerken</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Klonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Schalen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
@@ -6845,12 +6846,12 @@ Wijzigingen opslaan?</translation>
         <translation type="vanished">Vul of maak rand om gekozen object(en)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>symbolen kiezen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Activeer sleur en pleur</translation>
     </message>
@@ -6859,72 +6860,72 @@ Wijzigingen opslaan?</translation>
         <translation type="vanished">Symbool of symbolen schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Er is een interne fout opgetreden. Onze excuses.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Het klembord bevat geen symbolen die hier ingevoegd kunnen worden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Selecteer alle objecten met dit symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Voeg alle objecten met dit symbool toe aan de selectie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Verwijder alle objecdten met dit symbool uit de selectie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Verbert alle objecten met dit symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Projecteer alle objecten met dit symbool</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Voeg alle objecten met de geselecteerde symbolen toe aan de selectie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Verwijder alle objecten met de geselecteerde symbolen uit de selectie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Verberg alle objecten met de geselecteerde symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Bescherm alle objecten met de geselecteerde symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Selecteer alles</translation>
     </message>
@@ -6934,122 +6935,122 @@ Wijzigingen opslaan?</translation>
         <translation type="vanished">F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Slecteer ongebruikte</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Wissel de selectie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Sorteer symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Sorteer symbolen op nummer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Sorteer symbolen op kleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Sorteer symbolen op prioriteit van hun primaire kleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Schaal naar percentage:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>De kaart bevat objecten met symbool &quot;%1&quot;. Door het te verwijderen worden deze objecten ook vewijderen evenals de herstel geschiedenis! Is dat echt de bedoeling?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Selecteer alle objecten met de geselecteerde symbolen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Wijzig het symbool van de gekozen objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Full / creëer rand voor de gekozen objecten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Schaal symbolen</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Symbool instellingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Sjabloon:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Sjabloon:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translatorcomment>Standardize &quot;(none)&quot; vs &quot;- none -&quot;</translatorcomment>
         <translation>(geen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Openen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Sjabloon centreren...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>Omhullende rond oorsprong</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Zwaartepunt rond oorsprong</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Kies achtergrondkleur</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -7061,58 +7062,58 @@ van de wijs
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- zonder naam -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Geen beschrijving!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Verband</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Vergelijking</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Voeg rij toe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Verwijder rij</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Verplaats omhoog</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Verplaats omlaag</translation>
     </message>
@@ -7125,7 +7126,7 @@ van de wijs
         <translation type="vanished">Help</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n object geselecteerd</numerusform>
@@ -7133,70 +7134,70 @@ van de wijs
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Ongeldige zoekterm</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Naam bestaat al</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>De naam  &quot;%1&quot; bestaat reeds en mag niet nogmaals gebruikt worden.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Zoek het verplaatste sjabloon-bestand</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Alle bestanden (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Geen dergelijk bestand.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Is het formaat van het bestand juist voor dit sjabloon type?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Onvoldoende beschikbaar geheugen.</translation>
     </message>
@@ -7206,134 +7207,134 @@ van de wijs
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Sjabloon aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Berekenen van aanpassign is mislukt!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Bepaal de positie van het paspunt op het sjabloon. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Bepaal de positie van het paspunt op de kaart. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klik&lt;/b&gt;: Verwijder paspunt. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt;: Paspunt verslepen. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Paspunten:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Verslepen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Sjabloon-X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Sjabloon-Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Kaart-X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Kaart-Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Paspunten toepassen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Toepassen &amp;&amp; allemaal verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Allemaal verwijderen</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Niet genoeg vrij geheugen beschikbaar (afbeelding: %1x%2 pixels)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7342,84 +7343,84 @@ Opslaan van GIF afbeeldingen wordt niet ondersteen. Dat betekent dat bewerkingen
 Indien dat toch niet de bedoeling is, is dat geen probleem.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Kies het coördinatensysteem van de coördinaten in de World file</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>%1 wordt geopend</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Afbeeldings grootte:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Geef aan hoe de afbeelding te positioneren of te schalen:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>World-file</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>geen geografische referentie informatie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Gegrafies gerefereeerd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Meter per pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Gescand met</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Sjabloon schaal: 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7428,342 +7429,342 @@ Indien dat toch niet de bedoeling is, is dat geen probleem.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Transparantie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Groep</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Tonen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Open...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Dupliceren</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Schets</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Sjabloon toevoegen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Verplaats omhoog</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Verplaats omlaag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Geografische referentie: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Handmatig verschuiven</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Aanpassen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Positionering...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importeren en verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Kaart, afbeelding, GPX-route of DXF bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Sjabloon bestanden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Alle gegevens</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>File formaat niet herkend.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Sjabloon laden mislukt. Bestaat het bestand en is het geldig?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Voer een geldig geheel getal in om een groep aan te geven, of laat leeg om het sjabloon aan geen enkele groep toe te wijzen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Schalen volgens nominale schaal van de kaart (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Schalen volgens schaal van huidige sjaboon (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Niet schalen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Importeer sjabloon</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Hoe moeten de symbolen van het geimporteerde sjabloon geschaald worden?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Het sjabloon zal onzichbaar zijn in de &apos;overprint&apos; simulatie. Omschakelen naar normale weergave?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Kaart -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Slepen&lt;/b&gt; om de huidige achtergrond te verschuiven</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Positionering</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Schaal:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Schaal:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Oriëntatie:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Schaling en positionering van spoor (&quot;track&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Coördinatensysteem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Werkelijkheid</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Kaart</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Een coördinateneenheid komt overeen met:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Positioneer spoor (&quot;track&quot;) op de aangegeven coördinaten</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Positioneer spoor (&quot;track&quot;) in het midden van het beeld</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Dit sjabloon moet worden geladen met GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translatorcomment>tracks is beter dan routes in deze contekst</translatorcomment>
         <translation>Kies het referentiecoördinatensysteem voor de coördinaten van de sporen (&quot;tracks&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translatorcomment>Track is beter dan route in deze contekst</translatorcomment>
         <translation>Spoor (&quot;track&quot;) openen ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Kromme (&quot;track&quot;) inlezen in geografisch gerefereerde of niet-geografisch gerefereerde modus?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Plaatst het pad (&quot;track&quot;) volgens de geografische uitlijning van de kaart.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translatorcomment>Add explanation for &quot;these&quot;.</translatorcomment>
         <translation>Deze zijn nog niet ingesteld, en worden dus getoond in de volgende stap.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Geografisce uitgelijnd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Niet-geografisce uitgelijnd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translatorcomment>Track is beter dan route in deze contekst</translatorcomment>
         <translation>Parallelprojectie van het pad (&quot;track&quot;) met als centrum het gemiddelde van de coördinaten van het pad. Aanpassing van de transformatie is mogelijk. De geografische uitlijning van de kaart kan worden aangepast met de positie van het pad.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Het pad is leeg, er valt niets te importeren!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Vragen</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Moeten de punten worden geimporteerd als een lijn door alle punten?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Porblemen bij importeren</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n pad-object kon niet geimporteerd worden (reden: ontbrekende coördinaten).</numerusform>
@@ -7771,12 +7772,12 @@ Indien dat toch niet de bedoeling is, is dat geen probleem.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Leesfout</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7785,39 +7786,39 @@ Indien dat toch niet de bedoeling is, is dat geen probleem.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Geen OSM-bestand.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Het OSM-bestand heeft versie %1.
 De oudste  ondersteunde versie is %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Het OSM-bestand heeft versie %1.
 De nieuwste ondersteunde versie is %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemen</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 lijn-punten konen niet correct verwerkt worden.</translation>
     </message>
 </context>
 <context>
-    <name>TemplateWidget</name>
+    <name>OpenOrienteering::TemplateWidget</name>
     <message>
         <source>Show</source>
         <translation type="vanished">Tonen</translation>
@@ -7957,7 +7958,7 @@ Vorlage konnte Niet geladen werden. Existiert deze Gegevens?</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Externe koppeling: %1</translation>
@@ -7968,80 +7969,80 @@ Vorlage konnte Niet geladen werden. Existiert deze Gegevens?</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Uitlijning</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Midden</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Boven</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Basislijn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Onder</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Tekstinstellingen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Lettertype:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Letterformaat:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
@@ -8050,272 +8051,272 @@ Vorlage konnte Niet geladen werden. Existiert deze Gegevens?</translation>
         <translation type="vanished">Grootte bepalen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Tekst kleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>vet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>cursief</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translatorcomment>or &quot;underline&quot;/&quot;unterstreichen&quot;</translatorcomment>
         <translation>understreept</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Tekst stijl:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Regelafstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Paragraaf afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Letter afstand:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Afspatiëring</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Symbool pictogram tekst:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Omlijsting</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Instellingen voor OCAD compatibiliteit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Kleur omlijsting:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Omlijsting (lijn)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Schaduw omlijsting</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Links/rechts-verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Op/neer-verschuiving:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD compatibiliteit</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>actief</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Lijnkleur:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Positie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Lijn onder paragraaf</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Afstand van basis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Aangepaste tab posities</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Aangepaste tab toevoegen</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Berekenen</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translatorcomment>Original diskutabel</translatorcomment>
         <translation>Ongedaan maken is niet mogelijk, omdat de laatste herstel-stap inmiddels ongeldig is geworden (bijvoorbeeld omdat het symbool van een object is gewijzigd, en het oude symbool is verwijderd).</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Deze stap ongedaan maken gaat verder terug dan het punt waarop het bestand is geladen. Is dat de bedoeling?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Ongedaan maken is niet mogelijk, omdat de eerste herstel-stap inmiddels ongeldig is geworden (bijvoorbeeld omdat het symbool van een zojuist getekend object is verwijderd).</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Help-bestanden konden niet gevanden worden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Help-Programma (&quot;Qt Assistant&quot;) kon niet gevanden worden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Help-Programma (&quot;Qt Assistant&quot;) kon niet opgestart worden.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Meer lezen...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Oudere versies van Mapper ondersteunen geen meerder kaartlagen. Om de kaart in voor die versies leesbaar formaat op te slaan,dien je eerst alle lagen van de kaart samen te voegen.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Element niet ondersteund: %1 (regel %2 kolom %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Delen van dit bestand kunnen niet worden gelezen met Mapper. De minimaal vereiste versie is %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Fout in regel %1, kolom %2: %3</translation>
     </message>
@@ -8324,49 +8325,49 @@ Vorlage konnte Niet geladen werden. Existiert deze Gegevens?</translation>
         <translation type="vanished">De aantekeningen van de kaart konden niet worden ingelezen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Sommige ongeldige karakters zijn verwijderd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Onbekende fout</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Niet-ondersteunde of ongeldige geografische uitlijning &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Uitspaar-eigenschap van kleur &apos;%1&apos; kon niet worden ingesteld.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>%1 kleuren veracht, maar %2 gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Steunkleur %1 niet gevonden bij bewerking van %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>%1 symbolen verwacht, maar %2 gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>%1 kaart-delen verwacht, %2 gevonden.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Sommige coördinaten vielen buiten het afdrukbereik. De inhoud van de kaart is aangepast.</translation>
     </message>

--- a/translations/OpenOrienteering_pl.ts
+++ b/translations/OpenOrienteering_pl.ts
@@ -2,9 +2,22 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pl_PL">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Dziękujemy za wkład:</translation>
     </message>
@@ -13,8 +26,8 @@
         <translation type="vanished">Dodatkowe informacje</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>O nas %1</translation>
     </message>
@@ -32,7 +45,7 @@
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Darmowy program do kreślenia map do BnO</translation>
@@ -50,229 +63,229 @@
         <translation type="vanished">Ten program wykorzystuje bibliotekę &lt;b&gt;Clipper&lt;/b&gt; Angusa Johnsona.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>Twórca projektu</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Wszystko na temat licencji, informacji o prawach autorskich, warunkach oraz zastrzeżeń.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Developerzy OpenOrienteering w uporządkowaniu alfabetycznym:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Niniejszy program jest darmowym oprogramowaniem: możesz rozprowadzać go dalej lub/i modyfikować na zasadach &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt; opublikowanych przez Free Software Fundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Niniejszy program jest publikowany w nadziei, że będzie użyteczny, lecz BEZ ŻADNEJ GWARANCJI; nawet bez gwarancji PRZYDATNOŚCI HANDLOWEJ lub PRZYDATNOŚCI DO OKREŚLONEGO CELU. &lt;a %1&gt;Dla większej ilości szczegółów&lt;/a&gt; spójrz na GNU General Public License (GPL), version&amp;nbsp;3.</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Otwórz ostatnio używany plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Pokaż wskazówkę dnia</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Pokaż pozostałe elementy</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Wypełnienie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Przesunięcie liniowe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Pojedyńcza linia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Odstępy pomiędzy rzędami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Ustawienia obszaru</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Wypełnienie liniowe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Kąt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Odstępy pomiędzy liniami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Przesunięcie rzędu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Odstępy wzoru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Kolor linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>Regulowany dla obiektu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Kolor obszaru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Równoległe linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Nie wybrano wypełnienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Wzór wypełnienia %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Szerokość linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Linia wypełnienia %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minimalny rozmiar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Rotacja wypełnienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Równoległe rzędy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Pojedyńczy wiersz</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Przesunięcie wzoru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Wzór wypełnienia</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Auto-zapisane pliki</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -281,193 +294,193 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Pliki zapisane przez użytkownika</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Plik odzyskiwania (recovery)</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Plik %1 nie został poprawnie zamknięty. W tej chwili są dwie wersje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Zapisz aktywny plik, by usunąć konfliktującą wersję.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Czerwony</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Niebieski</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Czarny</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Zielony</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Własna mieszanka RGB:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Własna mieszanka CMYK:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Żółty</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definiuj kolor spotowy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Edytuj kolor</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Edytuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mieszanka kolorów:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Profesjonalny wydruk</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Oblicz z palety CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Pulpit</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Oblicz z palety RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Oblicz z koloru spotowego</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout: kasuje dolne kolory</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>(puste)</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Nowy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.O.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
@@ -476,59 +489,59 @@
         <translation type="vanished">Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Powiel)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Mapa zawiera symbole, które wykorzystują ten kolor. Usunięcie koloru spowoduje usunięcie go również z tych symboli. Czy na pewno chcesz to zrobić?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Kiliknij dwukrotnie, aby zdefiniować kolor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Do góry</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Krycie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Kolory spotowe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Powiel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Kliknij dwukrotnie w kolor, aby otworzyć okno dialogowe.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>W dół</translation>
     </message>
@@ -537,61 +550,61 @@
         <translation type="vanished">Wpisz wartość procentową od 0% do 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Kliknij, by zaznaczyć nazwę oraz kliknij ponownie, by ją edytować.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Ustawienia kombinacji</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Użyć starego symbolu jako szablonu do prywatnego symbolu?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Zastrzeżony symbol powierzchniowy -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Symbol %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Zmień symbol z publicznego na zastrzeżony</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Edytuj symbol zastrzeżony...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Zastrzeżony symbol liniowy -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Liczba części:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
         <source>m</source>
         <translation type="obsolete">m</translation>
@@ -601,12 +614,12 @@
         <translation type="obsolete">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Początek w: %1</translation>
     </message>
@@ -615,224 +628,224 @@
         <translation type="obsolete">Jednostki:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Wyświetl:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Przyciągaj do siatki</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Ustaw zgodnie z północą geograficzną</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Linie pionowe</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Ustaw zgodnie z północą topograficzną</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milimetry na mapie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>metry w terenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Wybierz...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Pokaż siatkę</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Kolor linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Przesunięcie poziome:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Ustaw zgodnie z północą magnetyczną</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>początku układu współrzędnych mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Odstęp pionowy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Dodatkowy obót (w lewo):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Rozmieszczenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Odstęp poziomy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>początku układu współrzędnych przestrzennych</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Edytuj siatkę</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Wszystkie linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Wybierz kolor linii siatki</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Przesunięcie pionowe:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Linie poziome</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Ustawienie</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Jednostki:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Kliknij lub przeciągnij&lt;/b&gt;: Zacznij rysować dziurę. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Linia podziału musi kończyć się na granicy obszaru!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt; na linii: Podziel na dwa. &lt;b&gt; Przeciągnij&lt;/b&gt; po linii: Usuń tę część linii. &lt;b&gt;Kliknij lub przeciągnij&lt;/b&gt; na granicy pola: Zacznij linię dzielącą. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Początek i koniec linii podziału są na dwóch różnych częściach obiektu!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Dzielenie dziur obiektu powierzchniowego nie jest (jeszcze) dostępne!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Początek i koniec linii podziału są w tym samym miejscu!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Przypnij całą mapę. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Kliknij lub przeciągnij&lt;/b&gt;: Wybierz obiekty do przypięcia. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Przypnij wybrane obiekty. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Nie można otworzyć pliku.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Ten plik nie jest w formacie DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -842,7 +855,7 @@
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Litera:</translation>
     </message>
@@ -855,249 +868,249 @@
         <translation type="vanished">W tym oknie można wybrać wielkość czcionki, co skutkuje dokładną wysokością konkretnej litery.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Wysokość:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Umieść punkty równomiernie wzdłuż ścieżki</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Liczba punktów na ścieżce:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Także umieść obiekty punktach końcowych linii</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Ustawienia rotacji</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Wyrównaj punkty z kierunkiem linii</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Zacznij rysować okrąg lub elipsę. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Zakończ rysować okrąg. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Narysuj okrąg. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Zacznij rysować elipsę. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Przytrzymaj %1, by zacząć rysować od środka.</translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation type="unfinished">&lt;b&gt;Przeciągnij&lt;/b&gt;: Narysować ścieżkę. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Stałe kąty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Click&lt;/b&gt;: Przyciągnij do istniejących obiektów. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Cofnij ostatni punkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Kliknij&lt;/b&gt;: Wybierz kierunek z istniejących obiektów. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Punkty przerwy włączone.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Kliknij&lt;/b&gt;: Przyciągnij lub najedź na istniejące obiekty. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Narysuj krzywą. &lt;b&gt;Przeciągnij&lt;/b&gt;:Narysuj krzywą. &lt;b&gt;PPM lub podwójne kliknięcie&lt;/b&gt;: Skończ rysowanie. &lt;b&gt;%1&lt;/b&gt;: Zamknij ścieżkę. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Przeciągnij&lt;/b&gt;: Śledź istniejące obiekty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Zacznij rysować krzywą. &lt;b&gt;Przeciągnij&lt;/b&gt;: Zacznij rysować krzywą. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Długość:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Zakończ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Kąt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation type="unfinished">Kliknij na mapę, by zakończyć (?)</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Resetowanie</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Kąt:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Stałe katy. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1106,204 +1119,204 @@
         <translation type="vanished">&lt;b&gt;Kliknij&lt;/b&gt;: Narysuj obiekt punktowy. &lt;b&gt;Przeciągnij&lt;/b&gt;: Narysuj obiekt i nadaj mu orientację (jeśli jest obrotowy). </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Kąt</translation>
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Przyciągnij do poprzednich linii. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Kliknij lub Przeciągnij&lt;/b&gt;: Zacznij rysować prostokąt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Ustaw punkt narożny. &lt;b&gt;PPM lub podwójne kliknięcie&lt;/b&gt;: Zakończ rysowanie. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Zakończ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation type="unfinished">Przyciąganie linii</translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
         <source>A</source>
         <translation type="vanished">A</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Stwórz obiekt tekstowy. &lt;b&gt;Przeciągnij&lt;/b&gt;: Stwórz pole tekstowe. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Zakończ edycję. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ruch swobodny. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Kliknięcie&lt;/b&gt; na odcinku: przełączaj pomiędzy prostą i krzywą. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Utrzymać przeciwne pozycje trzonków. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Kliknięcie&lt;/b&gt; na punkcie: Usuń; na linii: Dodaj nowy punkt pośredni; z &lt;b&gt;%2&lt;/b&gt;: Dodaj normalny punkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Kliknięcie&lt;/b&gt; na punkcie aby przełączać pomiędzy pośrednim a normalnym punktem. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Kliknięcie&lt;/b&gt; na punkcie: Usuń; na linii: Dodaj nowy punkt z &lt;b&gt;%2&lt;/b&gt;: Dodaj pośredni punkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punkt / Kąt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Zakończ edycję. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Wybierz pojedyńczy obiekt. &lt;b&gt;Przeciągnij&lt;/b&gt;: Wybierz wiele obiektów. &lt;b&gt;%1+Kliknięcie&lt;/b&gt;: Przełącz wybór. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Stałe kąty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Przesunięcie koordynatów:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Dystans:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Przyciągnij do istniejących obiektów. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Usuń wybrane obiekty. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
         <source>px</source>
         <translation type="vanished">px</translation>
@@ -1313,280 +1326,280 @@
         <translation type="obsolete">°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Akcja przy usuwaniu punktu krzywej z %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Promień krzyża pomocniczego:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolerancja kliknięcia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Wyświetlanie mapy w wyskoiej jakości (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Edycja krzywych:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Zachowaj zewnętrzną obsługę krzywych</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Wybierając obiekt, automatycznie wybierz jego symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Oddalaj widok względem kursora</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Resetuj zewnętrzną obsługę krzywych</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Wartość dla trybu stałego kąta (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing sprawia, że mapa wygląda zdecydowanie lepiej, ale spowalnia jej wyświetlanie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Wyświetlanie tekstu w wysokiej jakości na mapie (antialiasing), wolniejsze</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Odległość przyciągania (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Tryb rysowania prostokątu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Zachowaj stary kształt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Narzędzia rysowania: kończąc rysowanie ustaw ostatni punkt klikając prawym przyciskiem myszy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Podgląd szerokości linii krzyża pomocniczego</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Podkłady: zachowaj ustawienia zamkniętych podkładów</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Nie można utworzyć nowego pliku: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Format (%1) nie wspiera eksportu</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Obszar mapy jest duży. Korzystanie z narzędzia może być bardzo powolne. Czy chcesz i tak użyć wypełnienia?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Kliknięty obszar mapy nie jest ograniczony liniami lub innymi obszarami, nie można wypełnić tego obszaru.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Kliknięte miejsce nie jest wolne, nie można użyć narzędzia wypełnienia.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Nie udało się utworzyć wypełnienia obiektu.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS jest wyłączony w ustawieniach urządzenia. Otworzyć je?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Tak</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Pliki tłumaczeń (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Wybrany plik nie jest poprawnym plikiem tłumaczenia.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Program musi być zrestartowany, żeby zobaczyć zmianę języka!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Język:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Uwaga</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Start programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Otwórz tłumacznie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Wygląd</translation>
     </message>
@@ -1595,106 +1608,106 @@
         <translation type="vanished">Użyj pliku tłumaczenia...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Importowanie i eksportowanie pliku</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-bitowe zakodowanie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Użyj nowego importera OCD także dla plików w wersji 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pikseli na cal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Zapisane pliki</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Zachowaj zgodność z Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Zapisz informacje dla automatycznego odzyskiwania</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Okres czasu zapisywania informacji o odzyskiwaniu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Więcej...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Rozdzielczość głównego ekranu w pikselach:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Rozdzielczość głównego ekranu w calach (przekątna):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
         <source>UTM</source>
         <translation type="obsolete">Układ UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokalny</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Współrzędne w odwzorowaniu Gaussa-Kruegera</translation>
     </message>
@@ -1707,12 +1720,12 @@
         <translation type="vanished">Tylko skala</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Nieobsługiwany układ odniesienia: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Współrzędne w układzie UTM</translation>
     </message>
@@ -1729,82 +1742,82 @@
         <translation type="vanished">Strefa w układzie UTM (numer północ/południe, np. &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Nieprawidłowa lub brakująca specyfikacja skali mapy.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Nieprawidłowy współczynnik skali siatki: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Nieznana specyfikacja układu odniesienia: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>Układ UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation type="unfinished">Odwzorowanie Gaussa-Kruegera, Elipsoida odniesienia: Bessel</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Numer strefy (1-119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation type="unfinished">przez kod EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Współrzędne lokalne</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Kod EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Specyfikacja</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
         <source>E</source>
         <translation type="obsolete">E</translation>
@@ -1822,26 +1835,26 @@
         <translation type="obsolete">Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Deklinacja:</translation>
     </message>
@@ -1850,76 +1863,76 @@
         <translation type="obsolete">%1 °</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>prawidłowa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Współrzędne geograficzne</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Współrzędne geograficzne:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Ustawienie kierunku północy na mapie</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokalny -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Obliczenie deklinacji online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Układ współrzędnych mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Przy zmianie układu odniesienia pozostaw:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Wskaż na mapie</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Wyszukaj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Zmiana deklinacji</translation>
     </message>
@@ -1928,12 +1941,12 @@
         <translation type="vanished">- brak -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Pokaż punkt odniesienia w:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georeferencja mapy</translation>
     </message>
@@ -1946,37 +1959,37 @@
         <translation type="vanished">Współrzędne w układzie odniesienia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Współrzędne w układzie odniesienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Wartość deklinacji nie została znaleziona.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Deklinacja magnetyczna dla punktu odniesienia %1° %2° nie będzie przywrócona z &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Czy chcesz kontynuować?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Współrzędne w układzie mapy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Wczytuję...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Deklinacja została zmieniona. Czy chcesz obrócić mapę zgodnie z jej wartością?</translation>
     </message>
@@ -1985,106 +1998,106 @@
         <translation type="vanished">Specyfikacja układu odniesienia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Punkt odniesienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Uchylenie magnetyczne:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Nie można przetworzyć danych.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Współrzędne w układzie lokalnym:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Wyszukiwanie wartości deklinacji online nie powiodło się: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Elipsoida odniesienia: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Współczynnik skali siatki:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>Układ współrzędnych:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. Another button to cancel.</source>
         <translation type="vanished">&lt;b&gt;Kliknij&lt;/b&gt;: Określ punkt odniesienia. Inny przycisk aby anulować.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Witaj w OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Exit</source>
         <translation type="vanished">Zakończ</translation>
@@ -2147,128 +2160,128 @@
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Działania</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Utwórz nową mapę...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Otwórz mapę...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Zakończ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Ostatnie mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Otwórz ostatnio używany plik na starcie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Wyczyść listę</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Wskazówka dnia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Pokaż wskazówkę dnia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Błąd wczytywania pliku typu %1 w linii %2 w koluemnie %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Nie można znaleźć symbolu dla obiektu %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Obiekt punktowy niezdefiniowany lub ze złym symbolem w %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>ID symbolu &apos;%1&apos; nie jest unikalne w linii %2 w kolumnie %3.</translation>
     </message>
@@ -2277,80 +2290,80 @@
         <translation type="vanished">Błąd wczytywania symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Błąd wczytywania obiektu typu %1.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>Wersje OCADa 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Znaleziono obiekt bez symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Nie można wczytać pliku: %1</translation>
     </message>
@@ -2359,79 +2372,79 @@
         <translation type="vanished">Przynajmniej jeden podkład nie może być odnaleziony. Kliknij na czerwoną nazwę podkładu w Podkłady -&gt; Okno edycji podkładu aby znaleźć nazwę tego podkładu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Błąd przy ładowaniu symbolu typu %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Błąd podczas przetwarzania symbolu.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Nieobsługiwany, nowszy format wersji pliku. Niektóre właściwości mapy nie będą wszytane lub zapisane w tej wesji. Pomyśl nad aktualizacją.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Błąd ładowania pliku.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Błąd przy wczytywaniu licznika części mapy.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>System odniesienia współrzędnych geograficznych mapy był &quot;%1&quot;. Ten CRS nie jest obsługiwany. Używa &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Błąd przy wczytywaniu poprzednich kroków.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Nieobsługiwana, stara wersja formatu pliku. Użyj starszej wersji programu, aby załadować i uaktualnić plik.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Podkład &quot;%1&quot; został wczytany ze ścieżki mapy zamiast lokalizacji, w której mapa była poprzednio.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Błąd przy wczytywaniu części mapy %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Nieprawidłowa wersja formatu pliku.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Nieobsługiwany format pliku.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Nieobsługiwany, nowszy format wersji pliku. Niektóre właściwości mapy nie będą wszytane lub zapisane w tej wesji.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2440,187 +2453,187 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>płaskie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>brak</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Kolor obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Środkowe symbole na punkt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>ukos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>skośna</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>okrągłe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Pokaż co najmniej jeden środkowy symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Prawe obramowanie:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Symbol startu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Dystand środkowych symboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Długość końca linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Odległość pomiędzy punktami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Połowa długości pierwszej i ostatniej kreski</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Wymaż kreski na początku i końcu linii</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Koniec linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Dystans od linii końcowej:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minimalna długość linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Długość przerwy w grupie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Długość kreski:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Kolor linii:</translation>
     </message>
@@ -2630,140 +2643,140 @@
         <translation>Linia jest kreskowana</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Minimalna liczba środkowych symboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>punktowe</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Łączenie linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Szerokość linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>kwadratowe</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Środkowy symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Końcowy symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Symbol kreski</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Obramowania</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Środkowe symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Kreski zgrupowane:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minimalna liczba środkowych symboli kiedy zamknięte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Kreskowana linia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Różne obramowania po lewej i prawej stronie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Długość przerwy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Obramowanie jest kreskowane</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Długość kreski obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Długość przerwy obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Lewe obramowanie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Szerokość obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Włącz linie obramowania</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Zmiana obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Ustawienia linii</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Nowy</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2774,152 +2787,152 @@ File format not recognized.</source>
 Format pliku nierozpoznany.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Ustawienia...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Pokaż plik pomocy programu</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>&amp;Wyjdź</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Otwórz &amp;instrukcję</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Wygląda na to, że %1 ostatni raz gdy był otwarty, powodował błąd:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Na pewno chcesz ponowić próbę otwarcia?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Pokaż informacje o Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Pokaż informacje o aplikacji</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Plik został zmodyfikowany. Zapisać zmiany?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Otwieram %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Zapisz &amp;jako...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Wszystkie mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Otórz istniejący plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Prosimy o zgłoszenie tego błędu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Otwórz...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Zamknij ten plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Ostrzeżenie przed awarią</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Zamknij program</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Wystąpił problem w ustalaniu formatu pliku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Otwórz o&amp;statnie</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;O %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2930,7 +2943,7 @@ Kliknij Tak aby zapisać ten format.
 Kliknij Nie aby wybrać inny format.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2939,92 +2952,93 @@ Do you want to scale the symbols to the selected scale?</source>
 Czy chcesz przeskalować symbole?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Plik nie może być zapisany:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Utwórz nową mapę</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Zapisz plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Wszystkie pliki</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Niezapisany plik</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3033,14 +3047,14 @@ because the format is unknown.</source>
 ponieważ ten format jest nieznany.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3049,12 +3063,12 @@ Rescale the imported data?</source>
 Przeskalować importowane dane?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>domyślna część</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3063,12 +3077,12 @@ because saving as %2 (.%3) is not supported.</source>
 ponieważ zapisywanie jako %2 (.%3) nie jest obsługiwane.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Mapa eksportuje wygenerowane ostrzeżenia.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3079,14 +3093,14 @@ ponieważ zapisywanie jako %2 (.%3) nie jest obsługiwane.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nowy kolor</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3095,7 +3109,7 @@ for reading.</source>
 do odczytu.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Pytanie</translation>
     </message>
@@ -3106,127 +3120,127 @@ do odczytu.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Import mapy generuje błędy.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Niewłaściwy format pliku.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Uwaga</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Węwnętrzny błąd w czasie zapisywania: 
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nie ma nic co zaimportowania.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished">Importuj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Rączka</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>&amp;Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Ponów</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Widok</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>W schowku nie ma obiektów do wklejenia!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Obróć wzór</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Edytuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Widok</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>&amp;Kopiuj</translation>
     </message>
@@ -3235,23 +3249,23 @@ Import the data anyway?</source>
         <translation type="vanished">Atrapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Obróć mapę...</translation>
     </message>
@@ -3260,64 +3274,64 @@ Import the data anyway?</source>
         <translation type="vanished">Oblicz nienakładające się części obszaru.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Zamiana na różnicę pól nie powiodła się.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Odwróć kierunek kresek</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Ukryj wszystkie podkłady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Rysuj okręgi i elipsy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Konfiguruj siatkę...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Edytuj obiekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Przybliż</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Wybierz podkład...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Zmień skalę mapy, ustaw obiekty na mapie i rozmiary symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Nie można zaimportować wybranej mapy, bo nie może być... załadowana.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importowalne pliki</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Stwórz wycinek obiektu lub całej mapy.</translation>
     </message>
@@ -3331,150 +3345,150 @@ Import the data anyway?</source>
         <translation type="vanished">Wytnij %1 obiekt(ów)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Wybierz co najmniej jeden obiekt, aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Napisz tekst na mapie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Uwagi do mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferencja...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Ustaw obiekty punktowe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Obraz</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>W&amp;klej</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Narzędzia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Rysuj prostokąty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Otwórz podkład...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Umieść obiekty punktowe na mapie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Okno kolorów</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Podzielenie nie powiodło się.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Uwagi...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Pomiar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Połącz punkty końcowe ścieżek, które są blisko siebie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Zaawansowana edycja</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Okno ustawień podkładu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Wybierz obszar z obrotowym wypełnienim lub obrotowy obiekt punktowy, aby użyć tego narzędzia.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Skaluj wszystkie symbole...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Pokaż/Ukryj okno kolorów</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Zamień symbole na te z innego pliku mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Podkłady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Podkłady</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importuj plik %1, GPX, OSM lub DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Kolory</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Skaluj procentowo:</translation>
     </message>
@@ -3483,18 +3497,18 @@ Import the data anyway?</source>
         <translation type="vanished">Wklejono %1 obiekt(ów)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Wytnij dziurę o dowolnym kształcie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Wybierz przynajmniej jeden obiekt i pasujący, inny symbol aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Ponów ostatni krok</translation>
     </message>
@@ -3503,12 +3517,12 @@ Import the data anyway?</source>
         <translation type="vanished">Zamienia symbol z zaznaczonych obiektów na wybrany symbol.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Cofnij ostatni krok</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Odwróć kierunek symboli na obiektach liniowych.</translation>
     </message>
@@ -3517,78 +3531,78 @@ Import the data anyway?</source>
         <translation type="vanished">Wypełnij wybrane linie lub utwórz obramowanie dla wybranych obszarów.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Nie można importować wybranego pliku, bo jego format nie jest obsługiwany.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Zamień ścieżki zrobione z prostych segmentów na wygładzone krzywe Beziera.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Oddal</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Zredukuj liczbę punktów w obiektach liniowych próbując zachować ich kształt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Edytuj linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Pokaż siatkę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Włącz tryb pełnoekranowy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Wytnij jakies obiekty lub wszystko w określonym obszarze.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Wytnij obiekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Wybierz krzywą aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importuj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Ponownie otwórz podkład...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Uprość ścieżkę</translation>
     </message>
@@ -3597,12 +3611,12 @@ Import the data anyway?</source>
         <translation type="vanished">Różnica obszarów</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Wytnij okrągłą dziurę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Maluj ręcznie na podkładzie. Utwórz lub załaduj podkład na którym można rysować, aby aktywować ten przycisk</translation>
     </message>
@@ -3615,7 +3629,7 @@ Import the data anyway?</source>
         <translation type="vanished">Skopiowano %1 obiekt(ów)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mierz długości i powierzchnie</translation>
     </message>
@@ -3624,27 +3638,27 @@ Import the data anyway?</source>
         <translation type="vanished">Skaluj obiekty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Ujednolicenie nie powiodło się.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Współrzędne mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Obszary z wyłączeniem obszaru wspólnego (XOR)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Drukuj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Wybór obiektu</translation>
     </message>
@@ -3653,12 +3667,12 @@ Import the data anyway?</source>
         <translation type="vanished">Powiel wybrany obiekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Brak dostępnych poprzednich kroków.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Symulacja nadrukowania</translation>
     </message>
@@ -3667,7 +3681,7 @@ Import the data anyway?</source>
         <translation type="vanished">Przetnij pierwszy wybrany obiekt ze wszystkimi pozostałymi wybranymi nakładającymi się obszarami.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Rysuj linie</translation>
     </message>
@@ -3676,23 +3690,23 @@ Import the data anyway?</source>
         <translation type="vanished">Wybierz przynajmniej dwa obszary z takim samym symbolem, aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Zmień skalę mapy...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Wybierz przynajmniej jeden obiekt liniowy aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Zakreskowane powierzchnie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Mapa jest w trakcie edytowania. Skończ operację edycji przed zapisaniem.</translation>
     </message>
@@ -3701,32 +3715,32 @@ Import the data anyway?</source>
         <translation type="vanished">Ujednolić nakładające się obszary.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Obróć całą mapę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Poziom przybliżenia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Zamień na krzywe</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Zamień zestaw symboli...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Ustaw kierunek wypełnienia lub obiektu.</translation>
     </message>
@@ -3735,54 +3749,54 @@ Import the data anyway?</source>
         <translation type="vanished">Odejmij wszystkie pozostałe wybrane obiekty od pierwszego wybranego.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Pokaż/Ukryj okno podkładu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Przewidywane koordynaty</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Wybierz obiekt zamkniętej ścieżki jako wycięcie kształu aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Rysuj polilinie i krzywe.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Wystąpił błąd wewnętrzny, sorry!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Ujednolić obszary</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Pokaż całą mapę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Rysuj okręgi i elipsy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Rysowanie</translation>
     </message>
@@ -3795,12 +3809,12 @@ Import the data anyway?</source>
         <translation type="vanished">Obróć wybrane obiekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Edytując</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Edytowanie w trakcie</translation>
     </message>
@@ -3809,107 +3823,107 @@ Import the data anyway?</source>
         <translation type="vanished">Żadne obiekty nie zostały wybrane, bo nie było obiektów zawierających ten symbol.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>&amp;Symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Połącz linie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Zaznaczenie obszarów oprócz wspólnego pola (XOR) nie powiodło się.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Wypełnij / Utwórz obramowanie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Odetnij</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Wytnij dziurę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Wybierz pojedyńczy obiekt aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Przetnij obszary</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Eksportuj jako...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Wyczyść historię ostatnich kroków dla zmniejszenia rozmiaru pliku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Okno symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Wyczyść historię ostatnich kroków</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Pokaż/Ukryj okno symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Widok podstawowy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Odwróć symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Szerokość/Długość geograficzna (stopnie dzięsiętne)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Szerokość/Długość geograficzna (stopnie, minuty, sekundy)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Ustaw własny poziom przybliżenia...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Skaluj wszystkie symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Rysuj na podkładzie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Wytnij prostokątną dziurę</translation>
     </message>
@@ -3918,7 +3932,7 @@ Import the data anyway?</source>
         <translation type="vanished">%1 obiekt został powielony</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Wszystkie pliki</translation>
     </message>
@@ -3927,402 +3941,402 @@ Import the data anyway?</source>
         <translation type="vanished">Skaluj wybrane obiekty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Wytnij dziurę w wybranym obiekcie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Skaluj cały zestaw symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Wybierz co najmniej jedną linię lub obszar aby aktywować to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Wybierz linię, obszar, lub połączony symbol, aby użyć tego narzędzia.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Ustal własny poziom przybliżenia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Rysuj prostokąty.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Wybierz symbol tekstowy aby móc użyć to narzędzie.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Wyświetl koordynaty jako...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Maluj ręcznie na podkładzie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Wybierz symbol punkowy aby użyć tego narzędzia.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Wybierz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Odwróć zaznaczenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4330,7 +4344,7 @@ selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4338,119 +4352,119 @@ selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation type="unfinished">
@@ -4460,7 +4474,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4469,7 +4483,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4478,42 +4492,42 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4522,153 +4536,153 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Więcej: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Więcej: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Więcej: %1, %2, %3</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Przerwij. </translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
         <source>m</source>
         <translation type="obsolete">m</translation>
@@ -4682,12 +4696,12 @@ selected</source>
         <translation type="obsolete">%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4702,7 +4716,7 @@ otworzyć okno kolorów i
 zdefiniować je.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4715,7 +4729,7 @@ Aby załadować podkład, kliknij
 Podkłady -&gt; Otwórz podkład...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4730,38 +4744,38 @@ i wybierz &quot;Nowy symbol&quot;
 aby utworzyć.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Wskazówka: przybliżaj i oddalaj widok mapy, kręcąc pokrętłem myszy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
         <source>m</source>
         <translation type="obsolete">m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
@@ -4770,253 +4784,253 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Obszar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Ta linia jest zbyt krótka.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimalna długość to %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Długość:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Minimalny obszar to %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Ten obiekt jest zbyt mały.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Długość granicy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Wybrany obiekt nie jest krzywą.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>Wybrano %1 obiektów.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nie wybrano żadnego obiektu.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Uwaga: Długość granicy i obszaru jest prawidłowa tylko jeśli nie jest on poprzecinany i podziurawiony.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>m²</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
         <source>Cancel</source>
         <translation type="vanished">Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Utwórz</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Pusty zestaw znaków</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Pokazuj tylko zestawy znaków pasujące do wybranej skali</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Skala:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Wybierz skalę i zestaw symboli dla nowej mapy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Zestawy symboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Utwórz nową mapę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Wszystkie pliki zestawów symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Załaduj zestaw symboli z pliku...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Wszystkie pliki</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>W symbolu powierzchniowym &quot;%1&quot;, zakładasz &quot;przesunięcia wierszy&quot; wzorów punktu. To może być nieprawidłowe.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>W symbolu liniowym &quot;%1&quot;, nie można prawidłowo eksportować obramowań.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>W symbolu powierzchniowym &quot;%1&quot;, omijam wzór wypełnienia.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Linka odcięta (odcinanie oznaczone trójką &apos;|&apos;): %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>W symbolu tekstowym %1: igoruję podkreślenie</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>W obiekcie liniowym &quot;%1&quot;, lekceważąc grupowanie kresek.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>W symbolu tekstowym %1: własne przerwy pomiędzy znakami są ustawione, ta implementacja nie odpowiada OCADowi</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Nie można eksportować podkładu: typ pliku &quot;%1&quot; nie jest jeszcze obsługiwany</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Mapa zawiera więcej niż 256 kolorów, co nie jest obsługiwane przez OCADa w wersji 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>W obiekcie liniowym &quot;%1&quot;, nie można odtworzyć kombinacji końcówek/połączeń.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>W symbolu tekstowym %1: ignoruję kerning</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>W symbolu liniowym &quot;%1&quot;, liczba kresek w grupie została zredukowana do 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>Libocad - zwrot %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Nie można eksportować przerwy wypełnienia dla obiektu powierzchniowego</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Podczas importowania symbolu tekstowego %1: zignorowano ramy tekstu (tryb %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Nie importuję symbolu tekstowego, nie mogę rozpoznać ścieżki (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Importuj warstwę z OCADa</translation>
     </message>
@@ -5025,103 +5039,103 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">Nie można importować podkładu: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Nie znaleziono koloru: %1, ignoruję ten kolor</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Nie można załadować obiektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>W kreskowanym symbolu liniowym %1, przerwy D i E są różne (%2 i %3). Użyto %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Nie można załadować prostokątnego obiektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Nie można importować symbolu &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>W kreskowanym symbolu liniowym %1, główna i końcowa długość są różne (%2 i %3). Używa %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Podczas importowania symbolu tekstowego %1: zignorowano wyjustrowanie</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Podczas importowania symbolu tekstowego %1: zignorowano własne odstępy pomiędzy słowami (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>W kreskowanym symbolu liniowym %1, przerwy początkowe i końcowe są różne (%2 i %3). Używa %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Próba importu obiektu tekstowego z nieznanym formacie koordynatów</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Podczas importowania symbolu tekstowego %1: własne odstępy pomiędzy literami są określone, implementacja nie pasuje do zachowania OCADa</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Podczas importowania symbolu tekstowego %1: zignorowano własne tirety (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Podczas importowania symbolu tekstowego %1: zignorowano własną szerokość (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Nie można załadować podkładu: tło &quot;%1&quot; nie jest plikiem rastrowym</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Nie można przydzielić buforów.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>W kreskowanym symbolu liniowym %1, długość końcowa nie może być poprawnie zaimportowana.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>Libocad zwrócony %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>Pliki OCADa w wersji %1 nie są obsługiwane!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>W kreskowanym symbolu liniowym %1, końcowa przerwa nie może być zaimportowana poprawnie.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5130,295 +5144,295 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Tekst</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Nie można załadować obiektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Nie można załadować prostokątnego obiektu</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Nie importuję symbolu tekstowego, nie mogę rozpoznać ścieżki (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Próba importu obiektu tekstowego z nieznanym formacie koordynatów</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation type="unfinished">Nie znaleziono koloru: %1, ignoruję ten kolor</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation type="unfinished">Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation type="unfinished">Linia</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation type="unfinished">Obszar</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation type="unfinished">Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5427,411 +5441,398 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Rysuj</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Wybierz podkład, na którym chcesz rysować</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Wybór koloru</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Kliknij i przeciągnij&lt;/b&gt;: Rysuj. &lt;b&gt; Kliknij PPM i przeciągnij&lt;/b&gt;: Usuń. </translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Przesuń mapę. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Dodaj współrzędne. &lt;b&gt;%1+Kliknij&lt;/b&gt;: Zmień wybrane współrzędne. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Obszar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>płaski</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>ukos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>kant</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>okrągły</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Kolor wewnętrzny:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Bieżące elementy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Zewnętrzny kolor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Koniec linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Zewnętrzna szerokość &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Zawsze zorientowany do północy (nieobracalny)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Linia zamknięta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Kolor linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Kolor obszaru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Początek krzywej</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Połączenie linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Szerokość linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>kwadratowy</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Średnica &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Punkt środkowy]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Nieznane</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Wyśrodkuj na uśrednione współrzędne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Współrzędne:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Wyśrodkuj wszystkie elementy</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Symbol punktowy</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area or its borders. </source>
         <translation type="obsolete">&lt;b&gt;Przeciągnij&lt;/b&gt;: Przesuń obszar wydruku bądź jego granice. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation type="unfinished">&lt;b&gt;Przeciągnij&lt;/b&gt;: Przesuń mapę. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Góra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Lewa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Wyeksportowano do %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Obszar mapy jest pusty. Tworzenie anulowane.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Pojedyńcza strona</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Obszar mapy:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Wydrukowano bez błędów</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Wydrukuj w innej skali:</translation>
     </message>
@@ -5840,108 +5841,108 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">Eksportuj do PDFa lub PS</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Nie udało się zapisać obrazu. Być może brakuje rozszerzenia pliku.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Rozdzielczość:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Eksportuj obraz</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Orientacja pozioma</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Własny obszar</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Szerokość:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opcje</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Pokaż siatkę</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Orientacja pionowa</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Eksportuj do PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Niestandardowy widok jest aktywny. Na pewno chcesz wydrukować /wyeksportować mapę w ten sposób?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Eksportuj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Zapisz jako PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Drukarka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Wycentruj obszar wydruku</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Rozmiar papieru:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Kopie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Pokrywanie strony:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Pokaż podkłady</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Wszystkie pliki (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Symuluj nadrukowanie</translation>
     </message>
@@ -5950,283 +5951,283 @@ zoom using the mouse wheel, if available.</source>
         <translation type="obsolete">Nieznany</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Eksportuj mapę...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Podgląd...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientacja strony:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Wysokość:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">Układ wspólrzędnych:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Przeciągnij elementy z listy po lewej w określony punkt listy po prawej, aby załadować je ponownie.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Wyczyść listę</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktywne podkłady:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Zamknięte podkłady:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Otwórz podkład ponownie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Usuń oryginalne symbole które nie są używane po zamianie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Usuń nieużywane kolory po zamianie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Dopasuj zamienione symbole po numerach symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6237,7 +6238,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6245,80 +6246,80 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Brak -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Zamień zestaw symboli</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Wybrany zestaw symboli jest w skali 1:%1, a mapa 1:%2. Czy na pewno chcesz wybrać ten zestaw?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Zamiennik</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Nie można załadować pliku mapy, przerywam.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Oryginalny</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importuj wszystkie nowe symbole nawet, jeśli nie używasz ich jako zamienników</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Skonfiguruj jak i które symbole mają być zamienione.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Odwzorowanie symboli:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Wybierz plik mapy aby załadować symbole z</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
         <source>X:</source>
         <translation type="obsolete">X:</translation>
@@ -6328,13 +6329,13 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
@@ -6347,17 +6348,17 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Punktu odniesienia z georeferencji</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Ustaw deklinację z georeferencji</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opcje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ustaw punkt odniesieniaz georeferencji</translation>
     </message>
@@ -6366,104 +6367,104 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Początku układu współrzędnych mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Obróć mapę</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Kąt (w lewo):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parametry obrotu</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Obróć wokół:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Obróć podkłady bez georeferencji</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Kąt:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Stałe kąty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Ustaw kierunek wypełnień bądź obiektów punktowych. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Stałe kąty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Obróć wybrane obiekty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: określ oś obrotu. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Obrót:&lt;/b&gt; %1° </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
         <source>X:</source>
         <translation type="obsolete">X:</translation>
@@ -6473,18 +6474,18 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Środek skalowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nowa skala:  1 :</translation>
     </message>
@@ -6497,27 +6498,27 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Punkt odniesienia z georeferencji</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skaluj pozycje obiektów na mapie</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opcje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Zmień skalę mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Parametry skalowania</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Dopasuj punkt odniesienia z georeferencji</translation>
     </message>
@@ -6526,78 +6527,78 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Początek układu współrzędnych mapy</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Skaluj rozmiary obiektów</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skaluj podkłady bez georeferencji</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skalowanie:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Skaluj wybrane obiekty. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Ustaw centrum skalowania. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokalny</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>poprawny</translation>
     </message>
@@ -6610,7 +6611,7 @@ Do you want to save your changes?</source>
         <translation type="vanished">Z listy</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
@@ -6619,7 +6620,7 @@ Do you want to save your changes?</source>
         <translation type="vanished">Specyfikacja układu odniesienia:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Wybierz układ odniesienia</translation>
     </message>
@@ -6632,251 +6633,251 @@ Do you want to save your changes?</source>
         <translation type="vanished">(lokalne)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Współrzędne geograficzne (WGS84)</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- brak -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- brak&apos; -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nazwa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Opis:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Numer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Edytuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Symbol pomocy (nie pokazany na finalnej mapie)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Obszar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Edytuj</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linia</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Ukryj obiekty z tym symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Sortuj po numerze</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Mapa zawieta obiekty z symbolem &quot;%1&quot;. Usuwanie skasuje te obiekty i wyczyści historię poprzednich kroków! Czy na pewno chcesz to zrobić?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Sortuj po priorytecie koloru podstawowego</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Chroń obiekty z wybranymi symbolami</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Zaznacz wszystkie obiekty z wybranymi symbolami</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skaluj procentowo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Sortuj po kolorze podstawowym</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Połączone</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Ukryj obiekty z wybranymi symbolami</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Chroń obiekty z tym symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Wybierz symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Powiel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Nowy symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>W schowki nie ma symboli, które można wkleić!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skaluj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Nastąpił błąd wewnętrzny, przepraszamy!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Wybierz wszystko</translation>
     </message>
@@ -6885,32 +6886,32 @@ Do you want to save your changes?</source>
         <translation type="obsolete">Skaluj symbol %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Wybierz wszystkie obiekty z tym symbolem</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Dla symboli z opisem, wciśnij F1 w czasie kiedy podpowiedzi są widoczne</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Odwróć zaznaczenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Zaznacz nieużywane</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Dodaj wszystkie obiekty z tym symbolem do zaznaczenia</translation>
     </message>
@@ -6923,56 +6924,56 @@ Do you want to save your changes?</source>
         <translation type="vanished">Zamień symbol wybranych obiektów</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Sortuj symbole</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Dodaj wszystkie obiekty z wybranymi symbolami do zaznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Wycentruj podkład...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6983,98 +6984,98 @@ przeskoczenia leniwego psa
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(brak)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Podkład:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Otwórz...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>Środek ciężkości ze źródła</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>obwiednia ze źródła</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Wybierz kolor tła</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Ustawienia symboli</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Brak opisu!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished">Do góry</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
@@ -7083,7 +7084,7 @@ przeskoczenia leniwego psa
         <translation type="obsolete">Pomoc</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7092,51 +7093,51 @@ przeskoczenia leniwego psa
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Close</source>
         <translation type="obsolete">Zamknij</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
@@ -7145,156 +7146,156 @@ przeskoczenia leniwego psa
         <translation type="vanished">Nie można zamienić podkładu na ten plik! Czy format pliku jest prawidłowy dla tego typu podkładu?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Znajdź przeniesiony plik podkładu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Wszystkie pliki (*,*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Nie udało się wpasować podkładu!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Wpasowanie podkładu</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Określ pozycję mapy na podstawie punktu odniesienia. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Określ pozycję podkładu na podstawie punktu odniesienia. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Kliknij&lt;/b&gt;: Usuń punkty odniesienia </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt;: Przenieś punkty odniesienia. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Nowy</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Przenieś</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>X na mapie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Y na mapie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Punkty wpasowania:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>X na podkładzie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Y na podkładzie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Wyczyść wszystko</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Podgląd transformacji podkładu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Zastosuj i wyczyść wszystkie</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7303,93 +7304,93 @@ Zapisywanie plików GIF nie jest obsługiwane. To oznacza, że rysowanie na tym 
 Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Wybierz układ współrzędnych w pliku podkładowym</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Uwaga</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Zgodnie z georeferencją</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>World file</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Skala podkładu:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Otwieram %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>brak</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Rozmiar obrazu:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Określ w jaki sposób zlokalizować plik podkładowy:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Liczba metrów na piksel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Zgodnie z parametrami skanowania</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
         <source>no</source>
         <translation type="obsolete">nie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
@@ -7398,59 +7399,59 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="obsolete">tak</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Pokaż</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nazwa pliku</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Błąs</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Grupa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Wpisz prawidłową liczbę całkowitą aby utworzyć grupę lub zostaw pole puste aby rozdzielić podkład!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Dopasuj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Zgodny z georeferencją: %1</translation>
     </message>
@@ -7459,12 +7460,12 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="obsolete">Podaj prawidłowy numer od 0 do 1, lub określ wartość procentową od 0 do 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Umiejscowienie...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Do góry</translation>
     </message>
@@ -7473,33 +7474,33 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="vanished">Usuń</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Szkic</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Otwórz obraz, ślad GPS, lub plik DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Krycie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Otwórz...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Format pliku nie został rozpoznany.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Powiel</translation>
     </message>
@@ -7512,7 +7513,7 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="obsolete">Wybrano wiele podkładów</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Pliki podkładów</translation>
     </message>
@@ -7521,22 +7522,22 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="obsolete">Utwórz...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>W dół</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Przesuń ręcznie</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Nie udało się załadować podkładu. Czy plik istnieje i jest poprawny?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Wszystkie pliki</translation>
     </message>
@@ -7545,49 +7546,49 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
         <translation type="obsolete">Wpisz wartość procentową od 0 do 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7597,165 +7598,165 @@ Jeśli nie masz zamiaru rysować na tym podkładzie, nie masz się czym martwić
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Przeciągnij&lt;/b&gt; aby przesunąć bieżący podkład</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-Skala:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-Skala:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Obrót:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Ustawienie</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
         <source>m</source>
         <translation type="obsolete">m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Osadź ślad w środku bieżącego widoku</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Jednostka układu współrzędnych równa:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Osadź ślad w określonym punkcie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Skalowanie i osadzenie śladu</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problemy przy importowaniu</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Tak</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>Plik OSM jest w wersji %1.
 Podstawowa obsługiwana wersja to %2.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Nie sa jeszcze skonfigurowane, więc będą pokazane w następnym kroku.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Błąd wczytywania</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Osadza ślad zgodnie z jego georeferencją.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Wybierz współrzędne odniesienia koordynatów śladu</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>Plik OSM jest w wersji %1.
 Maksymalna obsługiwana wersja to %2.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Otwieram ślad...</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 węzły nie mogą być przetworzone prawidłowo.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n obiekt(y) ścieżki nie mogą być zaimportowane (powód: brakujące koordynaty).</numerusform>
@@ -7764,32 +7765,32 @@ Maksymalna obsługiwana wersja to %2.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemy</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Osadza ślad wykorzystując rzut ortogonalny scentrowany na jego uśrednionych współrzędnych. Umożliwia wyrównanie transformacji śladu oraz ustawienie georeferencji po jego wyrównaniu.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Pytanie</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Czy waypointy powinny być importowane jako linie przechodzące przez wszystkie punkty?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Czy osadzić ślad zgdodnie z jego georeferencją?</translation>
     </message>
@@ -7802,12 +7803,12 @@ Maksymalna obsługiwana wersja to %2.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Ślad jest pusty, nie ma co zaimportować!</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7816,56 +7817,56 @@ Maksymalna obsługiwana wersja to %2.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Góra</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Lewa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Prawa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Dół</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Środek</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Linia bazowa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Wyrównanie</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -7874,23 +7875,23 @@ Not an OSM file.</source>
         <translation type="obsolete">A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>pogrubienie</translation>
     </message>
@@ -7899,327 +7900,327 @@ Not an OSM file.</source>
         <translation type="vanished">Określ rozmiar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kerning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Zgodność z OCADem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Komponowanie cieni</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linia pod akapitami</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Odstęp między wierszami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Własne ustawienia tabulacji</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Symbol ikony tekstu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Szerokość:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Ustawienia tekstu</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Rozmiar czcionki:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Górne/Dolne przesunięcie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Kolor Linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Kolor tekstu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>pochylenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Szerokość linii:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Styl tekstu:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Lewe/Prawe przesunięcie:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Odstęp między literami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Dodaj własny tabulator</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Czcionka:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Komponowanie linii</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Odległość od linii bazowej:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Pozycja:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Odstęp między akapitami:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>Włączona</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>podkreślenie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Obramowanie</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Kolor obramowania:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Ustawienia zgodne z OCADem</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Nie można cofnąć, bo ostatni krok jest nieprawidłowy. Może się tak dziać np. jeśli zmienisz symbol obiektu na inny, a potem usuniesz stary symbol.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Nie można ponowić, ponieważ następny krok jest nieprawidłowy. Dzieje się tak np. kiedy usuniesz symbol obiektu, który narysowałeś.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Cofanie tego kroku oznacza wrócenie do wersji sprzed załadowania pliku. Czy na pewno chcesz to zrobić?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Potwierdzenie</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Nie udało się zlokalizować plików pomocy.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Nie udało się zlokalizować przeglądarki pomocy (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Nie udało się uruchomić przeglądarki pomocy (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Nieobsługiwany element: %1 (wers %2 koluma %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Spodziewana %1 część mapy, znaleziona %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Spodziewany %1 symbol, znaleziony %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Kolor dodatkowy %1 nie znaleziony w trakcie przetwarzania %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Spodziewane %1 kolory, znalezione %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_pt_BR.ts
+++ b/translations/OpenOrienteering_pt_BR.ts
@@ -2,251 +2,264 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_BR">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Mapa de orientação</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Sobre %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Tudo sobre licenças, notas de direitos autorais, condições e renúncias.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Desenvolvedores do OpenOrienteering em ordem alfabética:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(iniciador do projeto)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Um programa livre para desenho de mapas de orientação</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Este programa é um aplicativo livre: você pode redistribuir e/ou modificar sob os termos de &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.
 Tradução em Português-BR feita por João Manoel Franco.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Este aplicativo é distribuído na esperança de ser útil, mas SEM NENHUMA GARANTIA; nem mesmo a garantia implícita de APTIDÃO PARA COMERCIALIZAÇÃO ou PARA UM DETERMINADO FIM. Veja a GNU General Public License (GPL), versão&amp;nbsp;3, para &lt;a %1&gt;mais detalhes&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Agradecemos às seguintes pessoas pelas contribuições:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Abrir o arquivo mais recente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Mostrar a Dica do Dia</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Mostrar itens remanescentes</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Tamanho mínimo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Preenchimento</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Preencher linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Preencher padronagem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Linha simples</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Linhas paralelas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Espaço de linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Coluna simples</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Intervalo de padronagem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Ajuste de padronagem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Ajuste de coluna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Colunas paralelas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Espaço de coluna:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Rotação completa</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translatorcomment>graus</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>Ajustar por objeto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Elemento desenhado na borda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Desenhe elementos se o centro está dentro dos limites</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Desenhe elementos se qualquer dos pontos está dentro dos limites.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Desenhe elementos se todos os pontos estão dentro do limite.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Configurações de área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Preencher padronagem %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Preencher linha %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Nenhum preencimento selecinado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Cor da área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Ajuste da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Cor da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Largura da linha:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Arquivo salvo automaticamente</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n byte</numerusform>
@@ -254,249 +267,249 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Arquivo salvo pelo usuário</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Recuperação de arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Arquivo %1 não foi fechado corretamente. No momento, há duas versões:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Salvar o arquivo ativo para remover a versão em conflito.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Editar cor do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definir como cor especial:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mistura de cores especiais (retículas e sobreimpressão):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Nocaute: apaga cores inferiores</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Calcula de cores especiais</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Calcula de cor RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Processo de cor personalizada:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Ciano</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Amarelo</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Preto</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Calcula de cor CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Cor RGB personalizada:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Vermelho</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Área de trabalho</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Impressão profissional</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>-sem nome-</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- nenhum -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Transparência</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Cor especial</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Novo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Mover acima</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Mover abaixo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Duplo-clique no valor de cor para abrir uma caixa de diálogo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>O mapa contém símbolos com esta cor. Apagando irá remover a cor desses objetos! Você quer mesmo fazer isso?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (duplicado)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Duplicar)</translation>
     </message>
@@ -509,301 +522,301 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         <translation type="vanished">Por favor inserir uma porcentagem entre 0% e 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Duplo-clique para definir a cor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Clicar para selecionar o nome e clicar novamente para editar.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Número de objetos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Símbolo de linha particular -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Símbolo de área particular -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Editar símbolo particular...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Ajustes de combinação</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Mudar símbolo de público para particular</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Pegar o símbolo antigo como modelo para símbolo particular?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Símbolo %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Configurar grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Mostar grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Alinhar à grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Escolher...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Todas as linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Linhas horizontais</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Linhas verticais</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Alinhamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Alinhar com o norte magnético</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Alinharcom a grade de norte</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Alinharcom o norte verdadeiro</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Rotação adicional (anti-horária):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translatorcomment>graus</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Posicionamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>metros no terreno</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milímetros no mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Espaçamento horizontal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Espaçamento vertical:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Ajuste horizontal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Ajuste vertical:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Unidade:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Cor da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Exibir:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Escolher cor da grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origem a: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>Origem das coordenadas do papel</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>Origem das coordenadas projetadas</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Clique ou arraste&lt;/b&gt;: Começar a desenhar o buraco. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>A linha de corte deve terminar na borda da área!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Início e final da linha de corte estão em diferentes partes do objeto!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Início e final da linha de corte estão na mesma posição!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Clique&lt;/b&gt; na linha: Dividir em duas. &lt;b&gt;Arrastar&lt;/b&gt; sobre alinha: Remover esta parte da linha. &lt;b&gt;Clicar ou Arrastar&lt;/b&gt; na borda da área: Iniciar uma linha de corte. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Dividir buracos em objetos de área não é possível ainda!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Recortar todo o mapa. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Clicar ou arrastar&lt;/b&gt;: Selecionar os objetos a recortar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Recortar os objetos selecionados. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Não pode abrir o arquivo.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>O arquivo não é um arquivo DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Determinar tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Letra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>A</translation>
@@ -817,1149 +830,1149 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         <translation type="vanished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Distribuir pontos uniformemente ao longo da linha</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Número de pontos por linha:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Também colocar objetos em pontos do final de linha</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Configurações de rotação</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Alinhar pontos com a direção da linha</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translatorcomment>graus</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Ângulo de rotação adicional (anti-horária):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Desenhar círculo começando do centro</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Iniciar um círculo ou elipse. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Desenhar um círculo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Segurar %1 para desenhar pelo centro.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Finalizar o círculo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Desenhar uma elipse. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Desenhar uma linha. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr</translatorcomment>
         <translation>&lt;b&gt;Pontos de traço.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt;: Encaixar ou anexar a objetos existentes. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt;: Pegar direção de objeto existente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt;: Encaixar em objeto existente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ângulos fixos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Desfazer último ponto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Terminar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translatorcomment>Encaixar em objeto existente.</translatorcomment>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Ângulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>Traço</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Distância:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Iniciar uma linha reta. &lt;b&gt;Arrastar&lt;/b&gt;: Iniciar uma curva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Arrastar&lt;/b&gt;: Seguir objeto existente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Desenhar uma linha reta. &lt;b&gt;Arrastar&lt;/b&gt;: Desenhar uma curva. &lt;b&gt;Duplo-clique ou direito&lt;/b&gt;: Terminar a linha. &lt;b&gt;%1&lt;/b&gt;: Fechar a linha. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Toque no mapa para terminar a média</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Terminar ajuste do objeto. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Ângulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translatorcomment>Voltar a rotação</translatorcomment>
         <translation>Desfazer a rotação</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translatorcomment>graus</translatorcomment>
         <translation>&lt;b&gt;Ângulo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ângulos fixos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Criar um objeto de ponto.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Criar um objeto e dar sua direção.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Voltar rotação.</translation>
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Terminar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Encaixar na linha</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>Traço</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Clicar ou Arrastar&lt;/b&gt;: Iniciar um retângulo. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Encaixar em linha existente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Definir ponto de canto. &lt;b&gt;Duplo-clique ou direito&lt;/b&gt;: Terminar o retângulo. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation type="unfinished">Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Cancela edição. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Criar um texto com ponto fixo. &lt;b&gt;Drag&lt;/b&gt;: Criar uma caixa de texto. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translatorcomment>Alternancia entre segmento reto e curvo.</translatorcomment>
         <translation>Alternar curva</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Movimento livre. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt; no segmento: Alternar entre segmento reto e curvo. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Encaixar</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Ponto / Ângulo</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>Alternar ponto de traço/canto</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Manter haste de posições opostas. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt; no ponto: Apagar; na linha: Adicionar ponto de traço; com &lt;b&gt;%2&lt;/b&gt;: Adicionar ponto normal. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt; no ponto: Apagar; na linha: Adicionar un novo ponto; com &lt;b&gt;%2&lt;/b&gt;: Adicionar um ponto de traço. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translatorcomment>Para adicionar pontos de traço/canto Clicar+Ctr+espaço. Para retirar ponto de traço/canto Clicar+Ctr. O ponto de traço/canto tem formato de diamante.</translatorcomment>
         <translation>&lt;b&gt;%1+Clicar&lt;/b&gt; no ponto para trocar ponto de traço para normal. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Ajuste de coordenada:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distância:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ângulos fixos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Encaixar em objeto existente. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Selecionar um objeto. &lt;b&gt;Arrastar&lt;/b&gt;: Selecionar vários objetos.&lt;b&gt;%1+Clicar&lt;/b&gt;: Alternar seleção. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Apagar objetos selecionados. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Exibição do mapa em alta qualidade (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing faz o mapa parecer melhor, mas  a exibição em tela fica mais lenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Exibição do mapa em alta qualidade (antialiasing), lenta</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Tolerância de clique:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Distância de encaixe (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Escalonamento do modo ângulo fixo (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translatorcomment>grau determinado para os ângulos</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Quando selecionar um objeto, automaticamente seleciona seu símbolo também</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Afastar visualização pelo cursor quando usar afastar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Ferramentas de desenho: definir último ponto ao terminar com clique direito</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Mapas base: manter ajustes dos mapas base fechados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Ferramenta de edição:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Manter forma antiga</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Voltar hastes de curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Manter hastes de curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Ação ao apagar um ponto de curva com %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Ferramenta Retângulo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Raio da cruz de auxílio:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Mostrar a largura de linhas com cruz de auxílio</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Não pode criar novo arquivo: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Formato (%1) não suporta exportar</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>A área do mapa é grade. Usar a ferramenta de preencher pode ser muito lento. Você quer usá-la mesmo assim?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>A área selecionada não é limitada por linhas ou áreas, não se pode preencher esta área.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>A posição selecionada não estã livre, não se pode usar a ferramenta de preencher.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Falha em criar o objeto de preenchimento.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Click&lt;/b&gt;: Preencher área com o símbolo ativo. A área a ser preenchida deve ter linhas ou areas na borda, outros símbolos não são levados em conta. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS está desabilitado nas configurações de dispositivos. Abrir configurações agora?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Sim</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Não</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importe com GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Configuração</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parâmetro</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Aparência</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Língua:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Tela</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixels por polegada:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Iniciar aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Salvar arquivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Manter compatibilidade com Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Salvar informação para recuperação automática</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervalo de salvamento da informação de recuperação:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translatorcomment>minutos</translatorcomment>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Importar e exportar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>Codificação de 8-bits:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Mais...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Use o novo importador OCD também para arquivos Ocad 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Nota</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>O aplicativo deve ser reiniciado para que a mudança de língua tenha efeito!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Tradução livre</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Arquivos de tradução (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>O arquivo selecionado não é uma tradução válida.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Resolução da tela inicial em pixels:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Tamanho da tela inicial em polegadas (diagonal):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translatorcomment>Universal Transverse Mercator</translatorcomment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>Coordenadas UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM Zone (número norte/sul)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, datum: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Coordenadas Gauss-Kruege</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Número de Zona (1 a 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>pelo código EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>Coordenadas EPSG @code@</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Coordenadas locais</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>Código EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Personalização PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Especificação</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Especificação da escala do mapa inválida ou perdida.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Fator da escala de grade inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Língua da especificação CRS desconhecida: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Especificação geográfica CRS não suportada: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Mapa Georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Busca...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Declinação:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Coordenadas projetadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Coordenadas geográficas</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Mostrar ponto de referência em:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>válido</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;Mapas de World of O&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Busca de declinação online</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Sistema de referência de coordenada do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- local -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translatorcomment>O fator de escala da grade é a razão entre a distância na grade plana e a distância correspondente no modelo curvo da Terra. Ele é aplicado como fator para distâncias no terreno para distâncias de grade plana.</translatorcomment>
         <translation>Fator de escala da grade:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Ponto de referência</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Pegar no mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Datum: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translatorcomment>Leste</translatorcomment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translatorcomment>norte</translatorcomment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translatorcomment>leste</translatorcomment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Norte do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>Sistema de  referência de &amp;Coordenada:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Coordenadas do mapa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Coordenadas geográficas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>Em mudanças de CRS, manter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Declinação:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>A declinação magnética para o ponto de referência %1° %2° vai agora ser recuperada a partir de &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Você quer continuar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Mudança de declinação</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>A declinação foi mudada. Você quer rotacionar o conteúdo do mapa também?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Coordenadas locais:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Carregando...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>travado</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Não foi possível analisar dados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Valor de declinação não encontrado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>A busca de declinação online falhou:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translatorcomment>valor em graus</translatorcomment>
@@ -1967,216 +1980,216 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Selecionar ponto de referência. &lt;b&gt;Clique direito&lt;/b&gt;: Cancelar.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Bem-vindo ao OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Atividades</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Criar um novo mapa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Abrir mapa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Sobre %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Mapas recentes</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Abrir o mapa mais recente ao iniciar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Limpar lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Dica do Dia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Mostrar Dica do Dia</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Exemplos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Sobre Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Lista de arquivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Arquivos de mapas não encontrados!&lt;br/&gt;&lt;br/&gt;Copie os arquivos de mapas numa pasta principal chamada &apos;OOMapper&apos; no dispositivo ou cartão de memória.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Erro ao carregar um símbolo do tipo %1 na linha %2 coluna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Símbolo ID &apos;%1&apos; não é o único na linha %2 coluna %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Erro ao carregar um símbolo do tipo %1 na linha %2 coluna %3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Erro ao carregar um objeto do tipo %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Erro enquanto busca um objeto do tipo %1 at %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Incapaz de encontrar símbolo para objeto em %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Objeto de ponto com símbolo indefinido ou errado em %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versões 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Não foi possível analisar as coordenadas.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Esperadas %1 coordenadas, encontradas %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Erro ao carregar a configuração de impressão em %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Erro ao carregar passos de desfazer/refazer em %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Não há tal opção: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Dado de Vetor Geoespacial</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Encontrado um objeto sem símbolo.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Entrou %n objeto irregular.</numerusform>
@@ -2184,18 +2197,18 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Erro durante pós-processamento de símbolo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Mapa Base &quot;%1&quot; foi carregado da pasta de mapas em vez da localização prevista no arquivo do mapa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Falha ao carregar mapa base &apos;%1&apos;, razão: %2</translation>
     </message>
@@ -2204,191 +2217,191 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         <translation type="vanished">Falha ao carregar mapa base &apos;%1&apos;, razão: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Avisos ao carregar mapa base &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Pelo menos um mapa base não foi encontrado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Clicar no nome em vermelho em Mapas Base -&gt; Janela Mapa Base para localizar nome do arquivo de mapa base.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Este arquivo usa um formato obsoleto. O suporte para este formato será removido deste aplicativo em breve. Para abrir o arquivo no futuro, salve-o em formato novo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Versão de formato de arquivo inválida.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Versão de formato de arquivo antiga sem suporte. Por favor usar um programa antigo para carregar e atualizar o arquivo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Versão de formato de arquivo nova sem suporte. Alguns elementos do mapa não serão carregados ou salvos nesta versão do programa. Melhor fazer atualização.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>O sistema de referência de coordenada geográfica do mapa é &quot;%1&quot;. Este CRS não tem suporte. Usando &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Erro ao carregar um símbolo do tipo %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Erro ao carregar um símbolo.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Erro ao carregar passos do desfazer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Erro ao ler o número de ítens do mapa parcial.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Erro ao carregar o mapa parcial%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Não foi possível ler o arquivo: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Formato de arquivo sem suporte.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Versão de formato de arquivo nova sem suporte. Alguns elementos do mapa não serão carregados ou salvos nesta versão do programa.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Formato (%1) não suporta importação</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Pode não ser lido &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Configuração de linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Largura de linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Cor da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Comprimento mínimo da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Ponta da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>plana</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>arredondada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>quadrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>pontuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Junção da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>em ângulo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>chanfrado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Comprimento da ponta:</translation>
     </message>
@@ -2398,334 +2411,335 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
         <translation>Linha pontilhada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Mostrar pelo menos um símbolo intermediário</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Quantidade mínima de símbolo intermediário:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Quantidade mínima de símbolo intermediário ao fechar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Comprimento de traço:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Linha tracejada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Comprimento de quebra:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Traços agrupados juntos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Comprimento de quebra de grupo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Comprimento pela metade no primeiro e último traço</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Símbolos intermediários</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Símbolos intermediários por local:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Distância de símbolo intermediário:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Bordas</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Bordas diferentes nos lados esquerdo e direito</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Borda esquerda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Borda direita:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Símbolo do início</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Símbolo intermediário</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Símbolo do final</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Símbolo de traço</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Habilitar linhas de borda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Distância entre pontos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Distância do final da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Suprimir o símbolo de traço no início e final da linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Largura da borda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Cor da borda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Deslocamento da borda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Borda tracejada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Comprimento de traço da borda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Comprimento de quebra da borda:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Criar um mapa novo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Abrir um arquivo existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Abrir &amp;Recente</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Salvar</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Salvar &amp;como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Configurações...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Fechar este arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>Sa&amp;ir</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Sair do aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Abrir  &amp;Manual</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Mostrar o arquivo de ajuda para este aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>So&amp;bre %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Mostrar informação sobre este aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Sobre o tradutor &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Mostra informação sobre o tradutor Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Você quer remover a versão salva automaticamente?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>O arquivo foi modificado.
 Você quer salvar as alterações?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Arquivo não salvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2734,60 +2748,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Quer alterar a escala dos símbolos para a escala do mapa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Aviso de falha</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Parece que %1 falhou na última vez que este arquivo foi aberto:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Tentar reabrir novamente?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Auto-salvamento...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Auto-salvamento falhou!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Todos os mapas</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Todos os arquivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Você precisa fechar o arquivo atual antes de abrir um novo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Abrindo %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2798,19 +2812,19 @@ File format not recognized.</source>
 Formato de arquivo não reconhecido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>O arquivo foi modificado.
 Você quer descartar as alterações?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2821,44 +2835,44 @@ Selecione &quot;Sim&quot; para salvar neste formato.
 Selecione &quot;Não&quot; para salvar em formato diferente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Salvar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Arquivo não pode ser salvo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Existe um problema em determinar o formato do arquivo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Por favor reportar isto como uma falha.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2867,7 +2881,7 @@ because saving as %2 (.%3) is not supported.</source>
 porque salvar como %2 (.%3) não é suportado.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2876,31 +2890,31 @@ because the format is unknown.</source>
 porque porque o formato é desconhecido.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>A exportação do mapa gerou avisos.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Erro interno ao salvar:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>A importação do mapa gerou avisos.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2909,12 +2923,12 @@ for reading.</source>
 para leitura.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Tipo de arquivo inválido.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2925,7 +2939,7 @@ para leitura.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -2934,17 +2948,17 @@ para leitura.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Nada para importar.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Pergunta</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -2953,23 +2967,23 @@ Rescale the imported data?</source>
 Alterar a escala dos dados importados?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>parte padrão</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Nova cor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation type="unfinished">Importar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Recolocação de Símbolo foi cancelada.
@@ -2977,201 +2991,201 @@ Importar os dados assim mesmo?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Preto de registro (todas as cores de impressão)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Coordenadas estão fora dos limites.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Desfazer o último passo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Refazer o último passo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Cor&amp;tar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>C&amp;opiar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>Co&amp;lar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Aproximar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Afastar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Alternar para modo de tela cheia</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Ajustar fator de ampliação...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Janela de Símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Mostrar/Ocultar a janela de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Janela de Cores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Mostrar/Ocultar a janela de cores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Substituir os símbolos pelos de outro arquivo de mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Alterar escala de todos os símbolos...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Alterar escala de todo o conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Alterar a escala do mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Alterar a escala do mapa e ajustar objetos do mapa e tamanho de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Notas do mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Configuração de Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Mostrar/Ocultar a janela de Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Abrir Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Mostrar mapa inteiro</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Editar objetos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Definir objetos de ponto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Desenhar linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Desenhar elipses e círculos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translatorcomment>Escreve um texto no mapa. Selecione um símbolo de texto para usar esta ferramenta.</translatorcomment>
         <translation>Escrever texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Trocar símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Preencher / Criar borda</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Trocar direção do traço</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Unir linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Cortar objeto</translation>
     </message>
@@ -3180,255 +3194,255 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Rotacionar objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Medir comprimentos e áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Cortar parte da área</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Mesclar buracos em área</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Pintar sobre o Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Habilitar cursor táctil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Ativar exibição de GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Ativar anéis de distância de GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Definir objeto de ponto na posição do GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Definir marcador temporário na posição do GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Criar linha temporária na posição do GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Limpar marcadores temporários do GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Ativar exibição de bússola</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Alinhar mapa com o norte</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Adicionar nova parte...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Renomear parte atual...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Remover parte atual</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Mesclar as partes</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Exibir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Ferramentas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Sí&amp;mbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>M&amp;apa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>Mapa &amp;Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Desenhar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Pintar no Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Edição em andamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>O mapa está sendo editado. Por favor termine a edição antes de salvar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Mapa salvo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Mostrar grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Configurar grade...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Áreas hachuriadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Vista de linha de base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Ocultar Mapas Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Trocar símbolos...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georreferência...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Rotacionar mapa...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Rotacionar o mapa todo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Reabrir Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translatorcomment>Pode gravar informação adicional a um objeto do mapa, por exemplo a altura de alguns elementos de ponto de controle.</translatorcomment>
         <translation>Editor de Tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Mostrar/Ocultar editor de Tag / Pode gravar informação adicional a um objeto do mapa, por exemplo a altura de alguns elementos de ponto de controle</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Desenhar retângulos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Desenhar a mão livre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Preencher áreas delimitadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Cortar buraco de forma livre</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Cortar buraco circular</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Cortar buraco retangular</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Rotacionar padronagem</translation>
     </message>
@@ -3437,225 +3451,225 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Reescalonar objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translatorcomment>Unificar áreas sobrepostas. Selecionar pelo menos dois objetos de área para realizar este comando.</translatorcomment>
         <translation>Unificar áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translatorcomment>Intersecção de áreas sobrepostas. Este comando deixa apenas a parte de intersecção entre duas áreas ou linhas sobrepostas.</translatorcomment>
         <translation>Intersecção de áreas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translatorcomment>Separar área não comum entre áreas sobrepostas. Retira a área de intersecção e deixa área a não comum entre áreas sobrepostas.</translatorcomment>
         <translation>Separar área não comum</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Cortar o interior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Distribuir pontos ao longo de linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Coordenadas do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Coordenadas projetadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Latitude/Longitude (Declinação)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Latitude/Longitude (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Exibir coordenadas como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Recortar buraco</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Selecionar nada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Inverter seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Editar o símbolo set ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Carregar arquivo CRT...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3668,81 +3682,81 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Mostre/Esconda a janela de seleção de Tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Copiar na posição</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Copiar para a área de transferência.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Exibir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Mapa parcial</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Selecionar Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Edição</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Edição avançada</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Selecionar símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Ocultar barra superior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Mostrar barra superior</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Imprimr / Exportar não está disponível nesta versão do programa!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Nenhum passo de desfazer disponível.</translation>
     </message>
@@ -3752,8 +3766,8 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Cortar %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Ocorreu um erro interno!</translation>
     </message>
@@ -3762,7 +3776,7 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Copiado %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Não há objetos na área de transferência que possam ser colados!</translation>
     </message>
@@ -3771,67 +3785,67 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Colado %1 objeto(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Configuração de fator de exibição</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Fator de exibição:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Cores</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Reescalonar todos os símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Reescalonar em porcentagem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Notas do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Mapas Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translatorcomment>Pode gravar informação adicional a um objeto do mapa, por exemplo a altura de alguns elementos de ponto de controle.</translatorcomment>
         <translation>Editor de Tag</translation>
@@ -3841,7 +3855,7 @@ Importar os dados assim mesmo?</translation>
         <translation type="vanished">Seletor de Tag</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3851,7 +3865,7 @@ símbolo
 selecionado</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3861,44 +3875,44 @@ símbolos
 selecionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Posiciona objeto de ponto no mapa. Clicar e arrastar para indicar direção do objeto, se for o caso.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translatorcomment>Esta ferramenta funciona somente com objetos de ponto.</translatorcomment>
         <translation>Selecione um objeto de ponto para usar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translatorcomment>Para desenhar linhas poligonais, clique e arraste em seguida com o mouse. Para curvas, clicar e soltar movendo o mouse para o ponto de tangência e aí clicar de novo e arrastar ajustando a curva.</translatorcomment>
         <translation>Desenhar linhas curvas e poligonais.  Clicar e arrastar para desenhar linha reta, mais um clique para confirmar. Clicar e soltar, depois clicar adiante e arrastar para desenhar curva. Duplo clique para finalizar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translatorcomment>Esta ferramenta funciona somente com objetos de linha, área ou símbolos combinados desses.</translatorcomment>
         <translation>Selecionar uma linha, área ou símbolos combinados para usar esta ferramenta. Esta ferramenta funciona somente com objetos de linha, área ou símbolos combinados desses.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Desenhar elipses e círculos. Clicar e arrastar para desenhar círculo. Clicar e soltar, depois clicar adiante marcando o comprimento e arrastar para desenhar largura da elipse.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Desenhar linhas a mão livre. Clicar e movimentar o mouse para desenhar a linha, finalizar com duplo clique.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Preenche áreas com bordas. Selecionar a linha no mapa e depois o símbolo para preencher e então selecionar este comando.</translation>
     </message>
@@ -3907,214 +3921,214 @@ selecionados</translation>
         <translation type="vanished">Apaga o(s) objeto(s) selecionado(s).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Ajusta a direção da padronagem da área ou de objeto de ponto. Selecione este comando depois clique sobre o objeto e arraste para indicar a direção.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translatorcomment>Esta ferramenta funciona somente com objetos de ponto ou padronagem de área que possam ser rotacionados.</translatorcomment>
         <translation>Selecione um objeto de área com padronagem rotacionável ou objeto de ponto para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Símbolo resultante: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translatorcomment>Esta ferramenta funciona somente com objetos de área ou combinados com linha.</translatorcomment>
         <translation>Selecione pelo menos dois objetos de área ou linha para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translatorcomment>Esta ferramenta funciona somente com objetos de área sobrepostos.</translatorcomment>
         <translation>Unificar objetos sobrepostos. Selecione dois objetos sobrepostos e depois use este comando.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translatorcomment>Deixa apenas a área de intersecção entre os objetos selecionados.</translatorcomment>
         <translation>Remove todas as partes que não estão sobrepostas com o primeiro objeto selecionado. Deixa apenas a área de intersecção entre os objetos selecionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translatorcomment>O segundo objeto deixa de ter a parte anteriormente sobreposta.</translatorcomment>
         <translation>Remove todas as partes sobrepostas com o primeiro objeto selecionado. O segundo objeto deixa de ter a parte anteriormente sobreposta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translatorcomment>Deixa a parte sobreposta com um buraco, depois de fundir os dois objetos. Assume o símbolo do primeiro objeto selecionado.</translatorcomment>
         <translation>Remove todas as partes que sobrepoem o primeiro objeto selecionado. Deixa a parte sobreposta com um buraco, depois de fundir os dois objetos. Assume o símbolo do primeiro objeto selecionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Mesclar área de buracos, ou mesclar buracos com a borda para cortar o que estiver de fora. Mescla os buracos e corta o que estiver de fora da borda selecionada.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translatorcomment>Os buracos devem estar sobrepostos para ter o efeito de mesclar.</translatorcomment>
         <translation>Selecionar um objeto de área com buracos para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translatorcomment>O recorte é feito no primeiro objeto selecionado.</translatorcomment>
         <translation>Criar um recorte fora de alguns objetos ou do mapa inteiro. O recorte é feito no primeiro objeto selecionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Selecione uma linha fechada como formato para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Corte para fora alguns objetos ou tudo em uma área delimitada.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Coloca objetos de ponto espaçados uniformemente ao longo de um objeto de linha existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Selecione pelo menos um objeto de linha e um símbolo de ponto para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Mesclar buracos falhou.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Limpar marcadores temporários</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Tem certeza de que deseja excluir todos os marcadores de GPS temporários? Isso não pode ser desfeito.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Mesclar esta parte com</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Mover objetos selecionados para</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Colocar o nome do mapa parcial:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Mudado para mapa parte &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Mesclar partes do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Você deseja mover todos os objetos do mapa parcial &quot;%1&quot; to &quot;%2&quot;, e remover &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Você deseja mover todos os objetos para o mapa parcial &quot;%1&quot;, e remover todas as outras partes do mapa?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Não é possível importar o arquivo de mapa selecionado porque ele não pôde ser carregado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translatorcomment>Clicar e arrastar na direção da primeira linha, depois clicar e arrastar a linha perpendicular. Finalizar com duplo-clique.</translatorcomment>
         <translation>Desenhar retângulos. Clicar e arrastar na direção da primeira linha, depois clicar e arrastar a linha perpendicular. Finalizar com duplo-clique.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Imprimir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Imagem</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Limpar histórico desfazer / refazer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Limpar histórico desfazer / refazer para reduzir tamanho de arquivo do mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Mover a tela</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Simulação de sobreimpressão</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Editar linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Converter em curvas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Simplificar linhas</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Exportar como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Escreve texto no mapa. Clicar para iniciar o texto a partir de um ponto. Clicar e arrastar para criar uma janela de texto.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Selecione um símbolo de texto para usar esta ferramenta.</translation>
     </message>
@@ -4123,27 +4137,27 @@ selecionados</translation>
         <translation type="vanished">Duplica o(s) objeto(s) selecionado(s).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Selecione pelo menos um objeto para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translatorcomment>Tem efeito em objetos de linha não simétricos.</translatorcomment>
         <translation>Muda a direção de símbolos em objetos de linha. Tem efeito em objetos de linha não simétricos.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Selecione pelo menos um objeto de linha para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Conecta pontas de linhas póximas. Une duas linhas de mesmo símbolo.</translation>
     </message>
@@ -4152,17 +4166,17 @@ selecionados</translation>
         <translation type="vanished">Corta o(s) objeto(s) selecionado(s) em pequenas partes.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Selecione pelo menos um objeto de linha ou área para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Corta um buraco no objeto de área selecionado. Usa a ferramento de denho de linhas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Selecione um objeto de área para ativar esta ferramenta.</translation>
     </message>
@@ -4175,18 +4189,18 @@ selecionados</translation>
         <translation type="vanished">Redimensiona o(s) objeto(s) selecionado(s). Aparece um ponto central, depois clicar e arrastar sobre o objeto para aumentar ou diminuir o tamanho.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Muda linhas feitas de segmentos de reta em curvas suaves.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Selecione um objeto de linha para ativar esta ferramenta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Reduz o número de pontos em objetos de linha enquanto tenta manter sua forma.</translation>
     </message>
@@ -4195,8 +4209,8 @@ selecionados</translation>
         <translation type="vanished">Troca o símbolo do(s) objeto(s) selecionado(s) para o símbolo selecionado. Funciona com símbolos de mesmo tipo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Selecione pelo menos um objeto e um símbolo diferente compatível para ativar esta ferramenta.</translation>
     </message>
@@ -4209,7 +4223,7 @@ selecionados</translation>
         <translation type="vanished">%1 objeto(s) duplicado(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Seleção de objeto</translation>
     </message>
@@ -4218,78 +4232,78 @@ selecionados</translation>
         <translation type="vanished">Nenhum objeto foi selecionado porque não há objetos com o(s) símbolo(s) selecionado(s).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translatorcomment>Mede comprimento de objeto de linha e área de objeto de área.</translatorcomment>
         <translation>Medir</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Falhou a unificação.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Falhou a intersecção.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Falhou a diferenciação.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Falhou a separaração de área não comum.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Você quer remover o mapa parcial &quot;%1&quot; e todos os seus objetos?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Pintura a mão livre no Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Pintura a mão livre no Mapa Base. Criar ou carregar um Mapa Base que possa ser pintado para ativar esta função</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importar %1, arquivo GPX, OSM ou DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Arquivos importáveis</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Todos os arquivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Não é possível importar o arquivo selecionado porque o seu formato de arquivo não é suportado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Girar objetos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Redimensione objetos</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4298,7 +4312,7 @@ selecionados</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Objeto(s) %n copiados</numerusform>
@@ -4306,7 +4320,7 @@ selecionados</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Objeto(s) %n adicionados</numerusform>
@@ -4314,42 +4328,42 @@ selecionados</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Apaga os objetos selecionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Duplica os objetos selecionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Gira os objetos selecionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Redimensiona os objetos selecionados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Corta os objetos selecionados em partes menores.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Troca o símbolo dos objetos selecionados para símbolo selecionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Preenche as linhas selecionadas ou cria um fronteira para as áreas selecionadas.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Objeto(s) %n duplicados</numerusform>
@@ -4357,180 +4371,180 @@ selecionados</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Nenhum objeto foi selecionado porque não há objetos com os símbolos selecionados.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Abortar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Mais: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Mais: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Mais: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Buscar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Buscar &amp;próximo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Objetos encontrados</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Buscar próximo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Buscar &amp;todos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Processando separações de página %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Processando página %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Cancelado</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Terminado</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Fonte do Texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Mapa (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>Linguagem não definida</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Tradução (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Antes de ser editado o texto gravado será substituído pela tradução corrente. Você deseja continuar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Após modificar o texto gravado a tradução não estará mais disponível. Você deseja continuar?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>milímetros</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>metros</translatorcomment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4545,7 +4559,7 @@ abrir o diálogo de cores e
 definir lá as cores.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4560,7 +4574,7 @@ e selecione &quot;Novo símbolo&quot;
 para criar um.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4573,7 +4587,7 @@ Para carregar o mapa base, clique
 Mapa Base -&gt; Abrir Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Dica: Segure o botão central do mouse para arrastar o mapa,
@@ -4581,128 +4595,128 @@ aproximar e afastar usando a roda do mouse, se disponível.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Medida da borda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Nenhum objeto selecionado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objetos selecinados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>O objeto selecinado não é uma linha.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>milímetros</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>metros</translatorcomment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translatorcomment>milímetros quadrados</translatorcomment>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translatorcomment>metros quadrados</translatorcomment>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Este objeto é muito pequeno.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>A área mínima é %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>mm²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Nota: Comprimento e área são corretos apenas se não há interseções e buracos sendo usados.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Esta linha é muito curta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>A distância mínima é %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translatorcomment>milímetros</translatorcomment>
         <translation>mm</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Criar novo mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Escolher escala e conjunto de símbolos para o novo mapa.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Escala:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Conjunto de símbolos:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Mostrar apenas conjuntos de símbolos de acordo com a escala selecionada</translation>
     </message>
@@ -4711,142 +4725,142 @@ aproximar e afastar usando a roda do mouse, se disponível.</translation>
         <translation type="vanished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Criar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Conjunto de símbolos vasio</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Carregar conjunto de símbolos de...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Todos os conjuntos de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Todos os arquivos</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>O mapa contém mais de 256 cores que não é suportado na versão 8 ocd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad devolvido %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Preto de registro é exportado como uma cor comum.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Não é possível exportar preenchimento de padronagem para um objeto de área</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Não foi possível exportar Mapa Base: tipo de arquivo &quot;%1&quot; ainda não tem suporte</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Símbolo de linha &quot;%1&quot;, não pode ter combinação juntar pontas.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Símbolo de linha &quot;%1&quot;, negligenciando o agrupamento de traço.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Símbolo de linha &quot;%1&quot;, o número de traços em um grupo foi reduzido a 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Símbolo de linha &quot;%1&quot;, não pôde exportar as bordas corretamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Símbolo de área &quot;%1&quot;, pulou um preenchimento de padronagem.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Símbolo de área &quot;%1&quot;, assumindo um padrão de ponto &quot;linhas deslocadas&quot;. Isso pode ser correto, bem como incorreto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Símbolo de texto &quot;%1&quot;, espaçamento personalizado de caracteres foi definido, a sua aplicação ainda não coincide com o comportamento do OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Símbolo de texto &quot;%1&quot;: ignorando sublinhado</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translatorcomment>kerning: o ato de formar uma parte saliente de um tipo de letra</translatorcomment>
         <translation>Símbolo de texto &quot;%1&quot;: ignorando kerning</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>String truncada (parte marcada com três &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translatorcomment>buffer: memória intermediária.</translatorcomment>
         <translation>Não foi possível alocar buffer.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad retornou %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>Arquivos OCAD %1 não são suportados!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n separação de cor foi ignorada, razão: Importação desativada.</numerusform>
@@ -4854,391 +4868,391 @@ aproximar e afastar usando a roda do mouse, se disponível.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Não foi possível carregar as definições de cores exatas, erro: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Cor &quot;preto de Registro&quot; é importado como uma cor especial.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Não é possível importar símbolo &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Camada de importação OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>Na linha tracejada símbolo%1, as pontas de início e de final são diferentes (%2 e%3). Usando%4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>Na linha tracejada símbolo%1, o comprimento final não pode ser importado corretamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>Na linha tracejada símbolo%1, o espaçamento final não pode ser importado corretamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>Na linha tracejada símbolo%1, o comprimento principal e final são diferentes (%2 e%3). Usando%4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>Na linha tracejada símbolo%1, os espaços D e E são diferentes (%2 e%3). Usando%4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Símbolo de linha%1: suprimir símbolo de traço nas extremidades da linha.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Durante a importação do símbolo de texto%1: ignorando alinhamento justificado</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Durante a importação do símbolo de texto%1: ignorar a largura personalizada (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Durante a importação do símbolo texto %1: o espaçamento entre caracteres personalizado foi definido, a sua aplicação ainda não coincide com o comportamento do OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Durante a importação do símbolo de texto %1:  ignorando o espaçamento entre as palavras personalizado (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Durante a importação do símbolo de texto %1:  ignorando travessões personalizados (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Durante a importação do símbolo de texto %1:  ignorando enquadramento de texto (modo %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Não é possível carregar objeto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Não é possível importar objeto retangular</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Não importando símbolo de texto, não consegue descobrir o caminho&apos; (npts=%1):%2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Não é possível importar Mapa Base: Fundo &quot;%1&quot; não parece ser uma imagem raster</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Tentando importar um objeto de texto com formato de coordenadas desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>ID de cor não encontrado:%1, ignorando esta cor</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>é</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>não é</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>contem</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Busca</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>e</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>ou</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Símbolo</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>invalido</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>Símbolo de linha %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>Símbolo de texto %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Não foi possível carregar o sistema de referência de coordenadas &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Informação de cor padrão foi ignorada.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Não é possível importar símbolo %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Tipo não suportado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Não é possível importar Mapa Base: &quot;%1&quot; não é um tipo de mapa base suportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Tipo de linha não suportado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Comprimentos diferentes para pontas no início (%1 mm) e no final (%2 mm) não são suportados. Usando%3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>O padrão de traço não pode ser importado corretamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>O padrão de traço e comprimento (%1 mm) não pode ser importado corretamente. Usando %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>O padrão de traço e espaço (%1 mm) não pode ser importado corretamente. Usando %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Estilo de enquadramento linha não suportado &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Ignorado símbolo de ponto secundário.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Suprimindo símbolo de traço nas extremidades da linha.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Este símbolo não pode ser salvo como um símbolo OCD apropriado novamente.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Alinhamento justificado não é suportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Alinhamento vertical &apos;%1&apos; não é suportado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ignorando largura personalizada (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Espaçamento entre caracteres personalizado pode estar incorreto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ignorando espaçamento entre as palavras personalizado (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ignorando travessões personalizados (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ignorando enquadramento de texto (modo%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Símbolos de texto em linha ainda não são suportados. Marcando o símbolo como oculto.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Codificação &apos;%1&apos; não está disponível.  Verifique as definições.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>Na área do símbolo %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Impossível carregar o objeto</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Impossível importar objeto retangular</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Não importando símbolo de texto, não consegue descobrir o caminho &apos;(npts=%1):%2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Tentando importar um objeto de texto com formato de coordenadas desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Dados inválidos.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>Arquivos do OCAD %1 não são suportados!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>ID de cor não encontrado:%1, ignorando esta cor</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Ponto</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Linha</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Impossível carregar camada %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Impossível carregar %n objetos, razão: %1</numerusform>
@@ -5246,828 +5260,815 @@ aproximar e afastar usando a roda do mouse, se disponível.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Geometria vazia.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Falha para transformar as coordenadas.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Geometria de tipo desconhecida ou não suportada.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Coordenadas não suficientes.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Mapa de orientação</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Selecione Mapa Base para desenhar sobre ele</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Desenhar</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Clique e arrastar&lt;/b&gt;: Pintar. &lt;b&gt;Clique direito e arrastar&lt;/b&gt;: Apagar. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Seleção de cor</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover a tela. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Adicionar uma coordenada. &lt;b&gt;%1+Clicar&lt;/b&gt;: Mudar a coordenada selecionada. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Sempre orientado para o norte (não rotaciona)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Elementos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Ponto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centralizar todos os elementos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Elemento atual</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Diâmetro &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translatorcomment>milímetros</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Cor interior:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Largura exterior &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Cor exterior:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Largura da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Cor da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Ponta da linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>plana</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>arredondada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>quadrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Juntar linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>pontuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>inclinada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Linha fechada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Cor da área:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Coordenadas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Início da curva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centralizar pela coordenada média</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Ponto central]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Símbolo de ponto</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Imprimindo</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Um erro ocorreu durante o processamento.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover o mapa, a área de impressão ou bordas da área. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover a área de impressão. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover o mapa. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover a borda da área de impressão. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Mover as bordas da área de impressão. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Mostrar Mapas Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Mostrar grade</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Orientação da página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Impressora:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Retrato</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Paisagem</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Formato de página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Cópias:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Esquerda:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Topo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Largura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Visualização...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Página simples</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Área personalizada</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Área do mapa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centralizar área de impressão</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Sobreposição de página:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Resolução:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Imprimir em escala diferente:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Aparência do Mapa Base pode diferir.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simular sobreimpressão</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Dispositivo CMYK (experimental)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Modo de cor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exportar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Exportar PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Exportar imagem</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Salvar em PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translatorcomment>pontos por polegada</translatorcomment>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Não suportado no Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Falha ao preparar a pré-visualização.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Progresso da Visualização de Impressão</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Um modo de exibição fora do padrão foi ativado. Tem certeza que deseja imprimir / exportar o mapa assim?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translatorcomment>Formato PNG</translatorcomment>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translatorcomment>Formato BMP</translatorcomment>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translatorcomment>Formato TIFF</translatorcomment>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translatorcomment>Formato JPEG</translatorcomment>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Falha ao preparar a exportação PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translatorcomment>Formato PDF</translatorcomment>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Ocorreu um erro durante a impressão.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Exportar mapa ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Todos os arquivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Falha ao preparar a impressão.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Progresso de Impressão</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Gráficos
 Vetoriais</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Gráficos
 Rasterizados</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Separações
 de cores</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Modo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Falha ao preparar a imagem. Memória insuficiente.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Falha ao salvar a imagem. Será que o caminho existe? Você tem direitos suficientes?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Exportado com sucesso para%1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Não conseguiu terminar a exportação PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Cancelado.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>O trabalho de impressão não poderia ser interrompido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Trabalho de impressão criado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translatorcomment>Tamanho do papel</translatorcomment>
         <translation>Desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>O mapa está vazio. Envio cancelado.</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Reabrir Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Arraste os itens da lista da esquerda para o local desejado na lista da direita para recarregá-las.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Mapas Base fechados:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Limpar lista</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Mapas Base ativos:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Substituir conjunto de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Configurar o modo como os símbolos devem ser substituídos, e qual.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importar todos os novos símbolos, mesmo se não for usado como substituto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Excluir símbolos originais que são inutilizados após a substituição</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Apagar as cores não utilizadas após a substituição</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Mapeamento de símbolo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Mantenha os  estados de símbolos ocultos / protegidos do conjunto de símbolo antigo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Conjunto de símbolos de substituição por número de símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Substituição</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6078,7 +6079,7 @@ de cores</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6086,470 +6087,470 @@ de cores</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Nenhum -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Escolher arquivo de mapa para carregar símbolos de</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Não é possível carregar arquivo de mapa, abortando.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>O conjunto de símbolo escolhido tem uma escala de 1:%1, enquanto que a escala do mapa é de 1:%2. Você realmente quer escolher este conjunto?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Rotacionar mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Ângulo (anti-horário):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translatorcomment>graus</translatorcomment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Parâmetros de rotação</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotacionar em torno de:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Origem do sistema de coordenadas do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Ponto de referência do georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translatorcomment>Ponto do centro de rotação</translatorcomment>
         <translation>Outro ponto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajustar ponto de referência do georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Ajustar declinação do georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Rotacionar Mapas Base não georreferenciados</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Ângulo:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ângulos fixos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt; Arrastar &lt;/b&gt;: Definir a direção de preenchimento da padronagem ou do objeto de ponto. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Rotação:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ângulos fixos. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Marcar centro de rotação. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Rotacionar objetos selcionados. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Mudar escala do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Parâmetros de escala</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Nova escala:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Centro da escala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translatorcomment>Ponto do centro da escala:</translatorcomment>
         <translation>Origem do sistema de coordenadas do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Ponto de referência do georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Outro ponto,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Reescalonar símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Reescalonar posições dos objetos do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Ajustar ponto de referência do georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Reescalonar Mapas Base não georreferenciados</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Reescalonar:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Clicar&lt;/b&gt;: Definir centro do reescalonamento. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt;: Reescalonar os objetos selecionados. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Selecionar sistema de referência das coordenadas</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>O mesmo do mapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Local</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Coordenadas Geográficas (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Situação:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>válido</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- nenhum -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Nenhum -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Número:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Descrição:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Símbolo auxiliar (não exibido no mapa final)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Para símbolos com descrição, pressione F1 enquanto a dica estiver visível para mostrá-lo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Novo símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>de Ponto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>de Linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>de Área</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>de Texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Combinado</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Reescalonar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
@@ -6562,12 +6563,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Preencher / Criar borda no(s) objeto(s) selecionado(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Símbolos selecionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Ativar arrastar e soltar</translation>
     </message>
@@ -6576,198 +6577,198 @@ Do you want to save your changes?</source>
         <translation type="vanished">Reescalonar símbolo(s)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Ocorreu um erro interno!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Não há símbolos na área de transferência que pode ser colados!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Selecione todos os objetos com este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Adicionar todos os objetos com este símbolo à seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Remover todos os objetos com este símbolo da seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Ocultar os objetos com este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Proteger os objetos com este símbolo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Adicionar todos os objetos com seus símbolos à seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Remover todos os objetos com seus símbolos da seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Ocultar objetos com os símbolos selecionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Proteger objetos com os símbolos selecionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Inverter seleção</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translatorcomment>Atalho para exibir a decrição dos símbolos</translatorcomment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Selecionar todos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Selecionar os não utilizados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Classificar símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Classificar por número</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Classificar por cor primária</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Classificar por prioridade de cor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Reescalonar para porcentagem:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>O mapa contém objetos com o símbolo &quot;%1&quot;. Excluindo ele irá apagar esses objetos e limpar o histórico de desfazer! Você realmente quer fazer isso?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Selecione todos os objetos com os símbolos selecionados</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Configuração de símbolos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Mapa Base:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Mapa Base:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(nenhum)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centralizar Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>caixa delimitadora na origem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>centro de gravidade na origem</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Selecionar cor de fundo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6778,58 +6779,58 @@ cegonhas felizes
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished">-sem nome-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Sem descrição!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished">Tecla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6838,7 +6839,7 @@ cegonhas felizes
         <translation type="obsolete">Ajuda</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6846,203 +6847,203 @@ cegonhas felizes
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Tecla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>A tecla existe</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>A tecla &quot;%1&quot; já existe e não pode ser usada duas vezes.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Encontrar arquivo de Mapa Base movido</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Todos os arquivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Arquivo inexistente.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>É o formato do arquivo correto para este tipo de Mapa Base?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Ajuste de Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Falha ao calcular o ajuste!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt; Clicar &lt;/b&gt;: Define a posição do ponto de ajuste no Mapa Base. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt; Clicar &lt;/b&gt;: Define a posição do ponto de ajuste no mapa. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt; Clicar &lt;/b&gt;: Apaga pontos de ajuste. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt; Arrastar &lt;/b&gt;: Move pontos de ajuste. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Pontos de ajuste:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Novo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Mapa Base X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Mapa Base Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Mapa X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Mapa Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Aplicar pontos de ajuste</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Aplicar &amp;&amp; limpar todos</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Limpar todos</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Não há memória livre suficiente (tamanho da imagem:%1x%2 pixels)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7051,219 +7052,219 @@ Salvar arquivos GIF não é suportado. Isto significa que os desenhos sobre este
 Se você não pretende desenhar sobre esta imagem no entanto, não há nenhum problema.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Selecione o sistema de coordenadas de referência das coordenadas no arquivo mundial</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Abrindo %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Tamanho da imagem:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Especifique como posicionar ou dimensionar a imagem:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Arquivo mundial</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>nenhuma informação de georreferenciamento</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Metros por pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Digitalizado com</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translatorcomment>pontos por polegada</translatorcomment>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Escala do Mapa Base:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Exibir</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Transparência</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Grupo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Nome do arquivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Rascunho</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georreferenciado: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Adicionar Mapa Base...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Mover para cima</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Mover para baixo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importar e remover</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Mover manualmente</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Abrir imagem, trilha de GPS  ou arquivo DXF</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Posicionando...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Arquivos de Mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Todos os arquivos</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Ajustar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Por favor insira um número inteiro válido para definir um grupo ou deixe o campo vazio para desagrupar o Mapa base!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Não definir escala</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Escala pela relação nominal da escala do mapa (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7272,205 +7273,205 @@ Se você não pretende desenhar sobre esta imagem no entanto, não há nenhum pr
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Formato de arquivo não reconhecido.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Falha ao carregar o Mapa Base. O arquivo existe e é válido?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Escala pela relação atual do Mapa Base (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Importar mapa Base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Como deve ser a escala dos símbolos do Mapa Base importado?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>O Mapa Base será invisível na simulação de sobreimpressão. Mudar para a vista normal?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Mapa -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Arrastar&lt;/b&gt; para mover o Mapa Base atual</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Posicionando</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Escala-X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Escala-Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Rotação:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Encontrar escala e posicionamento</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Sistema de coordenada</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Real</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>metros</translatorcomment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Uma unidade de coordenada é igual a:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Posição do elemento dada em coordenadas</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Posição do elemento no centro da visualização</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Selecione o sistema de coordenadas de referência das coordenadas do GPS</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Abrindo trilha do GPS ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Carregar a trilha no modo georreferenciado ou não georreferenciado?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Posiciona a trilha de acordo com as configurações de mapas de georreferenciamento.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Estes ainda não estão configurados, de modo que será mostrado como o próximo passo.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Não georreferenciado</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projeta a trilha usando uma projeção ortográfica com centro em coordenada média da trilha. Permite o ajuste da transformação e definir o mapa de georreferenciamento usando a posição da trilha ajustada.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>O caminho está vazio, não existe nada para importar!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Pergunta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Podem os pontos do GPS ser importados como uma linha passando por todos os pontos?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Problemas de importação</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n objeto de linha não pôde ser importado (razão: coordenadas faltando).</numerusform>
@@ -7478,12 +7479,12 @@ Se você não pretende desenhar sobre esta imagem no entanto, não há nenhum pr
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Erro de leitura</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7492,39 +7493,39 @@ Se você não pretende desenhar sobre esta imagem no entanto, não há nenhum pr
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Não é um arquivo OSM.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>O arquivo OSM tem versão %1.
 A versão mínima suportada é %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>O arquivo OSM tem versão %1.
 A versão máxima suportada é %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problemas</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 não pôde ser processado corretamente.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Link externo: %1</translation>
@@ -7535,58 +7536,58 @@ A versão máxima suportada é %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Alinhamento</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Esquerda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Direita</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Topo</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Linha de base</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Inferior</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Configurações de texto</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Família da fonte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Tamanho da fonte:</translation>
     </message>
@@ -7595,339 +7596,339 @@ A versão máxima suportada é %2.</translation>
         <translation type="vanished">Determinar tamanho...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Cor do texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>negrito</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>itálico</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>sublinhado</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>estilo de texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Espaçamento de linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Espaçamento de parágrafo:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Espaçamento de caracter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Kerning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Ícone do símbolo de texto:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Enquadramento</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Ajustes de compatibilidade do OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Enquadramento de cor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Enquadramento de linha</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Largura:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Enquadramento de sombra</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Ajuste Esquerda/Direita:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Ajuste Topo/Base:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Compatibilidade do OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>permitido</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Largura de linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Cor de linha:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Posição:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linha abaixo de parágrafos</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Distância da linha de base:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Posições de tabulação personalizada</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Adicionar tabulação personalizada</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Calcular</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Não pôde desfazer, porque a última etapa de desfazer tornou-se inválida. Isto pode acontecer, por exemplo, se você alterar o símbolo de um objeto para outro e, em seguida, excluir o símbolo antigo.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Desfazendo esta etapa irá além do ponto em que o arquivo foi carregado. Você tem certeza?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Não é possível refazer porque o primeiro passo tornou-se inválido. Isto pode acontecer, por exemplo, se você excluir o símbolo de um objeto que você desenhou.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Falha em localizar arquivos de ajuda.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Falha ao localizar o navegador de ajuda (&quot;Assistente do Qt&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Falha ao carregar o navegador de ajuda (&quot;Assistente do Qt&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Versões mais antigas do Mapper não suportam várias partes do mapa. Para salvar o mapa no modo de compatibilidade, você deve primeiro unir todas as partes do mapa.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elemento não suportado:%1 (linha%2 coluna%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Algumas coordenadas estavam fora dos limites para a impressão. O conteúdo do mapa foi ajustado.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Partes deste arquivo não podem ser lidas por esta versão do Mapper. Versão mínima exigida: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Erro nt linha %1 coluna %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Especificação georreferenciamento sem suporte ou inválido &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Não foi possível definir propriedade de nocaute da cor &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Esperadas %1 cores, encontradas %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Cor padrão %1 não foi encontrada ao processar %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Esperados %1 símbolos, encontrados %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Esperadas %1 partes do mapa, encontradas %2.</translation>
     </message>

--- a/translations/OpenOrienteering_pt_PT.ts
+++ b/translations/OpenOrienteering_pt_PT.ts
@@ -2,5093 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_PT">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation>Sobre %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation>&lt;a %1&gt;Tudo sobre licenças, notas de direitos de autor, condições e renúncias.&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation>Desenvolvedores do OpenOrienteering em ordem alfabética:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation>(iniciador do projecto)</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation>Um programa livre para desenho de mapas de orientação</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation>Este programa é software livre: pode ser redistribuído e/ou modificado sob os termos de &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, como publicado pela Free Software Foundation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation>Este programa é distribuído na esperança de ser útil, mas SEM NENHUMA GARANTIA; nem mesmo a garantia implícita de APTIDÃO PARA COMERCIALIZAÇÃO ou PARA UM DETERMINADO FIM. Veja a GNU General Public License (GPL), versão&amp;nbsp;3, para &lt;a %1&gt;mais detalhes&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation>Pelas contribuições, agradecimentos a:</translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation>Abrir ficheiro mais recente</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation>Mostrar dica do dia</translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation>Mostrar itens restantes</translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation>Tamanho mínimo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation>Preenchimentos</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>º</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation>Ângulo:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation type="unfinished">
-            <numerusform>%n bytes</numerusform>
-            <numerusform>%n bytes</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished">Nome</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>Nome</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>Novo</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation>Eliminar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation>Duplicar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation>Ajuda</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation type="unfinished">º</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation type="unfinished">º</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation>Ponto / Ângulo</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished">º</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation type="unfinished">E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation type="unfinished">N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished">º</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation type="unfinished">N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation type="unfinished">E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation type="unfinished">Sobre %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished">Ajuda</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished">Mostrar dica do dia</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation>Guardar ficheiro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation>O ficheiro não pôde ser guardado:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation>Ocorreu um problema ao determinar o formato do ficheiro.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation>Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation>Aviso</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation>Erro interno ao gravar:
-%1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished">Duplicar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation type="unfinished">Eliminar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation>Ctrl+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation>Ctrl+Shift+A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation>Ctrl+I</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation>S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation>P</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation>O</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation>Ctrl+R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation>T</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation>Ctrl+G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation>Ctrl+F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation>Ctrl+D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation>C</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation>R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation>Z</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation>K</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation>U</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation>Ctrl+M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished">mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished">m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation type="unfinished">Erro</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>mm</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation>m²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished">mm</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5102,767 +15,2855 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
+        <translation>Sobre %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
+        <translation>&lt;a %1&gt;Tudo sobre licenças, notas de direitos de autor, condições e renúncias.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation>Desenvolvedores do OpenOrienteering em ordem alfabética:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation>(iniciador do projecto)</translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
+        <translation>Um programa livre para desenho de mapas de orientação</translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
+        <translation>Este programa é software livre: pode ser redistribuído e/ou modificado sob os termos de &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, como publicado pela Free Software Foundation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation>Este programa é distribuído na esperança de ser útil, mas SEM NENHUMA GARANTIA; nem mesmo a garantia implícita de APTIDÃO PARA COMERCIALIZAÇÃO ou PARA UM DETERMINADO FIM. Veja a GNU General Public License (GPL), versão&amp;nbsp;3, para &lt;a %1&gt;mais detalhes&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
+        <translation>Pelas contribuições, agradecimentos a:</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
+        <translation>Abrir ficheiro mais recente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation>Mostrar dica do dia</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation>Mostrar itens restantes</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
+        <translation>Tamanho mínimo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
+        <translation>Preenchimentos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
-        <translation type="unfinished">mm</translation>
+        <translation>mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>º</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
+        <translation>Ângulo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation type="unfinished">
+            <numerusform>%n bytes</numerusform>
+            <numerusform>%n bytes</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDropDown</name>
+    <message>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>Novo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation>Duplicar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation type="unfinished">º</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
-        <source>Warning</source>
-        <translation type="unfinished">Aviso</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation type="unfinished">º</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation>Ponto / Ângulo</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;: Terminar edição. </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished">º</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GPSDisplay</name>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation type="unfinished">E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation type="unfinished">N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished">º</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation type="unfinished">N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation type="unfinished">E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation type="unfinished">Sobre %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished">Ajuda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished">Mostrar dica do dia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation>Guardar ficheiro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation>O ficheiro não pôde ser guardado:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation>Ocorreu um problema ao determinar o formato do ficheiro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation>Erro interno ao gravar:
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5870,7 +2871,3007 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished">Duplicar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation type="unfinished">Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation>Ctrl+Shift+A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation>P</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation>O</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation>Ctrl+R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation>T</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation>D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl+G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation>C</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation>K</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation>H</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation>M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation>U</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl+M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation>m²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished">mm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5878,672 +5879,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished">º</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished">Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6551,58 +6552,58 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6611,7 +6612,7 @@ to jump over the lazy dog
         <translation type="obsolete">Ajuda</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -6619,625 +6620,625 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished">Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished">Novo</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished">Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished">Duplicar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished">Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished">m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -7245,436 +7246,436 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished">mm</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished">m</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_ru.ts
+++ b/translations/OpenOrienteering_ru.ts
@@ -2,249 +2,262 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Спортивная карта</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Программа картографии для спортивного ориентирования</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Всё о лицензиях, авторских правах, условиях и оговорках.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Разработчики OpenOrienteering в алфавитном порядке:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(инициатор проекта)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Свободное программное обеспечение для создания спортивных карт</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Эта программа является свободным программным обеспечением: вы можете распространять и/или изменять её в соответствии с условиями &lt;a %1&gt;GNU General Public License (GPL), версии&amp;nbsp;3&lt;/а&gt;, опубликованной Фондом Свободного Программного обеспечения.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Эта программа распространяется в надежде, что она будет полезной, но БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ; даже без подразумеваемых гарантий КОММЕРЧЕСКОЙ ЦЕННОСТИ или ПРИГОДНОСТИ ДЛЯ КОНКРЕТНЫХ ЦЕЛЕЙ. Смотрите GNU General Public License (GPL) версии&amp;nbsp;3, для получения &lt;a %1&gt;дополнительной информации&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>За вклад спасибо:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Открыть последний использованный файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Показывать подсказки</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Показать остальные пункты</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Наименьший размер:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Заливка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Заполнение линиями</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Заливка узором</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Одиночная линия</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Параллельные линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Интервал между линиями:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Одиночный ряд</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Шаг:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Смещение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Смещение ряда:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Параллельные ряды</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Интервал между рядами:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Поворот заливки</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>регулируется объектом</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Отображение элемента на границе</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Обрезать элементы на границе.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Отображать елементы, если центр находится внутри границы.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Отображать елементы, если какая-нибудь точка находится внутри границы.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Отображать елементы, если все точки находятся внутри границы.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Настройки площади</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Заливка узором %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Заполнение линиями %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Заливка не выбрана</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Цвет площади:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Смещение линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Цвет линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Толщина линии:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>автоматически сохранённый файл</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n байт</numerusform>
@@ -253,249 +266,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Файл сохранён пользователем</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Восстановление файла</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Файл %1 не был должным образом закрыт. В настоящее время существует две версии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Сохраните активный файл для удаления конфликтной версии.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Редактировать цвет карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Определить комбинированный цвет:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Смесь комбинированных цветов (экраны и оверпринт):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Выворотка: закрашивать нижние цвета</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Рассчитать из комбинированных цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Рассчитать из RGB цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Настроить цвет вручную:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Бирюзовый</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Пурпурный</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Жёлтый</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Чёрный</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Рассчитать из цветов CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Пользовательский RGB цвет:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Красный</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Зелёный</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Голубой</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation>#RRGGBB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Рабочий стол</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Профессиональная печать</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- безымянный -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- нет -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Непрозрачность</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Комбинированный цвет</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Переместить вверх</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Переместить вниз</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Дважды щёлкните на значении цвета, чтобы открыть диалоговое окно.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Подтверждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Карта содержит символы с этим цветом. Его удаление приведёт к удалению цвета из этих объектов! Вы действительно хотите это сделать?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (дубликат)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Копия)</translation>
     </message>
@@ -508,300 +521,300 @@
         <translation type="vanished">Пожалуйста, введите процент от 0% до 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Дважды щёлкните, чтобы определить цвет</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Щёлкните, чтобы выбрать имя и щёлкните ещё раз, чтобы изменить.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Число частей:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Приватный линейный символ -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Приватный площадной символ -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Редактировать отдельный символ…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Параметры комбинации</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Изменить символ с публичного на приватный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Использовать старый символ в качестве основы для приватного символа?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Символ %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Параметры сетки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Показать сетку</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Привязка к сетке</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Выбрать…</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Все линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Горизонтальные линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Вертикальные линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Ориентация</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>На магнитный север</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>На север прямоугольной сетки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>На истинный север</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Дополнительный поворот (против часовой стрелки):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Положение</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>метры на местности</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>миллиметры на карте</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Горизонтальный интервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Вертикальный интервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Горизонтальное смещение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Вертикальное смещение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Единицы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Цвет линий:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Показать:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Выбор цвета линий сетки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Начало отсчёта: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>проекции</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Щелчок или перетаскивание&lt;/b&gt;: Начать рисовать отверстие. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Секущая линия должна заканчиваться на границе области!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Начало и конец секущей линии находятся на разных частях объекта!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Начало и конец секущей линии совпадают!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt; на линии: Разбить её на две. &lt;b&gt;Перетаскивание&lt;/b&gt; вдоль линии: Удалить эту часть линии. &lt;b&gt;Щелчок или Перетаскивание&lt;/b&gt; на границе области: Начать секущую линию. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Разделение отверстий в площадных объектах до сих пор не поддерживается!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Вырезать всю карту. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Щелчок или Перетаскивание&lt;/b&gt;: Выбрать объекты для вырезания. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Вырезать выбранные объекты. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Не удалось открыть файл.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Файл не является файлом DXF.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Определить размер шрифта</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Буква:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation>А</translation>
@@ -815,778 +828,778 @@
         <translation type="vanished">мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Распределить точки равномерно вдоль линии</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Количество точек в линии:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Также расположить объекты на концах отрезка</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Параметры вращения</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Выровнять точки в направлении линии</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Дополнительный угол поворота (против часовой стрелки):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Из центра</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Начать рисование окружности или эллипса. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Рисование окружности. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Удерживать %1 для начала рисования из центра.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Завершить окружность. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Рисовать эллипс. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Рисовать контур. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Штриховые точки вкл-ны.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt;: Привязать или добавить к существующим объектам. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt;: Выбрать направление по существующим объектам. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Азимут и длина сегмента. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt;: Привязать к существующим объектам. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фиксированные углы. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Удалить последнюю точку. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Завершить</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Замкнуть</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Привязать</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Штрих</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Длина:&lt;/b&gt; %1 м </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Начать отрезок прямой. &lt;b&gt;Перетаскивание&lt;/b&gt;: Начать кривую. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Перетаскивание&lt;/b&gt;: Продолжить существующие объекты. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Рисовать отрезок прямой. &lt;b&gt;Перетаскивание&lt;/b&gt;: Рисовать кривую. &lt;b&gt;Правый или двойной щелчок&lt;/b&gt;: Завершить контур. &lt;b&gt;%1&lt;/b&gt;: Замкнуть контур. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Нажмите на карту, чтобы закончить усреднение</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Завершить установку объекта. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Привязать</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Угол</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Сброс</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Угол:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фиксированные углы. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Создать точечный объект.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Создать объект и задать его ориентацию.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Сбросить ориентацию.</translation>
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Завершить</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Привязать</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Привязать к линии</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Штрих</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Щелчок или Перетаскивание&lt;/b&gt;: Начало рисования прямоугольника. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Привязать к предыдущим линиям. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Установить угловую точку. &lt;b&gt;Правый или двойной щелчок&lt;/b&gt;: Завершить прямоугольник. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Привязка</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Завершить редактирование. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Отмена изменений. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Создать текстовый объект с одним якорем. &lt;b&gt;Перетаскивание&lt;/b&gt;: Создать текстовое поле. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Привязка</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Переключатель кривой</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Свободное движение. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt; на сегменте: Переключиться между отрезком прямой и кривой. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Привязка</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Точка / Угол</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Переключить штрихи</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Завершить редактирование. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Сохранить позицию противоположной маркера. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt; на точке: Удалить её; на контуре: Добавить новую штриховую точку; с &lt;b&gt;%2&lt;/b&gt;: Добавить обычную точку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt; на точке: Удалить её; на контуре: Добавить новую точку; с &lt;b&gt;%2&lt;/b&gt;: Добавить новую штриховую точку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Щелчок&lt;/b&gt; на точке для переключения между штриховой и обычной. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Смещение координат:&lt;/b&gt; %1, %2 мм  &lt;b&gt;Дистанция:&lt;/b&gt; %3 м </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фиксированные углы. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Привязать к существующим объектам. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Выбрать один объект. &lt;b&gt;Перетаскивание&lt;/b&gt;: Выбрать несколько объектов. &lt;b&gt;%1+Щелчок&lt;/b&gt;: Снять выбор. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Удалить выбранные объекты. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Высокое качество отображения карты (сглаживание)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Сглаживание улучшает внешний вид карты, но также замедляет её отображение на дисплее</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Высокое качество отображения текста на карте (сглаживание), медленно</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Допуск курсора:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Дистанция привязки (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Шаг в режиме фиксированных углов (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Размер значка символа:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>При выборе объекта, также автоматически выбирать соответствующий символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Держаться рядом с курсором во время удаления</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Инструменты рисования: устанавливать последнюю точку правой кнопкой мыши</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Подложки: сохранять настройки закрытых подложек</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Инструмент редактирования:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Сохранить форму</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Сбросить внешние манипуляторы кривой</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Сохранить внешние манипуляторы кривой</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Действие при удалении точки кривой с %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Инструмент рисования прямоугольников:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Радиус вспомогательного креста:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Предварительный просмотр толщины линий со вспомогательным крестом</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Не удалось создать новый файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Формат (%1) не поддерживает экспорт</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Площадь карты большая. Использование инструмента заливки может быть очень медленным. Вы всё равно хотите использовать его?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Область на месте щелчка не ограничена линиями или контуром, невозможно заполнить эту область.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Область на месте щелчка занята, невозможно здесь использовать инструмент заливки.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Ошибка при создании заливки.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Заполнить область активным символом. Область должна быть ограничена линиями или площадями, другие символы не учитываются. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS отключён в настройках устройства. Открыть настройки?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Импортировать с помощью GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Конфигурация</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Параметр</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Внешний вид</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Язык:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Экран</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Точек на дюйм:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Запуск программы</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Сохранение файлов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Сохранить совместимость с Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Сохранять историю изменений</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Сохранять информацию для автоматического восстановления</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Интервал сохранения информации для восстановления:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>мин</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Импорт и экспорт файлов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-битная кодировка:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Ещё…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Использовать новый механизм OCD импорта также для файлов версии 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Уведомление</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Необходимо перезапустить программу, чтобы изменения языковых настроек вступили в силу!</translation>
     </message>
@@ -1595,570 +1608,570 @@
         <translation type="vanished">Использовать файл перевода…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Открыть перевод</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Файлы перевода (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Выбранный файл не является допустимым файлом перевода.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Основное разрешение экрана в пикселях:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Основной размер экрана в дюймах (диагональ):</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM координаты</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>Зона UTM (номер N/S)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Проекция Гаусса - Крюгера, датум: Потсдам</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Координаты в проекции Гаусса - Крюгера</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Номер зоны (от 1 до 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>по коду EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>Координаты EPSG @code@</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Локальные координаты</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>код EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Пользовательская PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Спецификация</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Определение масштаба карты некорректное или отсутствует.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Некорректный коэффициент масштабирования сетки: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Неизвестный язык описания БСК: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Неподдерживаемая спецификация географической СК: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Локальные</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Геопривязка карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Просмотр…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Склонение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Проекционные координаты</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Географические координаты</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Показать опорную точку в:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>действительный</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Поиск склонения в Интернете</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Система координат карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- локальные -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Коэффициент масштабирования сетки:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Опорная точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Выбрать на карте</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Датум: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Север карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Базовая система координат (БСК):</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Координаты карты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Географические координаты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>При изменении БСК сохранить:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Квазисклонение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Магнитное склонение для опорной точки %1° %2° будет взято из &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Вы хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Изменить склонение</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Склонение изменено. Вы хотите также повернуть содержимое карты?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Локальные координаты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Загрузка…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>выключен</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Невозможно прочитать данные.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Значение склонения не найдено.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Ошибка поиска склонения в Интернете:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Задать опорную точку. &lt;b&gt;Правый щелчок&lt;/b&gt;: Отмена.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Добро пожаловать в OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Действия</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Создать новую карту …</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Открыть карту …</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Выход</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Последние карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Открывать последний файл при запуске программы</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Очистить список</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Подсказка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Показывать подсказки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Предыдущая</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Следующая</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Примеры</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Про Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Список файлов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Не найдены файлы карт!&lt;br/&gt;&lt;br/&gt;Скопируйте файлы карт в папку верхнего уровня &apos;OOMapper&apos; на устройстве или карте памяти.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Ошибка при загрузке символа типа %1 в строке %2 колонке %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>ID символа &apos;%1&apos; не уникален в строке %2 столбце %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Ошибка при загрузке символа типа %1 в строке %2 столбце %3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Ошибка при загрузке объекта типа %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Ошибка при загрузке объекта типа %1 из %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Невозможно найти символ для объекта из %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Точечный объект с неопределённым или неверным символом в %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD версии 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Невозможно прочитать координаты.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Ожидалось %1 координат, найдено %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Ошибка при загрузке конфигурации печати в %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Ошибка при загрузке истории изменений в %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Нет такой опции: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Геопространственные векторные данные</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Найден объект без символа.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Отброшен %n нерегулярный объект.</numerusform>
@@ -2167,207 +2180,207 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Ошибка во время постобработки символа.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Подложка &quot;%1&quot; была загружена из каталога карты, а не из места её расположения относительно файла карты, где она находилась раньше.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Не удалось загрузить подложку &quot;%1&quot; по следующей причине: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>При загрузке подложки &quot;%1&quot; выданы следующие предупреждения:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Ни один файл подложки не найден.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Щёлкните на красное название подложки в меню Подложки -&gt; Окно настройки подложек, чтобы определить новое имя файла подложки.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Этот файл использует устаревший формат. Поддержка этого формата должна быть удалена из этой программы в ближайшее время. Для того, чтобы открыть файл в будущем, сохраните его снова.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Некорректная версия формата файла.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Неподдерживаемая старая версия формата файла. Пожалуйста используйте предыдущие версии программы для загрузки и правки файла.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Неподдерживаемая новая версия формата файла. Некоторые параметры карты не могут быть загружены или сохранены в данной версии программы. Рекомендуется обновление.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Географическая базовая система координат карты была &quot;%1&quot;. Данная СК не поддерживается. Используйте &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Ошибка при загрузке символа типа %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Ошибка при загрузке символа.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Ошибка при загрузке шага отката.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Ошибка при чтении счётчика слоёв карты.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Ошибка при загрузке слоя карты %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Не удалось прочитать файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Неподдерживаемый формат файла.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Неподдерживаемая новая версия формата файла. Некоторые параметры карты не могут быть загружены или сохранены в данной версии программы.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Импорта формата (%1) не поддерживается</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Не удалось прочитать &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Параметры линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Толщина линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Цвет линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Наименьшая толщина линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Конец линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>срезанный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>скруглённый</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>квадратный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>заострённый</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Соединение отрезков:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>угловое</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>с фаской</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Длина окончания:</translation>
     </message>
@@ -2377,334 +2390,335 @@
         <translation>Линия пунктиром</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Показывать хотя бы один срединный символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Минимальное количество срединных символов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Минимальное количество срединных символов для замкнутой линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Длина штриха:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Пунктирная линия</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Интервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Группировка штрихов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>нет</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Внутригрупповой интервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Первый и последний штрихи в два раза короче</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Срединный символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Срединных символов на штрихе:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Расстояние между срединными знаками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Границы</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Различные границы слева и справа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Левая граница:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Правая граница:</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Начальный символ</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Средний символ</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Конечный символ</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Штриховой символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Включить граничную линию</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Расстояние между точками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Расстояние от конца линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Опустить штриховой символ в начале и конце линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Масштабировать знак конца отрезка в углах</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Толщина границы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Цвет границы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Смещение границы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Граница пунктиром</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Длина штриха границы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Интервал границы:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Новый</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Создать новую карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Открыть…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Открыть существующий файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Открыть &amp;последний</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Сохранить &amp;как…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Параметры…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Закрыть этот файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>В&amp;ыход</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Выйти из программы</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Открыть &amp;Справку</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Показать файл справки программы</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Показать информацию о программе</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>О &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Показать информацию о Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Вы хотите удалить автоматически сохранённую версию?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Файл был изменён.
 Вы хотите сохранить ваши правки?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Несохранённый файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2713,60 +2727,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Вы хотите масштабировать символы в выбранный масштаб?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Предупреждение сбоя</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Видимо %1 аварийно завершился в последний раз, когда файл был открыт:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Действительно попробовать открыть его?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Автосохранение…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Автосохранение не удалось!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Форматы карт</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Вы должны закрыть текущий файл перед тем, как открыть другой.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Открытие %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2777,19 +2791,19 @@ File format not recognized.</source>
 Формат файла не распознан.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Файл был изменён.
 Вы хотите отменить изменения?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2800,22 +2814,22 @@ Press No to choose a different format.</source>
 Нажмите &quot;Нет&quot;, чтобы выбрать другой формат.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Сохранение файла</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Файл не может быть сохранён:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Возникла проблема при определении формата файла.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Пожалуйста, сообщите об этом как об ошибке.</translation>
     </message>
@@ -2825,23 +2839,23 @@ Press No to choose a different format.</source>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2850,7 +2864,7 @@ because saving as %2 (.%3) is not supported.</source>
 потому что сохранение в %2 (.%3) не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2859,31 +2873,31 @@ because the format is unknown.</source>
 поскольку формат неизвестен.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Экспорт карты вызвал предупреждения.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Внутренняя ошибка при сохранении:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Импорт карты вызвал предупреждения.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2892,12 +2906,12 @@ for reading.</source>
 для чтения.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Некорректный тип файла.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2908,7 +2922,7 @@ for reading.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -2917,17 +2931,17 @@ for reading.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Нечего импортировать.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Вопрос</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -2936,23 +2950,23 @@ Rescale the imported data?</source>
 Отмасштабировать импортируемые данные?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Слой по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Новый цвет</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Импорт…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Замена символа была отменена.
@@ -2960,200 +2974,200 @@ Import the data anyway?</source>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Регистрационный чёрный (все печатаемые цвета)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Координаты вне границ.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Отменить последнее действие</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Вернуть</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Вернуть последнее действие</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Вы&amp;резать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>К&amp;опировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Вставить</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Отдалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Переключить в полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Задать коэффициент увеличения…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Окно символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Показать/Скрыть окно символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Окно настройки цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Показать/Скрыть окно настройки цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Заменить символы на аналогичные из другого файла карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Масштабировать все символы…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Масштабировать весь набор символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Изменить масштаб карты…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Изменить масштаб карты и настроить объекты карты и размеры символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Описание карты…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Окно настройки подложек</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Показать/Скрыть окно настройки подложек</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Открыть подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Показать всю карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Редактировать объекты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Поставить точку</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Рисовать контур</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Рисовать окружность или эллипс</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Написать текст</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Заменить символ выделенного объекта(-ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Залить / Создать контур выделенного объекта(-ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Поменять направление штрихов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Соединить контуры</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Разделить объект</translation>
     </message>
@@ -3162,254 +3176,254 @@ Import the data anyway?</source>
         <translation type="vanished">Повернуть объект(-ы)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Измерение длин и площадей</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Вырезать из области</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Слияние отверстий площади</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Параметры рисования на подложке</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Включить сенсорный курсор</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Включить отображение GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Показывать кольцо расстояний GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Поставить точечный объект в позиции GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Поставить вспомогательный маркер в позиции GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Создать вспомогательную линию в позиции GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Очистить вспомогательные маркеры GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Включить отображение компаса</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Ориентировать карту на север</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Добавить новый слой…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Переименовать текущий слой…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Удалить текущий слой</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Объединить все слои</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Импорт…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Инструменты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>Си&amp;мволы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>К&amp;арта</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Подложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Рисовать на подложке</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Редактирование в процессе</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Карта в настоящее время редактируется. Пожалуйста, закончите операцию редактирования перед сохранением.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Карта сохранена</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Показать сетку</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Параметры сетки…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Штриховать области</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Показ базовых линий</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Скрыть все подложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Заменить набор символов…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Геопривязка…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Поворот карты…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Повернуть всю карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Повторно открыть подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Редактор тегов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Показать/Скрыть окно редактора тегов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Рисовать прямоугольник</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Рисовать произвольную линию</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Заполнить ограниченные области</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Вырезать отверстие произвольной формы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Вырезать круглое отверстие</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Вырезать прямоугольное отверстие</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Повернуть узор</translation>
     </message>
@@ -3418,222 +3432,222 @@ Import the data anyway?</source>
         <translation type="vanished">Масштабировать объект(ы)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Соединить площади</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Пересечение площадей</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Взаимоисключение площадей</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Обрезать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Расположить точки вдоль линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Координаты карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Координаты проекции</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Широта/Долгота (десят)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Широта/Долгота (° ′ ″)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Отображать координаты как…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Вырезать отверстие</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Ничего не выбрать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Обратить выделение</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>ID набора символов…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Редактировать ID набора символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Загрузить CRT файл…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Присвоить новые символы с помощью CRT таблицы</translation>
     </message>
@@ -3646,81 +3660,81 @@ Import the data anyway?</source>
         <translation type="vanished">Показать/Скрыть окно выбора тегов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Скопировать позицию</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Скопировать позицию в буфер обмена.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Слои карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Выбрать подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Редактирование</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Расширенное редактирование</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Выбрать символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Скрыть верхнюю панель</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Показать верхнюю панель</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Печать / Экспорт недоступны в данной версии программы!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Нет действий для отмены.</translation>
     </message>
@@ -3730,8 +3744,8 @@ Import the data anyway?</source>
         <translation type="vanished">Вырезан(о) %1 объект(а)(ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Извините, произошла внутренняя ошибка!</translation>
     </message>
@@ -3740,7 +3754,7 @@ Import the data anyway?</source>
         <translation type="vanished">Скопирован(о) %1 объект(а)(ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Нет объектов в буфере обмена для вставки!</translation>
     </message>
@@ -3749,67 +3763,67 @@ Import the data anyway?</source>
         <translation type="vanished">Вставлен(ы) %1 объект(а)(ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Задать коэффициент увеличения</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Коэффициент увеличения:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Символы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Цвета</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>ID набора символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Редактировать ID набора символов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Масштабировать все символы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Масштаб в процентах:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Описание карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Подложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Редактор тегов</translation>
     </message>
@@ -3818,7 +3832,7 @@ Import the data anyway?</source>
         <translation type="vanished">Селектор тега</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3828,7 +3842,7 @@ selected</source>
 выбранны</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3838,41 +3852,41 @@ selected</source>
 символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Расположить точечный объект на карте.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Выберите точечный символ для активации этого инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Рисовать ломанные и кривые линии.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Выберите линейный, площадной или комбинированный символ для активации этого инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Рисовать окружности и эллипсы.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Рисовать произвольную линию.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Заполнить ограниченные области.</translation>
     </message>
@@ -3881,205 +3895,205 @@ selected</source>
         <translation type="vanished">Удалить выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Задать направление заполняющей штриховки или точечных объектов.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Выберите площадной объект с ориентируемой штриховкой или вращаемый точечный объект для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Результирующий символ: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Выберите хотя бы два площадных или линейных объекта для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Объединить перекрывающиеся объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Удалить все части, которые не перекрываются с первым выделенным объектом.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Удалить перекрывающиеся с первым выделенным объектом части.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Удалить все части, которые перекрывают первый выделенный объект.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Объединить отверстия между собой или объединить отверстия с границей объекта для вырезания данной части.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Выберите один площадной объект с отверстиями для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Вырезать фрагмент из объектов или всей карты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Выберите замкнутый контур в качестве секущей фигуры для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Обрезать объекты или всё в ограниченной области.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Разместить равномерно точечные объекты вдоль существующего линейного объекта</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Выберите хотя бы один линейный объект и один точечный символ для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Слияние отверстий не удалось.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Очистить вспомогательные маркеры</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Вы хотите удалить все вспомогательные GPS маркеры? Данное действие нельзя отменить.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Объединить текущий слой с</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Переместить выбранные объекты на</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Введите имя слоя карты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Перешёл на слой &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Объединение слоёв карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Вы хотите перенести все объекты с слоя &quot;%1&quot; на &quot;%2&quot;, и удалить &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Вы хотите перенести все объекты на слой &quot;%1&quot;, и удалить все другие слои?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Невозможно импортировать выбранный файл карты, потому что он не может быть загружен.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Рисовать прямоугольники.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Печать…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Изображение</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Очистить историю изменений</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Очистить историю изменений для уменьшения размера файла карты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Двигать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Имитировать наложение цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Редактировать линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Преобразовать в кривую</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Упростить контур</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Экспортировать как…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Добавить текст на карту.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Выберите текстовый символ для разрешения данного действия.</translation>
     </message>
@@ -4088,26 +4102,26 @@ selected</source>
         <translation type="vanished">Дублировать выбранный(ые) объект(ы).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Выберите хотя бы один объект для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Поменять направление символов на линейных объектах.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Выберите хотя бы один линейный объект для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Соединить концевые точки контуров, которые замыкают друг друга.</translation>
     </message>
@@ -4116,17 +4130,17 @@ selected</source>
         <translation type="vanished">Разрезать выделенные объекты на меньшие части.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Выберите хотя бы один линейный или площадной объект для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Вырезать отверстие в выбранном площадном объекте.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Выберите один площадной объект для активации данного инструмента.</translation>
     </message>
@@ -4139,18 +4153,18 @@ selected</source>
         <translation type="vanished">Масштабировать выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Переключить линии, состоящие из прямых отрезков, в гладкие кривые Безье.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Выберите линейный объект для активации данного инструмента.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Уменьшить количество точек в линейных объектах, пытаясь сохранить их форму.</translation>
     </message>
@@ -4159,8 +4173,8 @@ selected</source>
         <translation type="vanished">Переключить символ выбранных объектов на выбранный символ.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Выберите хотя бы один объект и другой подходящий символ для активации данного инструмента.</translation>
     </message>
@@ -4173,7 +4187,7 @@ selected</source>
         <translation type="vanished">%1 объект(а)(ов) продублирован(о)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Выбор объектов</translation>
     </message>
@@ -4182,77 +4196,77 @@ selected</source>
         <translation type="vanished">Объекты не были выбраны, так как нет объектов указанного символа(ов).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Измерение</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Объединение не удалось.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Пересечение не удалось.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Исключение не удалось.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Взаимоисключение не удалось.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Вы хотите удалить слой карты &quot;%1&quot; и все его объекты?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Рисовать произвольную линию на подложке</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Рисовать произвольную линию на подложке. Создать или загрузить подложку, на которой можно рисовать, чтобы активировать эту кнопку</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Импорт %1, GPX, OSM или DXF файла</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Импортируемые файлы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Невозможно импортировать выбранный файл, так как его формат не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Повернуть объекты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Масштабировать объекты</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4262,7 +4276,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Скопирован %n объект</numerusform>
@@ -4271,7 +4285,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Вставлен %n объект</numerusform>
@@ -4280,42 +4294,42 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Удалить выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Дублировать выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Повернуть выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Масштабировать выбранные объекты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Разрезать выделенные объекты на меньшие части.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Переключить символ выбранных объектов на выбранный символ.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Заполнить выбранные контуры или создать границу выбранных областей.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Продублирован %n объект</numerusform>
@@ -4324,178 +4338,178 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Объекты не были выбраны, так как нет объектов с указанными символами.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Прервать. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Больше: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Больше: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Больше: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Найти…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Найти &amp;следующий</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Найти объекты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Найти следующий</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Найти &amp;все</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Редактор запросов</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Обработка разделения на страницы %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Обработка страницы %1…</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Отменена</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Завершена</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Исходный текст:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Карта (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>неопределённый язык</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Перевод (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Перед редактированием, сохраненный текст будет заменен на текущий перевод. Продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>После изменения сохранённого текста, перевод больше не может быть найден. Продолжить?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4509,7 +4523,7 @@ define the colors there.</source>
 для открытия диалога и определения цветов.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4524,7 +4538,7 @@ to create one.</source>
 для его создания.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4537,7 +4551,7 @@ Templates -&gt; Open template...</source>
 Подложки -&gt; Открыть подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Совет: Нажмите среднюю клавишу мыши для перемещения карты,
@@ -4545,123 +4559,123 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Периметр:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Площадь:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Нет выделенных объектов.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 объект(а)(ов) выделено.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Выделенный объект не контур.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation>м²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Этот объект слишком маленький.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Минимальная площадь %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Примечание: периметр и площадь верны, только если нет самопересечений, и отверстия используются в качестве таковых.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Эта линия слишком короткая.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Минимальная длина %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Создание новой карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Выберите масштаб и набор символов для новой карты.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Масштаб:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Наборы символов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Показывать только наборы символов для выбранного масштаба</translation>
     </message>
@@ -4670,140 +4684,140 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">Отмена</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Создать</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Пустой набор символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Загрузить набор символов из файла…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Файлы наборов символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Все файлы</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Карта содержит более 256 цветов, что не поддерживается OCD версии 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad вернула %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Регистрационный чёрный экспортирован как обычный цвет.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Невозможно экспортировать смещение заполняющего узора для площадного объекта</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Невозможно экспортировать подложку: тип файла &quot;%1&quot; пока не поддерживается</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Координаты поправлены так, чтобы вписываться в зону рисования OCAD 8 (-2 м … 2 м).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Некоторые координаты выходят за границы зоны рисования OCAD 8. Они могут быть недоступны в OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Для линейного символа &quot;%1&quot; невозможно отразить комбинацию окончания / соединения.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Для линейного символа &quot;%1&quot; не воспроизведена группировка штрихов.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Для линейного символа &quot;%1&quot; количество штрихов в группе было уменьшено в 2 раза.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Для линейного символа &quot;%1&quot; невозможно верно экспортировать границы.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Для площадного символа &quot;%1&quot; пропущен заполняющий узор.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Для площадного символа &quot;%1&quot; выявлено &quot;смещение рядов&quot; точечного рисунка. Это может быть как верным, так и нет.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>В текстовом символе %1: установлен нестандартный межсимвольный интервал, его реализация пока не соответствует функциональности OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>В текстовом символе %1: проигнорировано подчёркивание</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>В текстовом символе %1: проигнорирован кернинг</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Строка усечена (усечение отмечено тройным &quot;|&quot;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Невозможно выделить буфер.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad вернула %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD файлы версии %1 не поддерживаются!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n выделение цветом пропущено, причина: Импорт запрещен.</numerusform>
@@ -4812,334 +4826,334 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Невозможно загрузить описание комбинированного цвета, ошибка: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Цвет &quot;Registration black&quot; импортирован как специальный цвет.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Нет возможности импортировать символ &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Слой импорта OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>В штриховой линии символа %1 длина заострений в начале и конце разные (%2 и %3). Используется %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>В штриховой линии символа %1 длина концевого штриха не может быть импортирована корректно.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>В штриховой линии символа %1 длина концевого промежутка не может быть импортирована корректно.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>В штриховой линии символа %1 главная и концевая длины отличаются (%2 и %3). Используется %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>В штриховой линии символа %1 промежутки D и E отличаются (%2 и %3). Используется %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Линейный символ %1: опущен штрих на концах линии.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Импорт текстового символа %1: игнорирование выравнивания по ширине</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Импорт текстового символа %1: игнорирование нестандартной ширины (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Импорт текстового символа %1: установлен нестандартный межсимвольный интервал, его реализация пока не соответствует функциональности OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Импорт текстового символа %1: игнорирование нестандартной ширины слова (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Импорт текстового символа %1: игнорирование нестандартных отступов (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Импорт текстового символа %1: игнорирование обрамления текста (режим %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Невозможно загрузить объект</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Невозможно импортировать прямоугольник</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Текстовый символ не импортирован, не удалось выяснить путь (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Невозможно импортировать подложку: похоже, подложка &quot;%1&quot; не растровое изображение</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Попытка импортировать текстовый объект с неизвестным форматом координат</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Идентификатор цвета не найден: %1, цвет игнорируется</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>есть</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>не есть</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>содержит</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>и</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>или</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Символ</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>некорректный</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>В линейном символе %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>В текстовом символе %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Не удалось загрузить опорную систему координат &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Информация о комбинированном цвете была проигнорирована.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Невозможно импортировать символ %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Неподдерживаемый тип &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Невозможно импортировать подложку: &quot;%1&quot; не поддерживаемый тип подложки.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Неподдерживаемый стиль линии &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Различные длины заострений в начале (%1 мм) и конце (%2 мм) линии не поддерживаются. Используется %3 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Штриховой узор невозможно импортировать корректно.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Длина конечного штриха в узоре (%1 мм) не может быть корректно импортирована. Используется %2 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Расстояние до конечного штриха в узоре (%1 мм) не может быть корректно импортирована. Используется %2 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Неподдерживаемый стиль обрамляющей линии &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Пропущен вторичный символ точки.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Подавление символов на концах отрезка.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Этот символ не может быть сохранён как правильный символ OCD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Выравнивание по ширине не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Вертикальное выравнивание &apos;%1&apos; не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Игнорирование нестандартной ширины (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Нестандартное межсимвольное расстояние может быть неправильным.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Игнорирование нестандартной ширины слова (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Игнорирование нестандартных отступов (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Игнорирование обрамления текста (режим %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Линейные текстовый символы пока не поддерживаются. Символ помечен как скрытый.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Кодировка &apos;%1&apos; не доступна. Проверьте настройки.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>В площадном знаке %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Невозможно загрузить объект</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Невозможно импортировать прямоугольник</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Текстовый символ не импортирован, не удалось выяснить путь (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Попытка импортировать текстовый объект с неизвестным форматом координат</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Некорректные данные.</translation>
     </message>
@@ -5148,59 +5162,59 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">Импорт не тестировался для формата файла: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD файлы версии %1 не поддерживаются!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Идентификатор цвета не найден: %1, цвет игнорируется</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Не удалось установить &quot;%1&quot; SRS для GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Пурпурный</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Площадь</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Невозможно загрузить слой %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Невозможно загрузить %n объект по следующей причине: %1</numerusform>
@@ -5209,821 +5223,808 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Пустая геометрия.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Невозможно определить преобразование координат: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Не удалось преобразовать координаты.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Неизвестный или неподдерживаемый тип геометрии.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Недостаточно координат.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Нельзя использовать эту пространственную ссылку:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>Геопространственные данные не имеют подходящей пространственной привязки.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Спортивная карта</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Программа картографии для спортивного ориентирования</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Выбор подложки для рисования на ней</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Рисовать</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Щелчок и перетаскивание&lt;/b&gt;: Рисовать. &lt;b&gt;Правый щелчок и перетаскивание&lt;/b&gt;: Стереть. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Выбор цвета</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Двигать карту. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Добавить координату. &lt;b&gt;%1+Щелчок&lt;/b&gt;: Изменить выбранную координату. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Всегда ориентирован на север (не вращаемый)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Элементы</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Площадь</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Центрировать все элементы</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Текущий элемент</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Диаметр &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Цвет внутренности:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Ширина кольца &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Цвет кольца:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Толщина линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Цвет линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Конец линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>срезанный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>скруглённый</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>квадратный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Соединение отрезков:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>угловое</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>с фаской</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Линия замкнута</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Цвет площади:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Координаты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Начало кривой</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Центрировать по средней координате</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Середина]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Неизвестный</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Точечный символ</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Во время обработки произошла ошибка.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Сместить карту, область печати или границы области. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Сместить область печати. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Сместить карту. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Сместить границы области печати. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Сместить границы области печати. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Показать подложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Показать сетку</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Ориентация страницы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Принтер:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Портретная</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Ландшафтная</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Формат страницы:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Количество копий:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Слева:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Сверху:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Просмотр…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Одна страница</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Настраиваемая область</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Область карты:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Центрировать область печати</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Перекрытие страниц:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Разрешение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Печатать в другом масштабе:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Внешний вид подложки может отличаться.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Имитировать наложение цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Устройство поддерживает CMYK (экспериментально)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Цветовой режим:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Экспорт…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Экспорт в PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Экспорт в изображение</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Сохранить в PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>точек на дюйм</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Не поддерживается на Андроид.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Не удалось подготовить просмотр.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Подготовка просмотра</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Активирован нестандартный режим просмотра. Вы уверены, что хотите печатать / экспортировать карту?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Не удалось подготовить изображение. Недостаточно памяти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Не удалось подготовить экспорт PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Экспорт карты…</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Не удалось подготовить печать.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Процесс печати</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Векторная
 графика</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Растровая
 графика</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Разделение
 цветов</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Не удалось сохранить изображение. Существует ли путь? У вас достаточно прав?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Экспортировано успешно в %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Не удалось завершить экспорт PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Отменена.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Задание на печать не может быть остановлено.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Успешно создано задание на печать</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Во время печати произошла ошибка.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Неизвестный</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Область карты пуста. Вывод отменен.</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Выбор подложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Перетащите элементы из левого списка в нужное место в списке справа, чтобы загрузить их.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Закрытые подложки:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Очистить список</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Активные подложки:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Заменить набор символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Укажите, какие символы и как должны быть заменены.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Импортировать все новые символы, даже если они не используются в качестве замены</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Удалить исходные символы, которые не используются после замены</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Удалить неиспользуемые цвета после замены</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Отображение символов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Сохранить состояние символов (скрытый / защищённый) из исходного набора символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Замена в соответствии с номером символа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Исходный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Редактировать ID набора символов:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Замена</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Совпадение по имени символа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Присвоить новые символы</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Шаблон</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Очистить замены</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Открыть CRT файл…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Сохранить CRT файл…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Сопоставление символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Существует несколько замен для символа %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6034,7 +6035,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6045,468 +6046,468 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Таблица преобразований была изменена.
 Сохранить изменения?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Нет -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Выбор файла карты для загрузки символов из него</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Не удаётся загрузить файл карты, прерывание.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Выбранный набор символов имеет масштаб 1:%1, но масштаб карты 1:%2. Вы действительно хотите выбрать данный набор?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>Невозможно загрузить CRT файл, прерывание загрузки.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Поворот карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Угол (против часовой стрелки):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Параметры поворота</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Повернуть вокруг:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Начало системы координат карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Географическая опорная точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Другая точка,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Отрегулировать опорную точку геопривязки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Отрегулировать склонение геопривязки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Вращать подложки без геопривязки</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Угол:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фиксированные углы. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Задать направление штриховки области или точечных объектов. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Поворот:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фиксированные углы. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Задать центр вращения. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Повернуть выбранные объекты. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Изменить масштаб карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Параметры масштабирования</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Новый масштаб:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Центр масштабирования:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Начало системы координат карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Географическая опорная точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Другая точка,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Масштабировать размеры символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Масштабировать положения объектов карты</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Отрегулировать опорную точку геопривязки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Масштабировать подложки без геопривязки</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Масштабирование:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Установить центр масштабирования. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Масштабировать выбранные объекты. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Выбор базовой системы координат</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Как на карте</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Локальные</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Географические координаты (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>действительный</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Параметры</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; сохранён в обычном месте.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; сохранён в каталоге программы. Эти файлы будут удалены при удалении программы.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; не доступен для записи. Изменения не могут быть сохранены.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; не является допустимым местом хранения.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- нет -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Нет -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Номер:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Описание:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Вспомогательный символ (не будет отображаться на конечной карте)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Для символов с описанием, нажмите клавишу F1 для отображения подсказки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Новый символ</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Площадь</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Комбинированный</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Масштаб…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
@@ -6519,12 +6520,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">Заполните / Создать границу для выбранного объекта(ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Выбрать символы</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Включить перетаскивания</translation>
     </message>
@@ -6533,197 +6534,197 @@ Do you want to save your changes?</source>
         <translation type="vanished">Масштаб символа(ов)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Извините, произошла внутренняя ошибка!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Нет символов в буфере обмена, которые могут быть вставлены!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Выбрать все объекты с этим символом</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Добавить все объекты с этим символом в выбор</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Удалить все объекты с этим символом из выбора</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Скрыть объекты с этим символом</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Защитить объекты с этим символом</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Добавить все объекты с выбранными символами в выбор</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Удалить все объекты с выбранными символами из выбора</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Скрыть объекты с выбранными символами</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Защитить объекты с выбранными символами</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Обратить выделение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Выбрать неиспользованные</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Сортировка символов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Сортировать по номеру</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Сортировать по основному цвету</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Сортировать по приоритету основного цвета</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Масштаб в процентах:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Подтверждение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Карта содержит объекты с символом &quot;%1&quot;. Его удаление приведёт к удалению этих объекты и очистке истории отмены! Вы действительно хотите это сделать?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Выбрать все объекты с выбранными символами</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Переключить символ выбранных объектов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Заполните / Создать границу для выбранных объектов</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Масштаб символов</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Редактор символа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Шаблон:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Подложка:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(нет)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Открыть…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Центрировать подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>рабочая рамка на начало</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>центр масс на начало</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Выбрать цвет фона</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6735,58 +6736,58 @@ to jump over the lazy dog
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- безымянный -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Нет описания!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Отношение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Ключ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Сравнение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Добавить ряд</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Удалить ряд</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Переместить вверх</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Переместить вниз</translation>
     </message>
@@ -6799,7 +6800,7 @@ to jump over the lazy dog
         <translation type="vanished">Справка</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n объект выбран</numerusform>
@@ -6808,203 +6809,203 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Неверный запрос</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Ключ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Ключ используется</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Ключ &quot;%1&quot; уже существует и не должен использоваться дважды.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Найти перемещённый файл подложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Нет такого файла.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Является ли формат файла подходящим для данного типа подложки?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Недостаточно свободной памяти.</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Совмещение подложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Ошибка вычисления совмещения!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Задать положение на подложке промежуточной точки. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Задать положение на карте промежуточной точки. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Щелчок&lt;/b&gt;: Удалить промежуточные точки. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt;: Двигать промежуточные точки. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Промежуточные точки:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Новая</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Сдвиг</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>X подложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Y подложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>X карты</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Y карты</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Рассогласование</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Применить промежуточные точки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Применить и очистить всё</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Очистить всё</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Не хватает свободной памяти (размер изображения:%1x%2 точек)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7013,197 +7014,197 @@ If you do not intend to draw on this template however, that is no problem.</sour
 Однако если вы не намерены рисовать на этой подложке, то проблем нет.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Выбор базовой системы координат по координатам из world файла</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Открытие %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Размер изображения:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Укажите, как позиционировать и масштабировать изображение:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translatorcomment>https://ru.wikipedia.org/wiki/World-%D1%84%D0%B0%D0%B9%D0%BB</translatorcomment>
         <translation>World-файл</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>нет информации о геопривязке</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>С геопривязкой</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Метров на точку:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Сканировано с</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>точек на дюйм</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Масштаб подложки:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Непрозрачность</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Группа</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Имя файла</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Показать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Открыть…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Дублировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Эскиз</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Добавить подложку…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Переместить вверх</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Переместить вниз</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>С геопривязкой: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Переместить вручную</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Совместить…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Позиционирование…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Импортировать и удалить</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Открыть изображение, GPS трек или DXF файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Файлы подложек</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7212,226 +7213,226 @@ If you do not intend to draw on this template however, that is no problem.</sour
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Формат файла не распознан.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Ошибка загрузки подложки. Файл существует и он корректный?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Пожалуйста введите корректное целое число для задания группы или оставьте поле пустым для удаления подложки из группы!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Масштабировать относительно номинального масштаба карты (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Использовать текущий масштаб подложки (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Не масштабировать</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Импорт подложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Как следует масштабировать символы с импортируемой подложки?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Подложка будет невидимой при имитации наложения цветов. Перейти к нормальному виду?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Перетаскивание&lt;/b&gt; для сдвига текущей подложки</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Позиционирование</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Масштаб по X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Масштаб по Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Поворот:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Позиционирование и масштабирование трека</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Система координат</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Действительная</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Карты</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Одна единица координат равна:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Позиционировать трек на основе полученных координат</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Позиционировать трек по центру экрана</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Эта подложка должна быть загружена с помощью GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Выбрать базовую систему координат для трека</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Открыть трек …</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Загрузить трек в режиме с геопривязкой или без?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Разместить трек в соответствии с настройками геопривязки карты.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Они ещё не настроены, поэтому будут показаны на следующем шаге.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>С геопривязкой</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Без геопривязки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Проецировать трек с использованием ортогональной проекции с центром в точке усреднённых координат трека. Это позволит осуществить трансформацию карты и установить её геопривязку подгонкой относительно позиции трека.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Путь пуст, нечего импортировать!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Вопрос</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Должны ли путевые точки быть импортированы в виде линии, их соединяющей?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Проблемы импорта</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n контурный объект не может быть импотрирован (причина: недостающие координаты).</numerusform>
@@ -7440,12 +7441,12 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Ошибка чтения</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7454,39 +7455,39 @@ If you do not intend to draw on this template however, that is no problem.</sour
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Не OSM файл.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM файл имеет версию %1.
 Наименьшая поддерживаемая версия %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM файл имеет версию %1.
 Наибольшая поддерживаемая версия %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Проблемы</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 узлов (nodes) не могут быть обработаны корректно.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Внешняя ссылка: %1</translation>
@@ -7497,58 +7498,58 @@ The maximum supported version is %2.</source>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Выравнивание</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>По левому краю</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>По центру</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>По правому краю</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>По верхнему краю</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>По базовой линии</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>По нижнему краю</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Текстовые параметры</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Шрифт:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Размер шрифта:</translation>
     </message>
@@ -7557,297 +7558,297 @@ The maximum supported version is %2.</source>
         <translation type="vanished">Определить размер…</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>А</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>пт</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Цвет текста:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>полужирный</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>курсив</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>подчёркнутый</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Стиль текста:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Интервал между строками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Интервал между абзацами:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Межзнаковый интервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Слияние</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Текст значка символа:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Обрамление</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Параметры совместимости с OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Цвет обрамления:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Обрамление</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Толщина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Тень</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Горизонтальное смещение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Вертикальное смещение:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Совместимость с OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>включена</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Толщина линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Цвет линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Позиция:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Линия подчёркивания</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Расстояние от базовой линии:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Пользовательские отступы</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Добавить пользовательский отступ</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Вычислить</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Отмена невозможна, потому что последний шаг отмены стал недействительным. Например, это произойдёт, если вы измените символ объекта на другой, а затем удалите старый символ.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Подтверждение</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Отмена этого действия будет выходить за рамки состояния файла в момент загрузки. Вы уверены?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Невозможно повторить, потому что первый шаг повтора стал недействительным. This can for example happen if you delete the symbol of an object you have drawn.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 м</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Не удалось найти файлы справки.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Не удалось найти браузер справки (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Не удалось запустить браузер справки (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Подробнее…</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Предыдущие версии Mapper не поддерживают многослойные карты. Для сохранения карты в совместимом формате Вы должны сначала объединить все слои карты.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Неподдерживаемый элемент: %1 (строка %2 столбец %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Некоторые координаты были вне границ печати. Содержания карты было скорректировано.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>неизвестен</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Части этого файла не могут быть прочитаны с помощью данной версии Mapper. Минимальная требуемая версия: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Ошибка в строке %1 столбце %2: %3</translation>
     </message>
@@ -7856,44 +7857,44 @@ The maximum supported version is %2.</source>
         <translation type="vanished">Описание карты не может быть прочитано.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Некоторые недопустимые символы должны были быть удалены.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Неподдерживаемая или некорректная спецификация геопривязки &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Невозможно установить свойства перекрытия для цвета &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Ожидалось %1 цвета(ов), найдено %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Комбинированный цвет %1 не найден при обработке %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Ожидалось %1 символов, найдено %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Ожидалось %1 слоя(ёв) карты, найдено %2.</translation>
     </message>

--- a/translations/OpenOrienteering_sv.ts
+++ b/translations/OpenOrienteering_sv.ts
@@ -2,47 +2,60 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="sv_SE" sourcelanguage="en">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Orienteringskarta</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Programvara för att rita orienteringskartor</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Allt om licenser, upphovsrätt, villkor och friskrivningar.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>OpenOrienteerings utvecklare i alfabetisk ordning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(initiativtagare)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Fri mjukvara för att rita orienteringskartor</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Detta program är öppen mjukvara: du kan sprida den och/eller modifiera den under villkoren i &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, publicerad av Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, för &lt;a %1&gt;mer detaljer&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Tack till dessa bidragsgivare:</translation>
     </message>
@@ -60,174 +73,174 @@
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Öppna den senast använda filen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Visa dagens tips</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Visa återstående delar</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Minsta storlek:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Fyllningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Linjefyllning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Mönsterfyllning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Enkel linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Parallella linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Linjeavstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Enkel rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Mönsterintervall:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Mönsterförskjutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Radförskjutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Parallella rader</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Radavstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Rotation av fyllningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Vinkel:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>justerbar per objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation type="unfinished">Klipp objekt vid ytterkant</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Rita ut element om dess centrum är inom området.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Rita ut element om någon del är inom området.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Rita ut element om alla dess punkter är inom området.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Inställningar för ytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Mönsterfyllning %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Linjefyllning %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Ingen fyllning vald</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Ytfärg:</translation>
     </message>
@@ -268,7 +281,7 @@
         <translation type="obsolete">Avstånd mellan centrumlinjer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Linjeförskjutning:</translation>
     </message>
@@ -277,12 +290,12 @@
         <translation type="obsolete">Förskjutning längs linje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Linjefärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Linjebredd:</translation>
     </message>
@@ -292,15 +305,15 @@
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Autosparad fil</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform></numerusform>
@@ -308,249 +321,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Fil sparad av användaren</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Filåterställning</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Fil %1 stängdes inte korrekt. Nu finns två versioner av filen:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Spara den aktiva filen för att ta bort den motstridiga versionen.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Redigera kartfärg</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Redigera</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Definiera en dekorfärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Mix av dekorfärger (skärmar och övertryck):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Knockout: tar bort lägre färger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Beräkna från dekorfärger</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Beräkna från RGB färg</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Egen färg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Turkos</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Svart</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Beräkna från CMYK-färg</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Egen RGB-färg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Röd</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Grön</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Skrivbord</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Professionell utskrift</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- namnlös -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- ingen -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Genomskinlighet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Dekorfärg</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Duplicera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Dubbelklicka på en färg för att öppna en dialog.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Bekräftelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Kartan innehåller symboler med denna färg. Tar du bort den försvinner färgen från de symbolerna! Vill du verkligen göra det?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (kopia)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Duplicera)</translation>
     </message>
@@ -563,13 +576,13 @@
         <translation type="vanished">Välj ett värde från 0% till 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Dubbelklicka för att definiera färgen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Klicka för att välja namnet, klicka igen för att redigera.</translation>
     </message>
@@ -583,39 +596,39 @@
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Antal delar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Personlig linjesymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Personlig ytsymbol -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Redigera privat symbol...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Kombinationsinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Ändra från offentlig till privat symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Använd den gamla symbolen som mall för den privata symbolen?</translation>
     </message>
@@ -624,201 +637,201 @@
         <translation type="obsolete">Antal symboler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation></translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Konfigurera rutnät</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Visa rutnät</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Snappa till rutnät</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Välj...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Alla linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Horisontella linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Vertikala linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Justering</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Passa till magnetiska norr</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Passa till rutnätets norr</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Passa till verkliga norr</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Ytterligare rotation (motsols):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Positionering</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>meter i terrängen</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>milimeter på kartan</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Horisontellt avstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Vertikalt avstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Horisontell förskjutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Vertikal förskjutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Enhet:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Linjefärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Visa:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Visa rutnätsfärg</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Origo vid: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>papperskoordinaters origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>projicerade koordinaters origo</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line to split it into two, &lt;b&gt;Drag&lt;/b&gt; along a line to remove this line part, &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary to start drawing a split line</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; på en linje för att dela den, &lt;b&gt;Dra&lt;/b&gt; längs med en linje för att ta bort en del av linjen, &lt;b&gt;Dra eller Klicka&lt;/b&gt; på en ytas kant för att börja rita en delningslinje</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Klicka eller dra&lt;/b&gt;: Börja rita hålet. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Delningslinjen måste sluta på ytans kant!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Början och slutet på delningslinjen är på olika delar av objektet!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Början och slutet på delningslinjen är på samma plats!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt; på en linje: Dela den i två. &lt;b&gt;Dra&lt;/b&gt; längs en linje: Ta bort denna linjedel. &lt;b&gt;Klicka på eller dra i&lt;/b&gt; en ytgräns: Starta en delad linje. </translation>
     </message>
@@ -827,45 +840,45 @@
         <translation type="obsolete">&lt;bl&gt;Klicka&lt;/b&gt; på en linje för att dela den, &lt;b&gt;Dra&lt;/b&gt; längs med en linje för att ta bort en del av den, &lt;b&gt;Klicka eller dra&lt;/b&gt; på en ytas kant för att börja rita en delningslinje</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Att dela hål i ytor stöds inte än!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klipp ut hela kartan. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Klicka eller dra&lt;/b&gt;: Välj objekten som ska klippas ut. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Klipp ut valda objekt. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Kunde inte öppna filen.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Denna fil är ingen DFX-fil.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Bestäm teckenstorlek</translation>
@@ -877,12 +890,12 @@ This dialog allows to choose a font size which results in a given exact height f
 Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek för ett visst tecken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Tecken:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation></translation>
@@ -892,7 +905,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Här kan du välja en typsnittsstorlek som ger en exakt höjd för ett specifikt tecken.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Höjd:</translation>
     </message>
@@ -902,46 +915,46 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Fördela punkter jämt längs linje</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Antal punkter per linje:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Placera också objekt vid linjeslut</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Rotationsinställningar</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Placera punkter längs linjens riktning</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Ytterligare rotations (motsols):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to start a circle or ellipse, &lt;b&gt;Drag&lt;/b&gt; to draw a circle</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att börja rita en cirkel eller ellips, &lt;b&gt;Dra&lt;/b&gt; för att rita en cirkel</translation>
@@ -951,92 +964,92 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att börja rita en cirkel eller ellips, &lt;b&gt;Dra&lt;/b&gt; för att rita en cirkel, &lt;b&gt;Esc&lt;/b&gt; för att avbryta</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Från centrum</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Börja en cirkel eller ellips. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Rita en cirkel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Håll ner %1 för att börja rita från centrum.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Färdigställ cirkeln. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Rita en ellips. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Rita en linje. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Streckade linjer på.&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt;: Snappa eller fortsätt rita existerande objekt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt;: Välj riktning från existerande objekt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Segmentets riktning och längd. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt;: Snappa till existerande objekt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Låsta vinklar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Ångra den senaste punkten. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation type="obsolete">&lt;b&gt;Streckade linjer på.&lt;/b&gt; </translation>
@@ -1050,131 +1063,131 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att rita ett polygonsegment, &lt;b&gt;Dra&lt;/b&gt; för att rita en kurva, &lt;b&gt;Höger- eller dubbelklicka&lt;/b&gt; för att avsluta linjen, &lt;b&gt;Tryck enter&lt;/b&gt; för att stänga linjen, &lt;b&gt;Backsteg&lt;/b&gt; för att ångra, &lt;b&gt;Esc&lt;/b&gt; för att avrbyta. Prova &lt;b&gt;Space&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Färdigställ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Snappa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Streck</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Ångra</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Längd:&lt;/b&gt; %1 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Börja en rak linje. &lt;b&gt;Dra&lt;/b&gt;: Börja en kurva. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Dra&lt;/b&gt;: Följ existerande objekt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Rita en rak linje. &lt;b&gt;Dra&lt;/b&gt;: Rita en kurva. &lt;b&gt;Höger- eller dubbelklicka&lt;/b&gt;: Färdigställ linjen. &lt;b&gt;%1&lt;/b&gt;: Stäng linjen. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Tryck på kartan för att avsluta medelvärdesbildningen</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Avsluta inställning av objektet. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set a point object, &lt;b&gt;Drag&lt;/b&gt; to set its rotation if the symbol is rotatable</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att placera ett punktobjekt, &lt;b&gt;Dra&lt;/b&gt; för att rotera symbolen om den är roterbar</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Snappa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Återställ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Låsta vinklar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Skapa ett punktobjekt.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Skapa ett objekt och välj dess orientering.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Återställ rotation.</translation>
     </message>
@@ -1184,7 +1197,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation type="obsolete">&lt;b&gt;Streckade linjer på.&lt;/b&gt; </translation>
@@ -1202,84 +1215,84 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">&lt;b&gt;Space&lt;/b&gt; för att växla streckade linjer</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Färdigställ</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Snappa</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Snappa till linje</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Streck</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Ångra</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Klicka eller dra&lt;/b&gt;: Börja rita en rektangel. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Snappa till tidigare linjer. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Sätt hörnpunkt. &lt;b&gt;Höger- eller dubbelklicka&lt;/b&gt;: Färdigställ rektangeln. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to write text with a single anchor, &lt;b&gt;Drag&lt;/b&gt; to create a text box</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att skriva text från ett ankare, &lt;b&gt;Dra&lt;/b&gt; för att skapa en textlåda</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Snappa till existerande objekt</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Färdigställ redigering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Avbryt redigering.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Skapa en textlåda med endast ett ankare. &lt;b&gt;Drag&lt;/b&gt;: Skapa en textlåda. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to select an object, &lt;b&gt;Drag&lt;/b&gt; for box selection, &lt;b&gt;Shift&lt;/b&gt; to toggle selection</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att välja ett objekt, &lt;b&gt;Dra&lt;/b&gt; för att välja flera, &lt;b&gt;Shift&lt;/b&gt; för att växla markering</translation>
@@ -1293,30 +1306,30 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">; Prova &lt;u&gt;Ctrl&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Snappa</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Växla kurvor</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fri förflyttning. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt; på del: Växla mellan rak och kurvig. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to select an object, &lt;b&gt;Drag&lt;/b&gt; for box selection, &lt;b&gt;Shift&lt;/b&gt; to toggle selection</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att välja ett objekt, &lt;b&gt;Dra&lt;/b&gt; för att välja flera, &lt;b&gt;Shift&lt;/b&gt; för att växla markering</translation>
@@ -1330,30 +1343,30 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">&lt;b&gt;Ctrl+klick&lt;/b&gt; på en punkt för att radera den, på en linje för att lägga till en ny punkt, med &lt;b&gt;Space&lt;/b&gt; för att göra den till en styrpunkt</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Snappa</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Punkt / Vinkel</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Streck av/på</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Färdigställ redigering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Behåll motsatta handtagspositioner. </translation>
@@ -1363,23 +1376,23 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">&lt;b&gt;%1&lt;/b&gt;: Behåll motsatta handtagspositioner. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt; på punkt: Radera den; på linje: Lägg till en ny streckpunkt; med &lt;b&gt;%2&lt;/b&gt;: Lägg till normal punkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt; på punkt: Radera den; på linje: Lägg till ny punkt; med &lt;b&gt;%2&lt;/b&gt;: Lägg till en streckpunkt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Klicka&lt;/b&gt; på punkt för att växla mellan streckpunkt och normal punkt. </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
         <source>&lt;b&gt;Coordinate offset [mm]:&lt;/b&gt; %1, %2  &lt;b&gt;Distance [m]:&lt;/b&gt; %3</source>
         <translation type="obsolete">&lt;b&gt;Koordinat-offset [mm]:&lt;/b&gt; %1, %2  &lt;b&gt;Distans [m]:&lt;/b&gt; %3</translation>
@@ -1401,232 +1414,232 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">; Prova &lt;u&gt;Ctrl&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Koordinatförskjutning:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Avstånd:&lt;/b&gt; %3 m </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Låsta vinklar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Snappa till existerande objekt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Välj ett objekt. &lt;b&gt;Dra&lt;/b&gt;: Välj flera objekt. &lt;b&gt;%1+Klicka&lt;/b&gt;: Växla markering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Radera markerade objekt. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Högkvalitetsvisning (antialiasing)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Antialiasing ger en bättre kartvisning, men kan göra visningen långsammare</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Högkvalitativ textvisning på karta (antialiasing), långsam</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Klicktolerans:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Avstånd för snappning (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Stegning i låst vinkel-läget (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Ikonstorlek:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Vid markering av ett objekt, markera automatiskt även dess symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Zooma ut från muspekaren vid utzoomning</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Ritverktyg: placera sista punkt under avslut med högerklick</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Bakgrunder: behåll inställningar för stängda bakgrunder</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Redigeringsverktyg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Behåll gammal form</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Nollställ kurvans yttre handtag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Behåll kurvans yttre handtag</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Åtgärd när en kurvpunkt raderas med %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Rektangelverktyg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Radie för hjälpkors:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Förhandsvisa bredden på linjer med hjälpkorset</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Redigerare</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Kunde inte skapa ny fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Format (%1) stödjer inte export</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Kartytan är stor. Fyllnadsverktyget kan vara långsamt. Vill du använda det i alla fall?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Den valda ytan är inte sluten av linjer eller areor, kan inte fylla denna yta.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Den valda positionen är inte tom, kan inte använda fyllnadsverktyget här.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Misslyckades med att fylla objektet.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Fyll ytan med den aktiva symbolen. Området måste vara slutet med linjer eller areor, hänsyn till andra symboler tas ej. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS är avstängd i enhetsinställningarna. Öppna inställningarna nu?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
 </context>
 <context>
-    <name>GPSProjectionParametersDialog</name>
+    <name>OpenOrienteering::GPSProjectionParametersDialog</name>
     <message>
         <source>GPS coordinates projection parameters</source>
         <translation type="obsolete">GPS-koordinaters projektionsparamtetrar</translation>
@@ -1649,139 +1662,139 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Importera med GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Utseende</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Skärm</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Pixlar per tum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Programstart</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Sparar filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Behåll kompatibilitet med Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Spara ångra/gör om-historiken</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Spara information för automatisk återställning</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Intervall för att spara återställningsinformation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Import och export av filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-bitars kodning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Mer…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Använd den nya OCD-fil importeraren även för version 8-filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Observera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Programmet måste startas om för att språket ska ändras!</translation>
     </message>
@@ -1790,58 +1803,58 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Använd översättningsfil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Öppna översättning</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Översättningsfiler (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Den valda filen är inte en giltig översättningsfil.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Primär skärmupplösning i pixlar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Primär skärmstorlek i tum (på diagonalen):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Allmänt</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Lokala koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM koordinat referenssystem</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM koordinater</translation>
     </message>
@@ -1850,74 +1863,74 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">UTM-zon (nummer nord/syd t.ex &quot;32 N&quot;, &quot;24 S&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM-Zon (nummer nord/syd)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Gauss-Krueger, utgångspunkt: Potsdam</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Gauss-Krueger koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Zon-nummer (1 till 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>av EPSG kod</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ koordinater</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG-kod</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>Egen PROJ.4</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Specifikation</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Specifikation för kartskala är ogiltig eller fattas.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Ogiltig rutnätsskalfaktor: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Okänt CRS-specifikationsspråk: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Geografisk CRS-specifikationen stöds ej: %1</translation>
     </message>
@@ -1926,7 +1939,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Skala endast</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
@@ -1936,7 +1949,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>GeoreferencingActivity</name>
+    <name>OpenOrienteering::GeoreferencingActivity</name>
     <message>
         <source>Georeferencing</source>
         <translation type="obsolete">Georeferera</translation>
@@ -1951,7 +1964,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>GeoreferencingAddTool</name>
+    <name>OpenOrienteering::GeoreferencingAddTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set the template position of the pass point</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att placera kalibreringspunktens position på bakgrunden</translation>
@@ -1962,28 +1975,28 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>GeoreferencingDeleteTool</name>
+    <name>OpenOrienteering::GeoreferencingDeleteTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to delete pass points</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att ta bort kalibreringspunkt</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Georeferering</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Rutnätsskalfaktor:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Sökning...</translation>
     </message>
@@ -2000,8 +2013,8 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Ändra projektionsparametrar…</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation></translation>
     </message>
@@ -2014,7 +2027,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Kartskala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Lutning:</translation>
     </message>
@@ -2023,13 +2036,13 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Referenspunkt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Projicerade koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Referenssystem:</translation>
     </message>
@@ -2038,7 +2051,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">&amp;Zon:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation></translation>
     </message>
@@ -2055,7 +2068,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Konvergens:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Geografiska koordinater</translation>
     </message>
@@ -2068,23 +2081,23 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Longitud för referenspunkt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Visa referenspunkt i:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>giltig</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Lutningssökning online</translation>
     </message>
@@ -2093,7 +2106,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Den magnetiska lutning för referenspunkten %1� %2� kommer nu att hämtas från &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Koordinat referenssystem</translation>
     </message>
@@ -2106,7 +2119,7 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">- från Proj.4 specifikationen -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- lokal -</translation>
     </message>
@@ -2115,106 +2128,106 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">CRS-specifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Referenspunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Välj på kartan</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(utgångspunkt: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation>Ö</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation>Ö</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Kartans norr</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Kartkoordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Geografiska koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>När CRS förändras, behåll:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Den magnetiska lutningen för referenspunkten %1° %2° kommer nu att hämtas från &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Lutningsförändring</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Lutningen har ändrats. Vill du rotera kartan efter ändringarna?</translation>
     </message>
@@ -2223,39 +2236,39 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Beräknade koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Lokala koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Hämtar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Kunde inte tolka data.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Lutningvärde kunde inte hittas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Lutningssökningen online misslyckades:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation></translation>
@@ -2266,14 +2279,14 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>GeoreferencingMoveTool</name>
+    <name>OpenOrienteering::GeoreferencingMoveTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move pass points</source>
         <translation type="obsolete">&lt;b&gt;Dra&lt;/b&gt; för att flytta kalibreringspunkt</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
         <source>&lt;b&gt;Left click&lt;/b&gt; to set the reference point, another button to cancel</source>
         <translation type="obsolete">&lt;b&gt;Vänsterklicka&lt;/b&gt; för att sätta referenspunkten, annan knapp för att avbryta</translation>
@@ -2283,13 +2296,13 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">&lt;b&gt;Klicka&lt;/b&gt;: Placera en referenspunkt. En annan knapp för att avbryta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Placera referenspunkt. &lt;b&gt;Högerklicka&lt;/b&gt;: Avbryt.</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingWidget</name>
+    <name>OpenOrienteering::GeoreferencingWidget</name>
     <message>
         <source>Pass points:</source>
         <translation type="obsolete">Kalibreringspunkter:</translation>
@@ -2340,15 +2353,15 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Välkommen till OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidget</name>
+    <name>OpenOrienteering::HomeScreenWidget</name>
     <message>
         <source>Clear list</source>
         <translation type="vanished">Töm listan</translation>
@@ -2408,90 +2421,90 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Aktiviteter</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Skapa ny karta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Öppna karta…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Avsluta</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Senaste kartor</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Öppna den senast använda kartan när programmet startar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Töm listan</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Dagens tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Visa dagens tips</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Föregående</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Nästa</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Exempel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Om Mapper</translation>
     </message>
@@ -2500,30 +2513,30 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Om Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Fil-lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Inga kartor hittades!&lt;br/&gt;&lt;br/&gt;Kopiera kartfiler till en folder på toppnivån med namnet &apos;OOMapper&apos; på enheten eller ett minneskort.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Fel vid läsning av symbol av typ %1 på linje %2 kolumn %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>Symbol-ID &apos;%1&apos; är inte unikt på linje %2 kolumn %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Fel vid inläsning av symbol av typen %1 vid linje %2 kolumn %3: %4</translation>
     </message>
@@ -2532,38 +2545,38 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Fel vid läsning av en symbol.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Fel vid läsning av ett objekt av typ %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Fel vid läsning av objekt, av typ %1 på %2:%3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Kunde inte hitta symbol för objekt, på %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Punktobjekt utan eller med felaktig symbol, på %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Versioner 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation></translation>
     </message>
@@ -2572,48 +2585,48 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="vanished">Kunde inte läsa datan.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Kunde inte läsa koordinaterna.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Förväntade %1 koordinater, hittade %2 koordinater.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Fel vid läsning av utskriftskonfigurationen vid %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Fel vid läsning av ångra/gör om-stegen vid %1:%2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Inget sådant alternativ: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Geospatial vektor data</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Hittade ett objekt utan symbol.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Dumpade %n oregelbundna objekt.</numerusform>
@@ -2621,207 +2634,207 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Fel under symbolers efterbehandling.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Bakgrund &quot;%1&quot; har lästs från kartans mapp istället för den relativa plats där filen tidigare låg.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Misslyckades att ladda bakgrund &apos;%1&apos;, anledning: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Varningar när bakgrund &apos;%1&apos; laddades:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Minst en bakgrund kunde inte hittas.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Klicka på de röda bakgrunderna i Bakgrunder -&gt; Bakgrundsfönstret för att hitta bakgrundsfilerna.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Denna fil använder ett föråldrat format. Stöd för detta format kommer försvinna från detta program snart. För att kunna spara filen i framtiden, spara den igen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Felaktig filformatsversion.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Filformatet är för gammalt och stöds ej. Använd en äldre version av programmet och uppdatera filen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>För ny version av filformatet. Kartan kan inte visas eller sparas korrekt av denna version. Överväg att uppdatera Mapper.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Det geografiska koordinatreferenssystemet för kartan var&quot;%1&quot;. Detta CRS-system stöds ej. Använder &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Fel vid läsning av en symbol av typ %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Fel vid läsning av en symbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Fel vid läsning av ångra-steg.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Fel vid läsning av kartdelarnas antal.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Fel vid läsning av kartdel %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Kunde inte läsa fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Filformatet stöds ej.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>För ny version av filformatet. Kartan kan inte visas eller sparas korrekt av denna version.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Format (%1) stödjer inte import</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Kunde inte läsa &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Linjeinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Linjebredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Linjefärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Minsta linjelängd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Linjeände:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>kapad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>kanting</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>spetsig</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>Linjeanslutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>spetsig</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>avfasad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Ändens längd:</translation>
     </message>
@@ -2839,161 +2852,161 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Avslutningslängd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Visa minst en mittsymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Minsta antal mellansymboler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Minsta antal mellansymboler för sluten linje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Strecklängd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Streckad linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Mellanrumslängd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Grupperade streck:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>inga</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Gruppens mellanrumslängd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Halva längden på första och sista strecket</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Mittsymboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Mellansymboler per plats:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Avstånd mellansymboler:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Kantlinjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Olika kantlinjer på höger och vänster sida</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Vänster gräns:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Höger gräns:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Dumpa strecksymbolen vid linjestart och linjeslut</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Skalera sträcklinjesymbolen vid hörn</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Startsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Mittsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Slutsymbol</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Strecksymbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Aktivera kantlinjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Avstånd mellan punkter:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Avstånd från linjeslutet:</translation>
     </message>
@@ -3002,175 +3015,176 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
         <translation type="obsolete">Kant</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Kantbredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Kantfärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Kantbyte:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Kanten är streckad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Strecklängd för kant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Mellanrumslängd för kant:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Skapa ny karta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Öppna…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Öppna en befintlig fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Öppna &amp;senaste</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Spara</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Spara &amp;som…</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Inställningar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Stäng denna fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>A&amp;vsluta</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Avsluta programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Allmänt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Öppna &amp;Manualen</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Visa hjälpfilen för programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Om %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Visa information om programmet</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Om &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Visa information om Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjälp</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Vill du ta bort den autosparade versionen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Filen har ändrats.
 Vill du spara dina ändringar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Osparad fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -3179,60 +3193,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Vill du skala om symbolerna till den valda skalan?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Kraschvarning</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Det verkar som att %1 kraschade senaste gången denna fil öppnades:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Vill du verkligen öppna den igen?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Autosparar...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Autosparning misslyckades!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Alla kartor</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Alla filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Öppna fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Du måste stänga den nuvarande filen innan du kan öppna en annan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Öppnar %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -3243,19 +3257,19 @@ File format not recognized.</source>
 Filformatet känns inte igen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Filen har modifierats.
 Vill du slänga dina ändringar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -3266,22 +3280,22 @@ Tryck Ja för att spara i detta format.
 Tryck Nej för att välja ett annat format.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Spara fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Filen kunde inte sparas:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Det uppstod ett problem när filformatet skulle bestämmas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Var god rapportera det här som en bugg.</translation>
     </message>
@@ -3331,27 +3345,27 @@ Tryck Nej för att välja ett annat format.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
         <source>default layer</source>
         <translation type="obsolete">förvalt lager</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -3360,7 +3374,7 @@ because saving as %2 (.%3) is not supported.</source>
 eftersom att spara som %2 (.%3) inte stöds.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -3375,25 +3389,25 @@ eftersom formatet är okänt.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Kartexporten gav varningar.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Internt fel vid sparning:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -3402,13 +3416,13 @@ eftersom formatet är okänt.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Kartimporten gav varningar.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -3417,12 +3431,12 @@ for reading.</source>
 för läsning.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Ogiltig filtyp.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -3443,17 +3457,17 @@ Error during symbol post-processing.</source>
 Fel vid bearbetning av symbolerna.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Inget att importera.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Fråga</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -3462,23 +3476,23 @@ Rescale the imported data?</source>
 Skala om den importerade datan?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>förvald del</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Ny färg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Importera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Symbol-ersättningen avbröts.
@@ -3486,104 +3500,104 @@ Importera datan ändå?</translation>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Registrerings svart (alla utskrivna färger)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Koordinater är utanför området.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
         <source>One or more templates could not be loaded. Use the Templates -&gt; Template setup window to resolve the issue(s) by clicking on the red template file name(s).</source>
         <translation type="obsolete">En eller flera bakgrundsbiler kunde inte öppnas. Använd Bakgrundsbilder -&gt; Bakgrundsinställningar för att lösa problemen genom att klicka på de röda filnamnen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Skriv ut…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Ångra</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Ångra senaste steget</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Gör om</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Gör om senaste steget</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>&amp;Klipp ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>K&amp;opiera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>K&amp;listra in</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Zooma in</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Zooma ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Växla helskärmsläge</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Ställ in egen zoomfaktor…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Symbolfönster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Visa/dölj symbolfönstret</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Färgfönster</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Visa/dölj färgfönstret</translation>
     </message>
@@ -3592,7 +3606,7 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Läs in symboler från…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Ersätt symboluppsättningen med symbolerna från en annan kartfil</translation>
     </message>
@@ -3605,43 +3619,43 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Byt ut färgerna med färger från en annan kartfil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Skala om alla symboler…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Skala om hela symboluppsättningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Ändra kartskala…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Ändra kartskalan och justera kartobjekt och symbolstorlekar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Kartanteckningar…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translatorcomment>Bakgrundsinställningsfönster för långt</translatorcomment>
         <translation>Bakgrundsinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Visa/dölj bakgrundsinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Öppna bakgrundsbild…</translation>
     </message>
@@ -3650,62 +3664,62 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Ändra projektionsparametrar…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Visa hela kartan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Redigera objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Sätt punktobjekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Rita linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Rita cirklar och ellipser</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Skriv text</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Duplicera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Byt ut symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Fyll / skapa kantlinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Byt streckningsriktning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>Anslut linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Dela objekt</translation>
     </message>
@@ -3718,261 +3732,261 @@ Importera datan ändå?</translation>
         <translation type="vanished">Rotera objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Mät längd och area</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Importera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Redigera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Visa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>V&amp;erktyg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>&amp;Symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Karta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>&amp;Bakgrundsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Ritning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Måla på bakgrundsbild</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>Ö</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Välj alla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Välj inget</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Invertera markering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Visa rutnät</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Redigera rutnät...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Konturteckna ytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Konturvisning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Dölj alla bakgrundsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>Symboluppsättnings-ID...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Redigera symboluppsättnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Läs in CRT-fil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Tilldela nya symboler med korsreferenstabell</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Georeferera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Rotera karta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Rotera hela kartan</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Läs in bakgrund igen...</translation>
     </message>
@@ -3985,27 +3999,27 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Visa/Dölj fönstret för tag-väljaren</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Rita rektanglar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Klipp hål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Klipp runt hål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Klipp rektangulärt hål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Rotera mönster</translation>
     </message>
@@ -4014,22 +4028,22 @@ Importera datan ändå?</translation>
         <translation type="vanished">Skala objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Slå ihop ytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Dela ytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>Symboluppsättnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Redigera symboluppsättnings-ID:</translation>
     </message>
@@ -4038,7 +4052,7 @@ Importera datan ändå?</translation>
         <translation type="vanished">Tag-väljare</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Ändrat till kartdel &apos;%1&apos;.</translation>
     </message>
@@ -4047,57 +4061,57 @@ Importera datan ändå?</translation>
         <translation type="vanished">Area-skillnad</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Yta XOr</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Kartkoordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Projicerade koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Latitud/longitud (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Latitud/longitud (DMS)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Visa koordinater som...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Klipp hål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Visa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Välj bakgrundsbild…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Redigering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Avancerad redigering</translation>
     </message>
@@ -4106,23 +4120,23 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Skriv ut eller exportera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Inga ångra-steg tillgängliga.</translation>
     </message>
@@ -4132,8 +4146,8 @@ Importera datan ändå?</translation>
         <translation type="vanished">Klipp %1 objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Ett internt fel uppstod, ursäkta!</translation>
     </message>
@@ -4142,7 +4156,7 @@ Importera datan ändå?</translation>
         <translation type="vanished">Kopierade %1 objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>Det finns inga objekt att klistra in!</translation>
     </message>
@@ -4151,91 +4165,91 @@ Importera datan ändå?</translation>
         <translation type="vanished">Klistrade in %1 objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Ställ in egen zoom</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Zoom:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Färger</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Skala om alla symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Skala om till procenttal:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Kartnoteringar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Bakgrundsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Placera punktobjekt på kartan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Välj en punktsymbol för att använda detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Rita polygon- och kurvlinjer.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Välj en linje, yta eller kombinerad symbol för att använda detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Rita cirklar och ellipser.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Ställ in riktningen för yt-mönster eller punktobjekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Välj ett ytobjekt med roterbart mönster eller ett roterbart punktobjekt för att aktivera detta verktyg.</translation>
     </message>
@@ -4244,177 +4258,177 @@ Importera datan ändå?</translation>
         <translation type="obsolete">Importera OMAP, OCD, GPX, OSM eller DXF filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Kan inte importera den valda kartfilen eftersom den inte kan laddas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Rita rektanglar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Redigering pågår</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Kartan redigeras, var vänlig avsluta redigeringen innan du sparar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Kartan sparades</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Bild</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Töm ångra / gör om historik</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Töm ångra / gör om historik för att minska storleken på kartfilen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Panorera</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Trycksimulering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Ersätt symboluppsättning...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Taggredigerare</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Visa/dölj taggredigeringsfönstret</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Redigera linjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Rita på frihand</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Fyll slutna ytor</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Klipp ut från yta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Slå ihop ythål</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Konvertera till kurvlinjer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Förenkla linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Klipp bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Fördela punkter längs linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Rita på bakgrund inställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Slå på touchmuspekare</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Slå på GPS-visning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Slå på distansringar för GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Placera punktobjekt vid GPS-position</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Placera en temporär GPS-punkt vid GPS-positionen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Placera en temporär linje vid GPS-positionen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Ta bort alla temporära GPS-punkter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Slå på kompassvisning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Justera kartan mot norr</translation>
     </message>
@@ -4423,78 +4437,78 @@ Importera datan ändå?</translation>
         <translation type="vanished">Växa bakgrundsvisning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Lägg till en ny del...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>By namn på denna del...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Ta bort denna del</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>Slå ihop alla delar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Kopiera position</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Kopiera position till urklipp.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>Exportera som...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Kartdelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Välj symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Dölj toppfältet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Visa toppfältet</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Skriv ut / exportera finns inte tillgänglig i denna version!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Taggredigerare</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -4504,7 +4518,7 @@ symbol
 vald</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -4514,22 +4528,22 @@ symboler
 valda</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Rita linjer på frihand.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Fyll slutna ytor.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Skriv text på kartan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Välj en textsymbol för att använda detta verktyg.</translation>
     </message>
@@ -4542,31 +4556,31 @@ valda</translation>
         <translation type="vanished">Duplicera de valda objekten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Vill du ta bort kartdel &quot;%1&quot; och alla dess objekt?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Välj minst ett objekt för att använda detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Byt riktning för symboler på linjeobjekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Välj minst ett linjeobjekt för att använda detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>Slå ihop slutpunkter på linjer som är nära varandra.</translation>
     </message>
@@ -4575,17 +4589,17 @@ valda</translation>
         <translation type="vanished">Dela de valda objekten i mindre bitar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Välj minst ett linje- eller ytobjekt för att använda detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Gör ett hål i det valda ytobjektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Välj ett ytobjekt för att använda detta verktyg.</translation>
     </message>
@@ -4622,74 +4636,74 @@ valda</translation>
         <translation type="vanished">Beräkna ej överlappande delar av ytor.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Ändra raka linjedelar till mjuka bezierkurvor.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Välj en linje för att aktivera detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Minska antalet punkter i linjeobjekt (försöker att behålla de ursprungliga formerna).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Resulterande symbol: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Välj minst två yt- eller linjeobjekt för att aktivera detta verktyg.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Förena överlappande objekt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Ta bort alla delar som inte överlappar med det först markerade objektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Ta bort överlappande delar av det först valda objektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Ta bort alla delar som överlappar det först markerade objektet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>Sammanfoga ytans hål, eller sammanfoga hål med objektets kant för att att skära ut den delen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Välj ett ytobjekt med hål för att aktivera detta verktyget.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Skapa ett utklipp med vissa objekt eller hela kartan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Välj ett slutet linjeobjekt som utklippsform för att aktivera det här verktyget.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Klipp bort några objekt eller allt i ett begränsat område.</translation>
     </message>
@@ -4698,8 +4712,8 @@ valda</translation>
         <translation type="vanished">Ändrar symbolen på de valda objekten till den valda symbolen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Välj minst ett objekt och en annan, passande, symbol för att använda detta verktyg.</translation>
     </message>
@@ -4708,12 +4722,12 @@ valda</translation>
         <translation type="vanished">Fyll den valda linjen eller skapa en kantlinje för vald yta.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Placerar jämnt fördelade punktobjekt längs ett befintligt linjeobjekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Välj minst ett linjeobjekt och ett punktobjekt, för att aktivera detta verktyg.</translation>
     </message>
@@ -4722,7 +4736,7 @@ valda</translation>
         <translation type="vanished">%1 objekt duplicerades</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Objektval</translation>
     </message>
@@ -4731,58 +4745,58 @@ valda</translation>
         <translation type="vanished">Inga objekt valdes för att det inte finns några objekt med den eller de valda symbolerna.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Mät</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Förening misslyckades.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Delning misslyckades.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Differens misslyckades.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>XOr misslyckades.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Ihopslagning av hål misslyckades.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Ta bort alla temporära punkter</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Är du säker på att du vill radera alla temporära GPS-punkter? Detta går inte att ångra.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>Slå ihop denna del med</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Flytta valda objekt till</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Skriv in namnet på kartdelen:</translation>
     </message>
@@ -4791,63 +4805,63 @@ valda</translation>
         <translation type="vanished">Vill du radera kartdelen &quot;%1&quot; och alla dess objekt? Detta går inte att ångra.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Slå ihop kartdelar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Vill du flytta alla objekt från kartdel &quot;%1&quot; till &quot;%2&quot;, och ta bort &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Vill du flytta alla objekt till kartdel &quot;%1&quot; och ta bort alla andra kartdelar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Rita på fri hand på en bakgrundsbild</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Rita fritt på en bakgrundsbild. Skapa eller öppna en bakgrundsbild som går att rita på för att använda detta verktyg</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Importera %1, GPX-, OSM- eller DXF-fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Importerbara filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Alla filer</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Kan inte importera den valda filen eftersom dess filformat inte stöds.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Rotera objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Skala objekt</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4856,7 +4870,7 @@ valda</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Kopierat %n objekt</numerusform>
@@ -4864,7 +4878,7 @@ valda</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Klistrat in %n objekt</numerusform>
@@ -4872,42 +4886,42 @@ valda</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Raderar de valda objekten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Duplicera de valda objekten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Rotera de valda objekten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Skala de valda objekten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Dela de markerade objekten i mindre delar.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Ändra symbolen på de valda objekten till den valda symbolen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation type="unfinished">Fyll valda linjer eller skapa kantlinjer för den/de markerade ytan/ytorna.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Duplicerat %n objekt</numerusform>
@@ -4915,178 +4929,178 @@ valda</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Inga objekt har markerats eftersom det inte finns några objekt med de valda symbolerna.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Avbryt. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Mer: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Mer: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Mer: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Hitta...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Sök &amp;nästa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Hitta objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Sök nästa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Sök &amp;alla</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Avancerad sökning</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Karta -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Bearbetar separering av sidan %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Bearbetar sida %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Avbruten</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Klar</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Textkälla:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Karta (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>odefinierat språk</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Översättning (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Före redigering, den lagrade texten kommer att ersättas med den nuvarande översättningen. Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Efter ändring av den lagrade texten, översättningen kanske inte längre kan hittas. Vill du fortsätta?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -5101,7 +5115,7 @@ färgdialogen och
 ställ in färgerna där.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -5116,7 +5130,7 @@ och välj &quot;Ny symbol&quot;
 för att skapa en.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -5129,7 +5143,7 @@ För att läsa in bakgrundsbilder, tryck på
 Bakgrundsbilder -&gt; Öppna bakgrundsbild...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Tips: Håll ner mittersta musknappen för att dra kartan,
@@ -5137,96 +5151,96 @@ zooma med scrollhjulet om tillgängligt.</translation>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translatorcomment>Osäker på denna.</translatorcomment>
         <translation>Omkrets:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Längd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Inget objekt valt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 objekt valt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Det valda objektet är inte en linje.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Detta objekt är för litet.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Den minsta arean är %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Obs: Omkrets och area visas bara korrekt om ytan inte korsar sig själv och hål används rätt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Denna linje är för kort.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Minimumlängden är %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation></translation>
     </message>
@@ -5236,29 +5250,29 @@ zooma med scrollhjulet om tillgängligt.</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Skapa ny karta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Välj skala och symboluppsättning för den nya kartan.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Skala:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Symboluppsättningar:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Visa bara symboluppsättningar i den valda skalan</translation>
     </message>
@@ -5267,140 +5281,140 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="vanished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Skapa</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Tom symboluppsättning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Läs in symboluppsättning från en fil…</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Alla symboluppsättningsfiler</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Alla filer</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Kartan innehåller fler än 256 färger vilket inte stöds av OCD version 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad gav %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Registrerings svart exporteras som en vanlig färg.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Det gick inte att exportera fyllningsmönstrets skifte för ett ytobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Kunde inte exportera bakgrund: filtypen &quot;%1&quot; stöds inte än</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Koordinaterna justerades till att passa i OCAD 8&apos;s ritarea (-2 m ... 2 m).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Några koordinater är fortfarande utanför ritningsytan för OCAD 8. Dessa kanske inte kan läsas av OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>I linjesymbolen &quot;%1&quot;, kan inte visa slut/anslutnings-kombination.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>I linjesymbolen &quot;%1&quot;, ignorerars strecknings-grupperingen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>I linjesymbolen &quot;%1&quot;, har antalet streck i en grupp har minskats till 2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>I linjesymbol &quot;%1&quot; kan inte kantlinjen exporteras korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>I ytsymbolen &quot;%1&quot;, hoppas ett fyllnadsmönster över.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>I ytsymbolen &quot;%1&quot;, antas ett &quot;bytta rader&quot;-mönster. Detta kan vara rätt eller fel.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>I textsymbolen %1: ett eget symbolutrymme är satt, implementationen matchar inte OCAD:s beteende än</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>I textsymbol %1: understreck ignoreras</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>I textsymbol %1: kerning ignoreras</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Sträng avkortad (avkortning märkt med tre &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Kunde inte tilldela buffert.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad gav %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD-filer av version %1 stöds ej!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n färgseperation skippades, anledning: importering avstängd.</numerusform>
@@ -5408,97 +5422,97 @@ zooma med scrollhjulet om tillgängligt.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Kunde inte läsa dekorfärgers definition, fel: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Färg &quot;Registrations svart&quot; är importerad som en specialfärg.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Kunde inte importera symbol &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>OCAD importlager</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>I streckad linje-symbolen %1 är längden för spetsiga linjeslut olika (%2 och %3). Använder %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>I streckad linje-symbol %1 kan inte slutlängden importeras korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>I streckad linje-symbol %1 kan inte slutmellanrumet importeras korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>I streckad linje-symbol %1 är huvud- och slutlängden olika (%2 och %3). Använder %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>I streckad linje-symbol %1 är mellanrummen D och E olika (%2 och %3). Använder %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Linjesymbol %1: döljer strecksymbol vid linjeslut.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Vid import av textsymbol %1: ignorerar marginaljustering av texten</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Vid import av textsymbol %1: ignorerar egen tjocklek (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Vid import av textsymbol %1: eget teckenavstånd inställt, implementationen matchar inte OCADs beteende än</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Vid import av textsymbol %1: ignorerar egeninställt ordavstånd (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Vid import av textsymbol %1: ignorerar egeninställda tabbavstånd (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Vid import av textsymbol %1: ignorerar textram (läge %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Kunde inte ladda objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Kunde inte importera rektangelobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Importerar inte textsymbol, kunde inte beräkna bana (npts=%1): %2</translation>
     </message>
@@ -5507,239 +5521,239 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Kunde inte importera bakgrundsbild: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Kunde inte importera bakgrundsbild: &quot;%1&quot; verkar inte vara en rasterbild</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Försöker importera textobjekt med okänt koordinatformat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Färg-ID gick inte att hitta: %1, ignorerar denna färg</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>är</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>är inte</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>innehåller</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Sök</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation type="unfinished">Text</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>och</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>eller</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>ogiltig</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>I linjesymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>I textsymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Kunde inte ladda koordinatsystemet &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Dekorfärgsinformation ignorerades.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Kan inte importera symbol %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Ostödd typ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Kan inte importera bakgrund: &quot;%1&quot; er inte en bakgrunds typ som stöds.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Linjeutseendet &apos;%1&apos; stöds ej.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Olika längder för spetsiga ändar vid början (%1 mm) och slut (%2 mm) stöds inte. Använder %3 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Det streckade mönstret kan inte importeras korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Det streckade mönstrets slutlängd (%1 mm) kan inte importeras korrekt. Använder %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Det streckade mönstrets slutmellanrum (%1 mm) kan inte importeras korrekt. Använder %2 mm.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Ostödd ramlinjestil &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Hoppade över sekundär punktsymbol.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Dumpa strecksymbol vid linjeslut.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Denna symbol kan inte sparas som en OCD-symbol igen.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Berättigad justering stöds inte.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Vertikal justering &apos;%1&apos; stöds ej.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Ignorerar egeninställd tjocklek (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Eget symbolmellanrum kan vara inkorrekt.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Ignorerar eget ord mellanrum (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Ignorerar eget indrag (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Ignorerar textinramning (läge %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Linjetextsymboler stöds inte än. Markerar symbolen som gömd.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Kodning &apos;%1&apos; är inte tillgänglig. Kontrollera inställningarna.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>I areasymbol %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Kunde inte ladda objekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Kunde inte importera rektangelobjekt</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Importerar inte textsymbol, kunde inte beräkna bana (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Försöker importera textobjekt med okänt koordinatformat</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Felaktig data.</translation>
     </message>
@@ -5748,59 +5762,59 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="vanished">Otestad fil-importerare för format: OCD %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD-filer med version %1 stöds ej!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Färg-ID gick inte att hitta: %1, ignorerar denna färg</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Omöjligt att tilldela &quot;%1&quot; SRS för GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Lila</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Yta</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Kan inte ladda lager %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Kan inte ladda %n objekt, eftersom: %1</numerusform>
@@ -5808,122 +5822,109 @@ zooma med scrollhjulet om tillgängligt.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Tom geometri.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Kan inte bestämma koordinattransformationen: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Misslyckades med att transformera koordinaterna.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Okänd eller icke-supporterad typ av geometri.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Inte tillräckligt många koordinater.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Kan inte använda detta referenssystem:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>Geodata har inte något passande referenssystem.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Orienteringskarta</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Programvara för att rita orienteringskartor</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Välj bakgrundsbild att rita på</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Rita</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
         <source>&lt;b&gt;Left mouse click and drag&lt;/b&gt; to paint, &lt;b&gt;Right mouse click and drag&lt;/b&gt; to erase</source>
         <translation type="obsolete">&lt;b&gt;Tryck ner vänster musknapp och dra&lt;/b&gt; för att rita, &lt;b&gt;tryck ner höger musknapp och dra&lt;/b&gt; för att sudda</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Klicka och dra&lt;/b&gt;: Rita. &lt;b&gt;Högerklicka och dra&lt;/b&gt;: ta bort. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Välj färg</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta kartan. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to add a coordinate, &lt;b&gt;Ctrl+Click&lt;/b&gt; to change the selected coordinate</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att lägga till en koordinat, &lt;b&gt;ctrl+klicka&lt;/b&gt; för att ändra den valda koordinaten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt; för att lägga till en koordinat, &lt;b&gt;%1+Klicka&lt;/b&gt; för att ändra den valda koordinaten. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
         <source>Point editor</source>
         <translation type="obsolete">Punktredigerare</translation>
@@ -5937,164 +5938,164 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Element:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Alltid riktad mot norr (ej roterbar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Yta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Centrera alla element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Valt element</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Innerfärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Yttre bredd &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Yttre färg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Linjebredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Linjefärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Ände:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>kapad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>rund</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>kanting</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>Linjeanslutning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>spetsig</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>avfasad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Linje sluten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Ytfärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Koordinater:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Start på kurva</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Centrera med medelvärde av koordinaterna</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>Mittpunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Okänd</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
         <source>Point settings</source>
         <translation type="obsolete">Punktinställningar</translation>
@@ -6104,63 +6105,63 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Pekar alltid mot norr (ej roterbar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Punktsymbol</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Skriver ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Ett fel inträffade under bearbetning.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the print area</source>
         <translation type="obsolete">&lt;b&gt;Dra&lt;/b&gt; för att flytta utskriftsområdet</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta kartan, utskriftsområdet eller områdets kanter. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta utskriftsområdet. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta kartan. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta utskriftsområdets kanter. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta utskriftsområdets kanter. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
         <source>Printer or exporter:</source>
         <translation type="obsolete">Skrivare eller export:</translation>
@@ -6174,42 +6175,42 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Exportera bild</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Visa bakgrundsbilder</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Visa rutnät</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Sidorientering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Skrivare:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Stående</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Liggande</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Storlek:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Exemplar:</translation>
     </message>
@@ -6218,22 +6219,22 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Utskriftsområde</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Vänster:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Överkant:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Bredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Höjd:</translation>
     </message>
@@ -6242,7 +6243,7 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Centrera yta på kartan</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Förhandsvisa…</translation>
     </message>
@@ -6251,264 +6252,264 @@ zooma med scrollhjulet om tillgängligt.</translation>
         <translation type="obsolete">Exportera</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>En sida</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Egen yta</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Kartyta:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Centrera utskriftområde</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Egenskaper</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Sidöverlappning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Upplösning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Skriv ut i annan skala:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Bakgrundsutseendet kan skilja sig åt.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Simulera tryck</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>Förvald</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Enhets CMYK (experimentell)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Färgläge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Skriv ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF-export</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Bild-export</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Spara som PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Stöds ej på Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Misslyckades med att förbereda förhandsvisningen.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Utskriftsförhandsvisning förlopp</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Ett icke standardiserat visningsläge är aktiverat. Är du säker att du vill skriva ut/exportera kartan med detta?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Misslyckades med att förbereda PDF-exporten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Ett fel inträffade under utskrift.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Exportera karta …</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Misslyckades med förberedning av utskrift.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Utskrift pågår</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Vektorgrafik</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Rastergrafik</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Färgseperationer</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Läge:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Misslyckades att förbereda bilden. Inte tillräckligt med minne.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Kunde inte spara bild. Existerar mappen? Har du tillräckliga rättigheter?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Exporterad till %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Misslyckades med färdigställning av PDF-exporten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Avbruten.</translation>
     </message>
@@ -6517,12 +6518,12 @@ separations</source>
         <translation type="vanished">Skriver ut</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Utskriften kunde inte stoppas.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Utskriftsjobb skapat</translation>
     </message>
@@ -6531,14 +6532,14 @@ separations</source>
         <translation type="vanished">Ett fel inträffade under bearbetning.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Okänd</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Kartområdet är tomt. Utskrift avbruten.</translation>
     </message>
@@ -6556,153 +6557,153 @@ separations</source>
     </message>
 </context>
 <context>
-    <name>ProjectedCRSSelector</name>
+    <name>OpenOrienteering::ProjectedCRSSelector</name>
     <message>
         <source>&amp;Coordinate reference system:</source>
         <translation type="vanished">&amp;Koordinatsystem:</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Återöppna bakgrundsbild</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Dra objekt från den vänstra listan till önskad plats i listan till höger för att ladda om dem.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Stängda bakgrundsbilder:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Töm listan</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Aktiva bakgrundsbilder:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Karta -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Ersätt symboluppsättning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Konfigurera hur symboler ska ersättas, och vilka.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Importera alla nya symboler även om de inte används som ersättning för en redan existerande symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Ta bort de ursprungliga symbolerna som inte längre används efter ersättningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Radera oanvända färger efter ersättningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Symbolmatchning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Behåll symbolernas gömd/skyddad status från den tidigare symboluppsättningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Matcha ersättningssymboler genom symbolnummer</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Redigera symboluppsättnings-ID:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Ersättning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Matcha mot symbolnamn</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Tilldela nya symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Mönster</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Rensa ersättningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Öppna CRT-fil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Spara CRT-fil...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Symbolöversättning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT-fil</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Det finns flera ersättningar för symbol %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6713,7 +6714,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6724,153 +6725,153 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Korsreferenstabellen har blivit modifierad.
 Vill du spara dina ändringar?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Inga -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Välj kartfil att hämta symboler ifrån</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Kan inte ladda kartfil, avbryter.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Den valda symboluppsättningen har skala !:%1, medans kartskalan är 1:%2. Vill du verkligen använda dessa symboler?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>Kan inte ladda CRT-filen, avbryter.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Rotera karta</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Grader (motsols):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Rotationsparametrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Rotera runt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Rotationscentrums koordinater</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Georefererat rotationscentrum</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Annan rotationscentrumspunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Justera georeferenspunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Justera georeferensens lutning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Rotera icke georefererade bakgrunder</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Vinkel:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fasta vinklar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Sätt riktning för ytfyllnadsmönster eller punktobjekt. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set the rotation center</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att ställa in rotationspunkten</translation>
@@ -6880,106 +6881,106 @@ Vill du spara dina ändringar?</translation>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att ställa in rotationspunkten, &lt;b&gt;dra&lt;/b&gt; för att rotera de valda objekten</translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Fasta vinklar. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Sätt rotationscentrum. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Rotera valda objekt. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Ändra kartskala</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Skalningsparametrar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Ny skala:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Skalningscentrum:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Kartkoordinats origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Georefererat skaleringscentrum</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Annan punkt,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Skala om symbolstorlekar</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Skala om kartobjektens positioner</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Justera georefererings referenspunkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Skala icke georefererade bakgrunder</translation>
     </message>
@@ -6993,19 +6994,19 @@ Vill du spara dina ändringar?</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Skalering:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Placera centrum för skalering. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Drag&lt;/b&gt;: Skala valda objekt. </translation>
     </message>
@@ -7019,9 +7020,9 @@ Vill du spara dina ändringar?</translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Välj koordinat referenssystem</translation>
     </message>
@@ -7030,17 +7031,17 @@ Vill du spara dina ändringar?</translation>
         <translation type="vanished">Samma som kartans</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Samma som kartans</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Lokal</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Koordinater (WGS84)</translation>
     </message>
@@ -7061,175 +7062,175 @@ Vill du spara dina ändringar?</translation>
         <translation type="vanished">CRS Specifikation:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>giltig</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished">&apos;%1&apos; är lagrad på en vanlig plats.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; finns i app-lagringen. Filerna kommer att tas bort när appen avinstalleras.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; är inte skrivbar. Ändringar kan inte sparas.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; är inte en giltig lagringsplats.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- ingen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- ingen -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Nummer:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Redigera</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Namn:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Beskrivning:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Hjälpsymbol (visas inte i den färdiga kartan)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Allmänt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Beskrivning</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>För symboler med beskrivning, tryck F1 medan inforutan är synlig för att visa beskrivningen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Ny symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Yta</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Kombinerad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Redigera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Duplicera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Skala…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Klistra in</translation>
     </message>
@@ -7242,12 +7243,12 @@ Vill du spara dina ändringar?</translation>
         <translation type="vanished">Fyll / skapa kantlinje för valda objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Välj symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Aktivera dra och släppa</translation>
     </message>
@@ -7260,103 +7261,103 @@ Vill du spara dina ändringar?</translation>
         <translation type="obsolete">Oanvända</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Ett internt fel uppstod, ursäkta!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>Det finns inga symboler i urklipp att klistra in!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Välj alla objekt med denna symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Ta bort alla objekt med denna symbol från markering</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Dölj objekt med denna symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Skydda objekt med denna symbol</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Lägg till alla objekt med valda symboler till markering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Ta bort alla objekt med den/de valda symbolerna från markering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Dölj objekt med valda symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Skydda objekt med valda symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Välj alla</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Välj oanvända</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Invertera markering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Sortera symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Sortera på nummer</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Sortera efter primärfärg</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Sortera efter primär färgprioritering</translation>
     </message>
@@ -7365,7 +7366,7 @@ Vill du spara dina ändringar?</translation>
         <translation type="obsolete">Skalera symbol %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Skalera till procenttal:</translation>
     </message>
@@ -7374,44 +7375,44 @@ Vill du spara dina ändringar?</translation>
         <translation type="vanished">Skalera symbol(er)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Bekräftelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Kartan innehåller objekt med symbolen &quot;%1&quot;. Tar du bort den kommer objekten tas bort och ångra-historiken kommer rensas! Vill du verkligen göra det?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Lägg till alla objekt med denna symbol till markeringen</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Välj alla objekt med valda symboler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Byt symbol på valda objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Fyll / Skapa kantlinjer för valda objekt</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Skalera symboler</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
         <source>General</source>
         <translation type="obsolete">Allmänt</translation>
@@ -7437,52 +7438,52 @@ Vill du spara dina ändringar?</translation>
         <translation type="obsolete">Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Symbolinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Bakgrund:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Bakgrundsbild:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(ingen)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Öppna…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Centrera bakgrundsbild…</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>begränsningsruta på origo</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>gravitationscentrum på utgångspunkten</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Välj bakgrundsfärg</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -7490,7 +7491,7 @@ to jump over the lazy dog
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- namnlös -</translation>
     </message>
@@ -7520,52 +7521,52 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Ingen beskrivning!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Relation</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Nyckel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Jämförelse</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Lägg till rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Ta bort rad</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
@@ -7578,7 +7579,7 @@ to jump over the lazy dog
         <translation type="vanished">Hjälp</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n objekt valt/valda</numerusform>
@@ -7586,77 +7587,77 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Ogiltigt uttryck</translation>
     </message>
 </context>
 <context>
-    <name>TagsDialog</name>
+    <name>OpenOrienteering::TagsDialog</name>
     <message>
         <source>Close</source>
         <translation type="obsolete">Stäng</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Nyckel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Nyckel existerar</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Nyckeln &quot;%1&quot; existerar redan och får inte användas två gånger.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Sök upp den flyttade bakgrundsbilden</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Ingen sådan fil.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Är filens format korrekt för denna bakgrundstyp?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Inte tillräckligt minne.</translation>
     </message>
@@ -7666,25 +7667,25 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Bakgrundsjustering</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Kunde inte beräkna justering!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to set the template position of the pass point</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att sätta kalibreringspunktens position på bakgrunden.</translation>
@@ -7694,110 +7695,110 @@ to jump over the lazy dog
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att sätta kalibreringspunktens position på kartan, &lt;b&gt;Esc&lt;/b&gt; för att avbryta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Placera bakgrundspositionen för kalibreringspunkten. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Placera kartpositionen för kalibreringspunkten. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
         <source>&lt;b&gt;Click&lt;/b&gt; to delete pass points</source>
         <translation type="obsolete">&lt;b&gt;Klicka&lt;/b&gt; för att ta bort kalibreringspunkt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Klicka&lt;/b&gt;: Ta bort kalibreringspunkter. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move pass points</source>
         <translation type="obsolete">&lt;b&gt;Dra&lt;/b&gt; för att flytta kalibreringspunkt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Dra&lt;/b&gt;: Flytta kalibreringspunkter. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Kalibreringspunkter:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Flytta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Bakgrund X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Bakgrund Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Karta X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Karta Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Applicera kalibreringspunkter</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Applicera &amp;&amp; rensa alla</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Rensa alla</translation>
     </message>
 </context>
 <context>
-    <name>TemplateGPS</name>
+    <name>OpenOrienteering::TemplateGPS</name>
     <message>
         <source>Error</source>
         <translation type="obsolete">Fel</translation>
@@ -7816,19 +7817,19 @@ to jump over the lazy dog
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Inte tillräckligt mycket tillgängligt minne (bildstorlek: %1x%2 pixlar)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7837,69 +7838,69 @@ Stöd för att spara GIF-filer finns inte. Det du ritar på denna bakgrund komme
 Tänker du inte rita på bakgrunden är det inget problem.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Välj koordinatsystemet som används i worldfilen</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
         <source>Open image template</source>
         <translation type="obsolete">Öppna bakgrundsbild</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Öppnar %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Bildens storlek:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Specifera hur bilden ska positioneras eller skalas:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>Worldfil</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>Ingen georefererings-information</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Georefererad</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Meter per pixel:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Scannad med</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Bakgrundsskala:  1:</translation>
     </message>
@@ -7908,35 +7909,35 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Annan skala för bakgrund 1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Öppna</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Visa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Genomskinlighet</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Gruppera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Filnamn</translation>
     </message>
@@ -7945,24 +7946,24 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Skapa…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Skissa</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Öppna…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Georefererade: %1</translation>
     </message>
@@ -7971,42 +7972,42 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="vanished">Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Duplicera</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Lägg till bakgrund...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Importera och ta bort</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
@@ -8015,17 +8016,17 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Valda bakgrunder</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Flytta för hand</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Justera...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Öppna bild, GPS-spår eller DXF-fil</translation>
     </message>
@@ -8034,17 +8035,17 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Georeferera…</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Positionering...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Bakgrundsfiler</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Alla filer</translation>
     </message>
@@ -8077,19 +8078,19 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Bildfiler (*.bmp *.jpg *.jpeg *.gif *.png *.tiff *.gpx);;Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Okänt filformat.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Kunde inte ladda bakgrund. Existerar filen och är den korrekt?</translation>
     </message>
@@ -8098,23 +8099,23 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         <translation type="obsolete">Ange ett nummer från 0 till 1 eller ange ett procenttal från 0 till 100!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Ange ett heltal för att sätta en grupp eller lämna fältet tomt för att avgruppera bakgrunden!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Skala inte</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Skala till kartans nominella skalförhållande (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -8123,28 +8124,28 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Skala enligt nuvarande bakgrundsskala (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Bakgrundsimportering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Hur ska symbolerna i den importerade bakgrundskartan skalas?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>Bakgrunden kommer vara osynlig i övertryckssimulering. Byta till normal vy?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Karta -</translation>
     </message>
@@ -8162,167 +8163,167 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Dra&lt;/b&gt; för att flytta aktuell bakgrund</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Positionering</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-skala:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-skala:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Skalning och position av spår</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Koordinatsystem</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Verklig</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Karta</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>En koordinatenhet är lika med:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Placera spår vid givna koordinater</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Placera spår vid visningscentm</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Denna mall måste laddas med GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Välj det koordinatsystem som används i spåret</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Öppnar spår ...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Läs in spåret som georefererat eller icke-georefererat?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Placera spåret enligt kartans georefereringsinställningar.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Dessa är inte konfigurerade än, så detta sker i nästa steg.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Georefererad</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Icke georefererad</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Projicera spåret med hjälp av en ortografisk projektion med centrum vid spårets genomsnittskoordinat. Tillåter justering av omvandlingen och inställning av kartans georeferering genom den justerade spårposition.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Sökvägen är tom, det finns inget att importera!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Fråga</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Ska waypointsen importeras som en linje som går genom alla punkter?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Importproblem</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n linjeobjekt kunde inte importeras (anledning: koordinater saknas).</numerusform>
@@ -8330,7 +8331,7 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Fel vid läsning</translation>
     </message>
@@ -8343,7 +8344,7 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -8352,38 +8353,38 @@ Tänker du inte rita på bakgrunden är det inget problem.</translation>
 %2 {1:?}</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1: ingen OSM-fil.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM-filen är av version %1.
 Lägsta versionen som stöds är %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM-filen är av version %1.
 Högsta versionen som stöds är %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Problem</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 nod kunde inte bearbetas korrekt.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Extern länk: %1</translation>
@@ -8394,58 +8395,58 @@ Högsta versionen som stöds är %2.</translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Justering</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>Centrum</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Toppen</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Baslinje</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Botten</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Textinställningar</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Typsnitt:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Storlek:</translation>
     </message>
@@ -8454,141 +8455,141 @@ Högsta versionen som stöds är %2.</translation>
         <translation type="vanished">Bestäm storlek…</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Färg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>fetstil</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>kursiv</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>understruken</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Textstil:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Linjeavstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Paragrafavstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Teckenavstånd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Symbol-ikon text:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Ram</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Kompabilitetsinställningar för OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Ramfärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Linjeram</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Skuggram</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Höger-/vänsterjustering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Topp-/bottenjustering:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>OCAD-kompabilitet</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>aktiverad</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Linjebredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Linjefärg:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation></translation>
     </message>
@@ -8609,7 +8610,7 @@ Högsta versionen som stöds är %2.</translation>
         <translation type="obsolete">Visa kompabilitetsinställningar för OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Linje under stycken</translation>
     </message>
@@ -8618,195 +8619,195 @@ Högsta versionen som stöds är %2.</translation>
         <translation type="obsolete">Aktivera</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Bredd:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Avstånd från baslinje:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Egna tabbpositioner</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Lägg till egen tabbposition</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Beräkna</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Kan inte ångra för att det senaste ångra-steget blev ogiltigt. Detta kan hända om du t.ex. ändrar symbolen för ett objekt och sen tar bort den gamla symbolen.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Bekräftelse</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Ångrar du detta steg går du bortanför steget där filen öppnades. Vill du göra det?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Kan inte ångra för att det senaste ångra-steget blev ogiltigt. Detta kan hända om du t.ex. tar bort symbolen för ett objekt du har ritat.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Kunde inte hitta hjälpfilerna.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Misslyckades med att hitta hjälp-utforskaren(&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Misslyckades med att starta hjälp-utforskaren (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Se mer...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Äldre versioner av Mapper stöder inte flera kartdelar. För att spara för dessa versioner behöver du slå ihop kartdelarna.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Elementet stöds ej: %1 (linje %2 kolumn %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Vissa koordinater var utanför det aktuella området. Kartans innehåll justerades.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>okänd</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Delar av denna fil kan inte läsas av denna version av Mapper. Använd: %1 eller nyare version</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Fel vid linje %1 kolumn %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Några ogiltiga tecken har tagits bort.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Georeferensspecifikationen stöds ej eller är felaktig &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Kunde inte sätta knockout egenskap för färg &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Förväntade %1 färger, hittade %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Dekorfärg %1 hittades inte under bearbetning av %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Förväntade %1 symboler, hittade %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Förväntade %1 kartdelar, hittade %2.</translation>
     </message>

--- a/translations/OpenOrienteering_template.ts
+++ b/translations/OpenOrienteering_template.ts
@@ -2,5084 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation type="unfinished">%1x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5093,767 +15,2852 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
-        <source>Cancel</source>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
-        <source>Draw</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateTool</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
-        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
-        <source>Color selection</source>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
-        <source>%</source>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
-        <source>Always oriented to north (not rotatable)</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
-        <source>Elements</source>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ActionGridBar</name>
+    <message>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
-        <source>Point</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
-        <source>Line</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
-        <source>Area</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
-        <source>Center all elements</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
-        <source>Current element</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
-        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
-        <source>Inner color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
-        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
-        <source>Outer color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
-        <source>Line width:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
-        <source>Line color:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
-        <source>Line cap:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
-        <source>flat</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
-        <source>round</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
-        <source>square</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
-        <source>Line join:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
-        <source>miter</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
-        <source>bevel</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
-        <source>Line closed</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
-        <source>Coordinates:</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>X</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
-        <source>Curve start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
-        <source>Center by coordinate average</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
-        <source>[Midpoint]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
-        <source>Unknown</source>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
-        <source>Point symbol</source>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
-        <source>Printing</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
-        <source>An error occurred during processing.</source>
-        <comment>PrintWidget</comment>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
-        <source>Show templates</source>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
-        <source>Page orientation:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
-        <source>Printer:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
-        <source>Portrait</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
-        <source>Landscape</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
-        <source>Page format:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
-        <source>Copies:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
-        <source>Left:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
-        <source>Top:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
-        <source>Width:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
-        <source>Height:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
-        <source>Preview...</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
-        <source>Single page</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
-        <source>Custom area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
-        <source>Map area:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
-        <source>Center print area</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
+        <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
-        <source>Properties</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
-        <source>Page overlap:</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
-        <source>Options</source>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
-        <source>Resolution:</source>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
-        <source>Print in different scale:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
-        <source>Template appearance may differ.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
-        <source>Simulate overprinting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
-        <source>Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
-        <source>Device CMYK (experimental)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
-        <source>Color mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
-        <source>Export...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
-        <source>PDF export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
-        <source>Image export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
-        <source>Save to PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
-        <source>dpi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <source>Not supported on Android.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <source>Failed to prepare the preview.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
-        <source>Print Preview Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
-        <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
-        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
-        <source>PNG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
-        <source>BMP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
-        <source>TIFF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
-        <source>JPEG</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <source>Failed to prepare the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
-        <source>PDF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <source>An error occurred during printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
-        <source>Export map ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
-        <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <source>Failed to prepare the printing.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
-        <source>Printing Progress</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
-        <source>Vector
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
-        <source>Raster
-graphics</source>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
-        <source>Color
-separations</source>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
-        <source>Mode:</source>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <source>Failed to prepare the image. Not enough memory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
-        <source>Exported successfully to %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <source>Failed to finish the PDF export.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
-        <source>Canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <source>The print job could not be stopped.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
-        <source>Successfully created print job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
-        <source>Unknown</source>
-        <comment>Paper size</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
-        <source>The map area is empty. Output canceled.</source>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
-        <source>Reopen template</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
-        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
-        <source>Closed templates:</source>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GPSDisplay</name>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
-        <source>Active templates:</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
-        <source>- Map -</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
-        <source>Replace symbol set</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
-        <source>Configure how the symbols should be replaced, and which.</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
-        <source>Import all new symbols, even if not used as replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
-        <source>Delete original symbols which are unused after the replacement</source>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
-        <source>Delete unused colors after the replacement</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
-        <source>Symbol mapping:</source>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
-        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
-        <source>Match replacement symbols by symbol number</source>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <source>Original</source>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
-        <source>Edit the symbol set ID:</source>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Replacement</source>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
-        <source>Match by symbol name</source>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
-        <source>Assign new symbols</source>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
-        <source>Pattern</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
-        <source>Clear replacements</source>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
-        <source>Open CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
-        <source>Save CRT file...</source>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
-        <source>Symbol mapping</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
-        <source>CRT file</source>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
-        <source>There are multiple replacements for symbol %1.</source>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -5861,7 +2868,3001 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation type="unfinished">%1x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
+        <source>Draw</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
+        <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
+        <source>Color selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PanTool</name>
+    <message>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PercentageDelegate</name>
+    <message>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
+        <source>Always oriented to north (not rotatable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
+        <source>Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <source>Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
+        <source>Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <source>Center all elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
+        <source>Current element</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
+        <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
+        <source>Inner color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
+        <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
+        <source>Outer color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
+        <source>Line width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
+        <source>Line color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <source>Line cap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <source>flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
+        <source>round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
+        <source>square</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <source>Line join:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <source>miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <source>bevel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
+        <source>Line closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
+        <source>Area color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
+        <source>Coordinates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
+        <source>Curve start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
+        <source>Center by coordinate average</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
+        <source>[Midpoint]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PointSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
+        <source>Point symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintProgressDialog</name>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
+        <source>Printing</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
+        <source>An error occurred during processing.</source>
+        <comment>PrintWidget</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintTool</name>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PrintWidget</name>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
+        <source>Show templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
+        <source>Show grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
+        <source>Page orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <source>Printer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
+        <source>Portrait</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <source>Landscape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
+        <source>Page format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <source>Copies:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
+        <source>Top:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <source>Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
+        <source>Preview...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
+        <source>Single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
+        <source>Custom area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
+        <source>Map area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
+        <source>Center print area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
+        <source>Page overlap:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
+        <source>Resolution:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
+        <source>Print in different scale:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
+        <source>Template appearance may differ.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <source>Simulate overprinting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
+        <source>Device CMYK (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
+        <source>Color mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
+        <source>Export...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
+        <source>PDF export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
+        <source>Image export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
+        <source>Save to PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
+        <source>dpi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <source>Not supported on Android.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <source>Failed to prepare the preview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
+        <source>Print Preview Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
+        <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
+        <source>PNG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
+        <source>BMP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
+        <source>TIFF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
+        <source>JPEG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <source>Failed to prepare the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
+        <source>PDF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <source>An error occurred during printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
+        <source>Export map ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
+        <source>All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <source>Failed to prepare the printing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <source>Printing Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
+        <source>Vector
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
+        <source>Raster
+graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
+        <source>Color
+separations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
+        <source>Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <source>Failed to prepare the image. Not enough memory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
+        <source>Exported successfully to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <source>Failed to finish the PDF export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
+        <source>Canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <source>The print job could not be stopped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <source>Successfully created print job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
+        <source>Unknown</source>
+        <comment>Paper size</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
+        <source>The map area is empty. Output canceled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
+        <source>Reopen template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
+        <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <source>Closed templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <source>Clear list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
+        <source>Active templates:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
+        <source>- Map -</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <source>Replace symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
+        <source>Configure how the symbols should be replaced, and which.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
+        <source>Import all new symbols, even if not used as replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
+        <source>Delete original symbols which are unused after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
+        <source>Delete unused colors after the replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
+        <source>Symbol mapping:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
+        <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <source>Match replacement symbols by symbol number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
+        <source>Match by symbol name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
+        <source>Assign new symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
+        <source>Clear replacements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
+        <source>Open CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
+        <source>Save CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
+        <source>Symbol mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
+        <source>CRT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
+        <source>There are multiple replacements for symbol %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5869,672 +5870,672 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6542,1124 +6543,1124 @@ to jump over the lazy dog
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/OpenOrienteering_uk.ts
+++ b/translations/OpenOrienteering_uk.ts
@@ -2,249 +2,262 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="uk_UA">
 <context>
-    <name>AboutDialog</name>
+    <name>OpenOrienteering</name>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
+        <location filename="../packaging/translations.cpp" line="10"/>
+        <source>Orienteering map</source>
+        <translation>Спортивна карта</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="11"/>
+        <source>Software for drawing orienteering maps</source>
+        <translation>Програма для креслення спортивних карт</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
         <source>About %1</source>
         <translation>Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
         <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
         <translation>&lt;a %1&gt;Більше про ліцензування copyright та обмеження відповідальності.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
         <source>The OpenOrienteering developers in alphabetical order:</source>
         <translation>Розробники OpenOrienteering у алфавітному порядку:</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
         <source>(project initiator)</source>
         <translation>(засновник проекту)</translation>
     </message>
     <message>
         <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
         <source>A free software for drawing orienteering maps</source>
         <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
         <translation>Вільна програма для креслення спортивних карт</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
         <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
         <translation>Цей програмний продукт відноситься до вільного програмного забезпечення: дозволяється розповсюджувати та/або змінювати його відповідно до умов &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, що розроблена Free Software Foundation.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
         <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
         <translation>Ми надаємо цю програму з надією що вона буде корисною, але БЕЗ БУДЬ-ЯКИХ ГАРАНТІЙ; навіть без гарантії КОМЕРЦІЙНОЇ ЦІННОСТІ або гарантії ПРИДАТНОСТІ ДО ПРАКТИЧНОГО ВИКОРИСТАННЯ. &lt;a %1&gt;Дізнайтеся більше&lt;/a&gt; у GNU General Public License (GPL), version&amp;nbsp;3.</translation>
     </message>
     <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
         <source>For contributions, thanks to:</source>
         <translation>Дякуємо за внесок:</translation>
     </message>
 </context>
 <context>
-    <name>AbstractHomeScreenWidget</name>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
         <source>Open most recently used file</source>
         <translation>Пропонувати нещодавно відкриті файли</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
         <source>Show tip of the day</source>
         <translation>Показувати пораду дня</translation>
     </message>
 </context>
 <context>
-    <name>ActionGridBar</name>
+    <name>OpenOrienteering::ActionGridBar</name>
     <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
         <source>Show remaining items</source>
         <translation>Показати інші пункти</translation>
     </message>
 </context>
 <context>
-    <name>AreaSymbolSettings</name>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
         <source>mm²</source>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
         <source>Minimum size:</source>
         <translation>Мінімальний розмір:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
         <source>Fills</source>
         <translation>Заповнення</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
         <source>Line fill</source>
         <translation>Заповнення лінією</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
         <source>Pattern fill</source>
         <translation>Заповнення візерунком</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
         <source>Single line</source>
         <translation>Окрема лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
         <source>Parallel lines</source>
         <translation>Паралельні лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
         <source>Line spacing:</source>
         <translation>Відстань між лініями:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
         <source>Single row</source>
         <translation>Окремий рядок</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
         <source>Pattern interval:</source>
         <translation>Інтервал візерунку:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
         <source>Pattern offset:</source>
         <translation>Зміщення візерунку:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
         <source>Row offset:</source>
         <translation>Зміщення рядка:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
         <source>Parallel rows</source>
         <translation>Паралельні рядки</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
         <source>Row spacing:</source>
         <translation>Відстань між рядками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
         <source>Fill rotation</source>
         <translation>Обертання заповнення</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
         <source>adjustable per object</source>
         <translation>регулюється за об&apos;єктом</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
         <source>Element drawing at boundary</source>
         <translation>Відображення елементів на межі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
         <source>Clip elements at the boundary.</source>
         <translation>Обрізати елементи на межі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
         <source>Draw elements if the center is inside the boundary.</source>
         <translation>Відображати елементи якщо центр всередині межі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
         <source>Draw elements if any point is inside the boundary.</source>
         <translation>Відображати елементи якщо будь-яка точка всередині межі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
         <source>Draw elements if all points are inside the boundary.</source>
         <translation>Відображати елементи якщо всі точки всередині межі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
         <source>Area settings</source>
         <translation>Параметри площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
         <source>Pattern fill %1</source>
         <translation>Заповнення візерунком %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
         <source>Line fill %1</source>
         <translation>Заповнення лінією %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
         <source>No fill selected</source>
         <translation>Заповення не вибрано</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
         <source>Area color:</source>
         <translation>Колір площі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
         <source>Line offset:</source>
         <translation>Зсув лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
         <source>Line color:</source>
         <translation>Колір лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
         <source>Line width:</source>
         <translation>Ширина лінії:</translation>
     </message>
 </context>
 <context>
-    <name>AutosaveDialog</name>
+    <name>OpenOrienteering::AutosaveDialog</name>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
         <source>Autosaved file</source>
         <translation>Автоматично збережені файли</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
         <source>%n bytes</source>
         <translation>
             <numerusform>%n байт</numerusform>
@@ -253,249 +266,249 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
         <source>File saved by the user</source>
         <translation>Файл збережений користувачем</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
         <source>File recovery</source>
         <translation>Відновлення файлу</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
         <source>File %1 was not properly closed. At the moment, there are two versions:</source>
         <translation>Файл %1 не був збережений перед закриттям. Наразі існує дві версії цього файла:</translation>
     </message>
     <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
         <source>Save the active file to remove the conflicting version.</source>
         <translation>Збережіть активну версію файла щоб позбутися конфлікту версій.</translation>
     </message>
 </context>
 <context>
-    <name>ColorDialog</name>
+    <name>OpenOrienteering::ColorDialog</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
         <source>Edit map color</source>
         <translation>Правка кольору карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
         <source>Defines a spot color:</source>
         <translation>Створити планшетний колір:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
         <source>Mixture of spot colors (screens and overprint):</source>
         <translation>Суміш планшетних кольорів (екран і overprint):</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
         <source>Knockout: erases lower colors</source>
         <translation>Витіснення: замальовувати нижні кольори</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
         <source>Calculate from spot colors</source>
         <translation>Розрахувати з планшетного кольору</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
         <source>Calculate from RGB color</source>
         <translation>Розрахувати з кольору RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
         <source>Custom process color:</source>
         <translation>Набрати колір вручну:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
         <source>Cyan</source>
         <translation>Блакитний</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
         <source>Magenta</source>
         <translation>Пурпурний</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
         <source>Yellow</source>
         <translation>Жовтий</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
         <source>Black</source>
         <translation>Чорний</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
         <source>Calculate from CMYK color</source>
         <translation>Розрахувати з кольору CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
         <source>Custom RGB color:</source>
         <translation>Набрати колір RGB вручну:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
         <source>Red</source>
         <translation>Червоний</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
         <source>Green</source>
         <translation>Зелений</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
         <source>Blue</source>
         <translation>Синій</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
         <source>#RRGGBB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
         <source>Desktop</source>
         <translation>Домашній друк</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
         <source>Professional printing</source>
         <translation>Професійний друк</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
         <source>- unnamed -</source>
         <translation>- без назви -</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
 </context>
 <context>
-    <name>ColorDropDown</name>
+    <name>OpenOrienteering::ColorDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
         <source>- none -</source>
         <translation>- немає -</translation>
     </message>
 </context>
 <context>
-    <name>ColorListWidget</name>
+    <name>OpenOrienteering::ColorListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Opacity</source>
         <translation>Непрозорість</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>Spot color</source>
         <translation>Планшетний колір</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>CMYK</source>
         <translation>CMYK</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
         <source>K.o.</source>
         <translation>K.o.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
         <source>New</source>
         <translation>Новий</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
         <source>Duplicate</source>
         <translation>Дублювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
         <source>Move Up</source>
         <translation>Підняти</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
         <source>Move Down</source>
         <translation>Опустити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
         <source>Double-click a color value to open a dialog.</source>
         <translation>Подвійний клік по кольору відкриє діалогове вікно.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>Confirmation</source>
         <translation>Підтвердження</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
         <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
         <translation>Карта містить знаки такого кольору. Видалення знебарвить ці об’єкти! Ви справді хочете це зробити?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
         <source>%1 (duplicate)</source>
         <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
         <translation>%1 (дублікат)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
         <source> (Duplicate)</source>
         <translation> (Дублікат)</translation>
     </message>
@@ -508,300 +521,300 @@
         <translation type="vanished">Введіть будь-ласка значення від 0% до 100%!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
         <source>Double click to define the color</source>
         <translation>Двічі клікніть щоб задати колір</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
         <source>Click to select the name and click again to edit.</source>
         <translation>Клацніть щоб вибрати колір і клацніть ще раз щоб редагувати його.</translation>
     </message>
 </context>
 <context>
-    <name>CombinedSymbolSettings</name>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
         <source>&amp;Number of parts:</source>
         <translation>&amp;Кількість складових:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
         <source>- Private line symbol -</source>
         <translation>- Приватний лінійний знак -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
         <source>- Private area symbol -</source>
         <translation>- Приватний площадний знак -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
         <source>Edit private symbol...</source>
         <translation>Правити приватний знак...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
         <source>Combination settings</source>
         <translation>Параметри комбінування</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
         <source>Change from public to private symbol</source>
         <translation>Змінити публічний знак на приватний</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
         <source>Take the old symbol as template for the private symbol?</source>
         <translation>Використати старий знак у якості основи для приватного знаку?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
         <source>Symbol %1:</source>
         <translation>Знак %1:</translation>
     </message>
 </context>
 <context>
-    <name>ConfigureGridDialog</name>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
         <source>Configure grid</source>
         <translation>Налаштувати сітку</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
         <source>Show grid</source>
         <translation>Показувати сітку</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
         <source>Snap to grid</source>
         <translation>Прив’язка до сітки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
         <source>Choose...</source>
         <translation>Виберіть...</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
         <source>All lines</source>
         <translation>Всі лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
         <source>Horizontal lines</source>
         <translation>Горизонтальні лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
         <source>Vertical lines</source>
         <translation>Вертикальні лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
         <source>Alignment</source>
         <translation>Вирівнювання</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
         <source>Align with magnetic north</source>
         <translation>Вирівняти по магнітній півночі</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
         <source>Align with grid north</source>
         <translation>Вирівняти по півночі сітки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
         <source>Align with true north</source>
         <translation>Вирівняти по істинній півночі</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
         <source>Additional rotation (counter-clockwise):</source>
         <translation>Додаткове обертання (проти годинникової стрілки):</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
         <source>Positioning</source>
         <translation>Позиціонування</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
         <source>meters in terrain</source>
         <translation>метри на місцевості</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
         <source>millimeters on map</source>
         <translation>міліметри на карті</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
         <source>Horizontal spacing:</source>
         <translation>Горизонтальна відстань:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
         <source>Vertical spacing:</source>
         <translation>Вертикальна відстань:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
         <source>Horizontal offset:</source>
         <translation>Горизонтальне зміщення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
         <source>Vertical offset:</source>
         <translation>Вертикальне зміщення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
         <source>Unit:</source>
         <comment>measurement unit</comment>
         <translation>Одиниці:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
         <source>Line color:</source>
         <translation>Колір ліній:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
         <source>Display:</source>
         <translation>Показувати:</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
         <source>Choose grid line color</source>
         <translation>Вибрати колір ліній сітки</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
         <source>Origin at: %1</source>
         <translation>Початок координат: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
         <source>paper coordinates origin</source>
         <translation>сітка на папері</translation>
     </message>
     <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
         <source>projected coordinates origin</source>
         <translation>проекція координатної сітки</translation>
     </message>
 </context>
 <context>
-    <name>CutHoleTool</name>
+    <name>OpenOrienteering::CutHoleTool</name>
     <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
         <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
         <translation>&lt;b&gt;Клацніть або потягніть&lt;/b&gt; щоб почати малювати отвір. </translation>
     </message>
 </context>
 <context>
-    <name>CutTool</name>
+    <name>OpenOrienteering::CutTool</name>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
         <source>The split line must end on the area boundary!</source>
         <translation>Лінія розрізу має закінчуватися на межі площі!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
         <source>Start and end of the split line are at different parts of the object!</source>
         <translation>Початок і кінецьї лінії розрізу знаходяться у різних частинах об&apos;єкта!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
         <source>Start and end of the split line are at the same position!</source>
         <translation>Початок і кінець лінії розрізу знаходяться в одній точці!</translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
         <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt; на лінії щоб розділити її на дві частини. &lt;b&gt;Потягніть&lt;/b&gt; вздовж лінії щоб вирізати її ділянку. &lt;b&gt;Клацніть або потягніть&lt;/b&gt; від межі площі щоб розділии її. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
         <source>Splitting holes of area objects is not supported yet!</source>
         <translation>Розділення отворів на площах поки що не підтримується!</translation>
     </message>
 </context>
 <context>
-    <name>CutoutTool</name>
+    <name>OpenOrienteering::CutoutTool</name>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Відсікти всю карту. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
         <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
         <translation>&lt;b&gt;%1+Клік або потягнути&lt;/b&gt;: Вибрати всі об&apos;єкти, що будуть відсічені. </translation>
     </message>
     <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Відсікти виділені об&apos;єкти. </translation>
     </message>
 </context>
 <context>
-    <name>DXFParser</name>
+    <name>OpenOrienteering::DXFParser</name>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
         <source>Could not open the file.</source>
         <translation>Неможливо відкрити файл.</translation>
     </message>
     <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
         <source>The file is not an DXF file.</source>
         <translation>Цей фал не є DXF файлом.</translation>
     </message>
 </context>
 <context>
-    <name>DetermineFontSizeDialog</name>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
     <message>
         <source>Determine font size</source>
         <translation type="vanished">Встановити розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
         <source>Letter:</source>
         <translation>Літера:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
         <source>A</source>
         <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
         <translation></translation>
@@ -815,1346 +828,1346 @@
         <translation type="vanished">мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
 </context>
 <context>
-    <name>DistributePointsSettingsDialog</name>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
         <source>Distribute points evenly along path</source>
         <translation>Розподілити точки рівномірно вздовж відрізку</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
         <source>Number of points per path:</source>
         <translation>Кількість точок вздовж відрізку:</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
         <source>Also place objects at line end points</source>
         <translation>Розмістити об&apos;єкти також на кінцях відрізку</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
         <source>Rotation settings</source>
         <translation>Параметри обертання</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
         <source>Align points with direction of line</source>
         <translation>Вирівняти точки у напрямку лінії</translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
         <source>°</source>
         <comment>degrees</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
         <source>Additional rotation angle (counter-clockwise):</source>
         <translation>Додатковий кут повороту (проти годинникової стрілки):</translation>
     </message>
 </context>
 <context>
-    <name>DrawCircleTool</name>
+    <name>OpenOrienteering::DrawCircleTool</name>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
         <source>From center</source>
         <comment>Draw circle starting from center</comment>
         <translation>Від центру</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Почати креслити коло або еліпс. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб накреслити коло. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
         <source>Hold %1 to start drawing from the center.</source>
         <translation>Утримуйте %1 щоб малювати від центру.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Завершити коло. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
         <translation>&lt;b&gt;Протягніть&lt;/b&gt; щоб накреслити еліпс. </translation>
     </message>
 </context>
 <context>
-    <name>DrawFreehandTool</name>
+    <name>OpenOrienteering::DrawFreehandTool</name>
     <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt;щоб намалювати лінію. </translation>
     </message>
 </context>
 <context>
-    <name>DrawLineAndAreaTool</name>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
         <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
         <translation>&lt;b&gt;Штрихові точки ввімкнено&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt;: Прив&apos;язуватись чи чіплятися за існуючі об&apos;єкти. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt;: Слідувати напрямку існуючих об&apos;єктів. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
         <translation>&lt;b&gt;%1+%2 &lt;/b&gt;: Азимут та довжина сегменту. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt;: Прив&apos;язуватись до існуючих об&apos;єктів. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фіксовані кути. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Скасувати останній крок. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPathTool</name>
+    <name>OpenOrienteering::DrawPathTool</name>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
         <source>Finish</source>
         <translation>Завершити</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Кут</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
         <source>Info</source>
         <comment>Show segment azimuth and length</comment>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Штрих</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
         <source>Undo</source>
         <translation>Відмінити</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
         <source>Abort</source>
         <translation>Перервати</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
         <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
         <translation>&lt;b&gt;Довжина:&lt;/b&gt; %1 м </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Почати ламану лінію. &lt;b&gt;Потягніть&lt;/b&gt; щоб накреслити криву. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
         <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
         <translation>&lt;b&gt;%1+Потягніть&lt;/b&gt; вздовж об&apos;єкта щоб повторити його контур. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Почати ламану лінію. &lt;b&gt;Протягніть&lt;/b&gt; щоб накреслити криву. &lt;b&gt;Правий або подвійний клік&lt;/b&gt;: Завершити лінію. &lt;b&gt;%1&lt;/b&gt;: Замкнути лінію. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointGPSTool</name>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
         <source>Touch the map to finish averaging</source>
         <translation>Торкніться карти щоб завершити усереднення</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt; завершить установку об&apos;єкта. </translation>
     </message>
 </context>
 <context>
-    <name>DrawPointTool</name>
+    <name>OpenOrienteering::DrawPointTool</name>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
         <source>Angle</source>
         <comment>Using constrained angles</comment>
         <translation>Кут</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
         <source>Reset</source>
         <comment>Reset rotation</comment>
         <translation>Скинути</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Кут:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фіксовані кути. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Створити точковий об&apos;єкт.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
         <translation>&lt;b&gt;Протягніть&lt;/b&gt; щоб створити об&apos;єкт і задати його орієнтацію.</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
         <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
         <translation>&lt;b&gt;%1, 0&lt;/b&gt;: Скинути поворот.</translation>
     </message>
 </context>
 <context>
-    <name>DrawRectangleTool</name>
+    <name>OpenOrienteering::DrawRectangleTool</name>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
         <source>Finish</source>
         <translation>Завершити</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
         <source>Line snap</source>
         <comment>Snap to previous lines</comment>
         <translation>Прив&apos;язка до лінії</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
         <source>Dash</source>
         <comment>Drawing dash points</comment>
         <translation>Штрих</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
         <source>Undo</source>
         <translation>Відмінити</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
         <source>Abort</source>
         <translation>Перервати</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
         <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
         <translation>&lt;b&gt;Клік або потягніть&lt;/b&gt; щоб накреслити прямокутник. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Прив&apos;язка до попередньої лінії. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: щоб поставити кутову точку. &lt;b&gt;Правий або подвійний клік&lt;/b&gt; завершить прямокутник. </translation>
     </message>
 </context>
 <context>
-    <name>DrawTextTool</name>
+    <name>OpenOrienteering::DrawTextTool</name>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
         <source>Snap</source>
         <extracomment>Snap to existing objects</extracomment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Завершити правку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
         <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
         <translation>&lt;b&gt;%1+%2&lt;/b&gt;: Скасувати правку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Створити текстовий об&apos;єкт з простим якорем. &lt;b&gt;Потягніть&lt;/b&gt; щоб створити текстову область. </translation>
     </message>
 </context>
 <context>
-    <name>EditLineTool</name>
+    <name>OpenOrienteering::EditLineTool</name>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
         <source>Toggle curve</source>
         <comment>Toggle between curved and flat segment</comment>
         <translation>Перемикач кривої</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Вільний рух. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt; на сегменті: Переключити між прямою та кривою. </translation>
     </message>
 </context>
 <context>
-    <name>EditPointTool</name>
+    <name>OpenOrienteering::EditPointTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
         <source>Snap</source>
         <comment>Snap to existing objects</comment>
         <translation>Прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
         <source>Point / Angle</source>
         <comment>Modify points or use constrained angles</comment>
         <translation>Точка / Кут</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
         <source>Toggle dash</source>
         <comment>Toggle dash points</comment>
         <translation>Переключити штрихи</translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Завершити правку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
         <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Утримувати позицію протилежного маркера. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt; на точці видалить її; на лінії: Додасть нову штрихову точку; з &lt;b&gt;%2&lt;/b&gt;: Додасть нормальну точку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt; на точці видалить її; на лінії: Додасть нову точку; з &lt;b&gt;%2&lt;/b&gt;: Додасть нову штрихову точку. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
         <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
         <translation>&lt;b&gt;%1+Клік&lt;/b&gt; на точці змінює її тип (штрихова точка / нормальна точка). </translation>
     </message>
 </context>
 <context>
-    <name>EditTool</name>
+    <name>OpenOrienteering::EditTool</name>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
         <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
         <translation>&lt;b&gt;Координати зміщення:&lt;/b&gt; %1, %2 мм  &lt;b&gt;Відстань:&lt;/b&gt; %3 м </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фіксовані кути. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Прив&apos;язуватись до існуючих об&apos;єктів. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Вибрати об&apos;єкт. &lt;b&gt;Потягніть&lt;/b&gt; щоб вибрати кілька об&apos;єктів. &lt;b&gt;%1+Клік&lt;/b&gt;: Зняти/додати виділення. </translation>
     </message>
     <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Видалити виділений об&apos;єкт. </translation>
     </message>
 </context>
 <context>
-    <name>EditorSettingsPage</name>
+    <name>OpenOrienteering::EditorSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
         <source>High quality map display (antialiasing)</source>
         <translation>Висока якість відображення карти (згладжування)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
         <source>Antialiasing makes the map look much better, but also slows down the map display</source>
         <translation>Згладжування робить вигляд карти значно кращим, але уповільнює відображення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
         <source>High quality text display in map (antialiasing), slow</source>
         <translation>Висока якість відображення тексту на карті (згладжування), повільно</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
         <source>Click tolerance:</source>
         <translation>Допуск курсора:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
         <source>Snap distance (%1):</source>
         <translation>Відстань для прив&apos;язки (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
         <source>Stepping of fixed angle mode (%1):</source>
         <translation>Кроки у режимі фіксованих кутів (%1):</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
         <source>°</source>
         <comment>Degree sign for angles</comment>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
         <source>Symbol icon size:</source>
         <translation>Розмір іконок знаків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
         <source>When selecting an object, automatically select its symbol, too</source>
         <translation>Якщо виділити об’єкт, автоматично виділяти і його знак</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
         <source>Zoom away from cursor when zooming out</source>
         <translation>Триматися поруч курсора під час віддалення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
         <source>Drawing tools: set last point on finishing with right click</source>
         <translation>Інструменти креслення: Правий клік завершує лінію</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
         <source>Templates: keep settings of closed templates</source>
         <translation>Підложки: запам&apos;ятовувати налаштування закритих підложок</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
         <source>Edit tool:</source>
         <translation>Інструменти редагування:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
         <source>Retain old shape</source>
         <translation>Зберегти стару форму</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
         <source>Reset outer curve handles</source>
         <translation>Скинути налаштування напрямних у зовнішніх точках кривої</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
         <source>Keep outer curve handles</source>
         <translation>Зберегти напрямні у зовнішніх точках кривої</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
         <source>Action on deleting a curve point with %1:</source>
         <translation>Дія при видаленні точки кривої з %1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
         <source>Rectangle tool:</source>
         <translation>Інструмент Прямокутник:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
         <source>Radius of helper cross:</source>
         <translation>Величина допоміжного хрестика:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
         <source>Preview the width of lines with helper cross</source>
         <translation>Попередній перегляд ширини лінії разом з допоміжним хрестиком</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
 </context>
 <context>
-    <name>Exporter</name>
+    <name>OpenOrienteering::Exporter</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>Could not create new file: %1</source>
         <translation>Неможливо сворити новий файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
         <source>Format (%1) does not support export</source>
         <translation>Формат (%1) не підтримує експорт</translation>
     </message>
 </context>
 <context>
-    <name>FillTool</name>
+    <name>OpenOrienteering::FillTool</name>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
         <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
         <translation>Площа карти дуже велика. Застосування інструменту заливки може бути повільним. Все одно застосувати?</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
         <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
         <translation>Ділянка не є обмеженою лініями, або іншими ділянками, неможливо залити таку ділянку.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
         <source>The clicked position is not free, cannot use the fill tool there.</source>
         <translation>Ця ділянка не є вільною, тут неможливо використати інструмент заливки.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
         <source>Failed to create the fill object.</source>
         <translation>Не вдалося створити об&apos;єкт заливки.</translation>
     </message>
     <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Залити площу активним знаком. Ділянка, що буде залита, має бути обмежена лініями або межами площі; інші знаки не будть взяті до уваги. </translation>
     </message>
 </context>
 <context>
-    <name>GPSDisplay</name>
+    <name>OpenOrienteering::GPSDisplay</name>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
         <source>GPS is disabled in the device settings. Open settings now?</source>
         <translation>GPS вимкнений у налаштуваннях пристрою. Відкрити налаштування?</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
         <source>Yes</source>
         <translation>Так</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
         <source>No</source>
         <translation>Ні</translation>
     </message>
 </context>
 <context>
-    <name>GdalSettingsPage</name>
+    <name>OpenOrienteering::GdalSettingsPage</name>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
         <source>Import with GDAL/OGR:</source>
         <translation>Імпорт з GDAL/OGR:</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
         <source>DXF</source>
         <translation>DXF</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
         <source>GPX</source>
         <translation>GPX</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
         <source>OSM</source>
         <translation>OSM</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
         <source>Configuration</source>
         <translation>Конфігурація</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Parameter</source>
         <translation>Параметр</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
         <source>GDAL/OGR</source>
         <translation>GDAL/OGR</translation>
     </message>
 </context>
 <context>
-    <name>GeneralSettingsPage</name>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
         <source>Appearance</source>
         <translation>Представлення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
         <source>Language:</source>
         <translation>Мова:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
         <source>Screen</source>
         <translation>Екран</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
         <source>Pixels per inch:</source>
         <translation>Пікселів на дюйм:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
         <source>Program start</source>
         <translation>Запуск програми</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
         <source>Saving files</source>
         <translation>Збереження файлів</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
         <source>Retain compatibility with Mapper %1</source>
         <translation>Зберігати сумісність з Mapper %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
         <source>Save information for automatic recovery</source>
         <translation>Зберігати інформацію для автоматичного відновлення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
         <source>Recovery information saving interval:</source>
         <translation>Інтервал автоматичного збереження:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
         <source>min</source>
         <comment>unit minutes</comment>
         <translation>хв</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
         <source>File import and export</source>
         <translation>Імпорт та експорт</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
         <source>8-bit encoding:</source>
         <translation>8-бітне кодування:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
         <source>More...</source>
         <translation>Більше...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
         <source>Save undo/redo history</source>
         <translation>Зберігати історію редагування</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
         <source>Default</source>
         <translation>За замовчуванням</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
         <source>Use the new OCD importer also for version 8 files</source>
         <translation>Використовувати новий механізм OCD імпорту також для файлів версії 8</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>Notice</source>
         <translation>Примітка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
         <source>The program must be restarted for the language change to take effect!</source>
         <translation>Потрібно перезапустити програму щоб зміни вступили в силу!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
         <source>Open translation</source>
         <translation>Відкрити переклад</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
         <source>Translation files (*.qm)</source>
         <translation>Файли перекладу (*.qm)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
         <source>The selected file is not a valid translation.</source>
         <translation>Вибраний файл не є файлом перекладу.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
         <source>%1 x %2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
         <source>Primary screen resolution in pixels:</source>
         <translation>Роздільна здатнісь екрану у пікселях:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
         <source>Primary screen size in inches (diagonal):</source>
         <translation>Діагональ екрану у дюймах:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
         <source>General</source>
         <translation>Загальне</translation>
     </message>
 </context>
 <context>
-    <name>Georeferencing</name>
+    <name>OpenOrienteering::Georeferencing</name>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
         <source>Local coordinates</source>
         <translation>Локальні координати</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
         <source>UTM</source>
         <comment>UTM coordinate reference system</comment>
         <translation>UTM</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
         <source>UTM coordinates</source>
         <translation>UTM координати</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
         <source>UTM Zone (number north/south)</source>
         <translation>UTM Зона (номер північ/південь)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
         <source>Gauss-Krueger, datum: Potsdam</source>
         <comment>Gauss-Krueger coordinate reference system</comment>
         <translation>Проекція Гауса-Крюгера, датум: Потсдам</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
         <source>Gauss-Krueger coordinates</source>
         <translation>Координати Гауса-Крюгера</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
         <source>Zone number (1 to 119)</source>
         <comment>Zone number for Gauss-Krueger coordinates</comment>
         <translation>Номер зони (від 1 до 119)</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
         <source>by EPSG code</source>
         <comment>as in: The CRS is specified by EPSG code</comment>
         <translation>за кодом EPSG</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
         <source>EPSG @code@ coordinates</source>
         <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
         <translation>EPSG @code@ координат</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
         <source>EPSG code</source>
         <translation>EPSG код</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
         <source>Custom PROJ.4</source>
         <comment>PROJ.4 specification</comment>
         <translation>PROJ.4 вручну</translation>
     </message>
     <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
         <source>Specification</source>
         <comment>PROJ.4 specification</comment>
         <translation>Специфікація</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
         <source>Map scale specification invalid or missing.</source>
         <translation>Специфікація маштабу карти неправильна або відсутня.</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
         <source>Invalid grid scale factor: %1</source>
         <translation>Некоректний коефіцієнт викривлення сітки: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
         <source>Unknown CRS specification language: %1</source>
         <translation>Невідома мова опису БСК: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
         <source>Unsupported geographic CRS specification: %1</source>
         <translation>Специфікація географічної СК %1 не підтримується</translation>
     </message>
     <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
         <source>Local</source>
         <translation>Лоакльно</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingDialog</name>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Lookup...</source>
         <translation>Розрахувати...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
         <source>m</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
         <source>Declination:</source>
         <translation>Магнітне схилення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
         <source>Projected coordinates</source>
         <translation>Проекційні координати</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
         <source>&amp;Coordinate reference system:</source>
         <translation>&amp;Базова система координат:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
         <source>Geographic coordinates</source>
         <translation>Географічні координати</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
         <source>Show reference point in:</source>
         <translation>Показати опорну точку в:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
         <source>valid</source>
         <translation>дійсний</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
         <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
         <source>Online declination lookup</source>
         <translation>Пошук схилення онлайн</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
         <source>Map coordinate reference system</source>
         <translation>Базова система координат карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
         <source>Map Georeferencing</source>
         <translation>Геоприв&apos;язка карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
         <source>- local -</source>
         <translation>- локально -</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
         <source>Grid scale factor:</source>
         <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
         <translation>Коефіцієнт викривлення сітки:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
         <source>Reference point</source>
         <translation>Опорна точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
         <source>&amp;Pick on map</source>
         <translation>&amp;Указати на карті</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
         <source>(Datum: WGS84)</source>
         <translation>(Датум: WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
         <source>X</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
         <source>Y</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
         <source>E</source>
         <comment>west / east</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
         <source>N</source>
         <comment>north / south</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
         <source>N</source>
         <comment>north</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
         <source>E</source>
         <comment>east</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
         <source>Map north</source>
         <translation>Північ карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
         <source>Map coordinates:</source>
         <translation>Координати карти:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
         <source>Geographic coordinates:</source>
         <translation>Географічні координати:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
         <source>On CRS changes, keep:</source>
         <translation>При змінах в БСК, зберегти:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
         <source>Grivation:</source>
         <translation>Квазісхилення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
         <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
         <translation>Магнітне схилення для опорної точки %1° %2° буде взято з &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Хочете продовжити?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>Declination change</source>
         <translation>Зміна магнітного схилення</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
         <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
         <translation>Величину магнітного схилення змінено. Повернути вміст карти відповідно?</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
         <source>Local coordinates:</source>
         <translation>Локальні координати:</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
         <source>Loading...</source>
         <translation>Завантаження...</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
         <source>locked</source>
         <translation>замкнено</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
         <source>Could not parse data.</source>
         <translation>Не вдається проаналізувати дані.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
         <source>Declination value not found.</source>
         <translation>Значення схилення не знайдено.</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
         <source>The online declination lookup failed:
 %1</source>
         <translation>Онлайн пошук схилення невдалий:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
         <source>%1 °</source>
         <comment>degree value</comment>
         <translation>%1 °</translation>
     </message>
 </context>
 <context>
-    <name>GeoreferencingTool</name>
+    <name>OpenOrienteering::GeoreferencingTool</name>
     <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Установити опорну точку. &lt;b&gt;Правий клік&lt;/b&gt;: Відміна.</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenController</name>
+    <name>OpenOrienteering::HomeScreenController</name>
     <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
         <source>Welcome to OpenOrienteering Mapper!</source>
         <translation>Вітаємо в OpenOrienteering Mapper!</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetDesktop</name>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
         <source>Activities</source>
         <translation>Дії</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
         <source>Create a new map ...</source>
         <translation>Створити нову карту ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
         <source>Open map ...</source>
         <translation>Відкрити карту ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
         <source>About %1</source>
         <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
         <translation>Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
         <source>Exit</source>
         <translation>Вихід</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
         <source>Recent maps</source>
         <translation>Недавні карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
         <source>Open most recently used file on start</source>
         <translation>Відкрити останню карту при запуску</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
         <source>Clear list</source>
         <translation>Очистити журнал</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
         <source>Tip of the day</source>
         <translation>Порада дня</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
         <source>Show tip of the day</source>
         <translation>Показувати пораду дня</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
         <source>Previous</source>
         <translation>Попередня</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
         <source>Next</source>
         <translation>Наступна</translation>
     </message>
 </context>
 <context>
-    <name>HomeScreenWidgetMobile</name>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
         <source>Examples</source>
         <translation>Приклади</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
         <source>About Mapper</source>
         <translation>Про Mapper</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
         <source>File list</source>
         <translation>Список файлів</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
         <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
         <translation>Файлів карт не знайдено!&lt;br/&gt;&lt;br/&gt;Покладіть фалйи карт у папку &apos;OOMapper&apos; в корені пристрою, або карти пам&apos;яті.</translation>
     </message>
 </context>
 <context>
-    <name>ImportExport</name>
+    <name>OpenOrienteering::ImportExport</name>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
         <translation>Помилка при завантаженні знаку типу %1 у рядку %2, стовбчик %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
         <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
         <translation>ID знаку &apos;%1&apos; не є унікальним, рядок %2, стовбчик %3.</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
         <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
         <translation>Помилка при завантаженні знаку типу %1 у рядку %2, стовбчик %3: %4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
         <source>Error while loading an object of type %1.</source>
         <translation>Помилка при загрузці об&apos;єкта типу %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
         <source>Error while loading an object of type %1 at %2:%3: %4</source>
         <translation>Помилка при загрузці об&apos;єкта типу %1 у %2:%3:%4</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
         <source>Unable to find symbol for object at %1:%2.</source>
         <translation>Неможливо знайти знак для об&apos;єкту у %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
         <source>Point object with undefined or wrong symbol at %1:%2.</source>
         <translation>Вкажіть об&apos;єкт з невідомим або невірним знаком у %1:%2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
         <source>OpenOrienteering Mapper</source>
         <translation>OpenOrienteering Mapper</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
         <source>OCAD Versions 7, 8</source>
         <translation>OCAD Версії 7, 8</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
         <source>OCAD</source>
         <translation>OCAD</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
         <source>Could not parse the coordinates.</source>
         <translation>Неможливо розпізнати координати.</translation>
     </message>
     <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
         <source>Expected %1 coordinates, found %2.</source>
         <translation>Очікувані координати %1, знайдені %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
         <source>Error while loading the printing configuration at %1:%2: %3</source>
         <translation>Помилка при загрузці конфігурації друку у %1:%2:%3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
         <source>Error while loading the undo/redo steps at %1:%2: %3</source>
         <translation>Помилка при загрузці кроків відмінити/повторити у %1:%2:%3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
         <source>No such option: %1</source>
         <comment>No such import / export option</comment>
         <translation>Опція %1 відсутня</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
         <source>Geospatial vector data</source>
         <translation>Геопросторові векторні дані</translation>
     </message>
 </context>
 <context>
-    <name>Importer</name>
+    <name>OpenOrienteering::Importer</name>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
         <source>Found an object without symbol.</source>
         <translation>Знайти об&apos;єкти без знаку.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
         <source>Dropped %n irregular object(s).</source>
         <translation>
             <numerusform>Відкинуто %n нестандартний об&apos;єкт.</numerusform>
@@ -2163,207 +2176,207 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
         <source>Error during symbol post-processing.</source>
         <translation>Помилка під час постобробки знаку.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
         <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
         <translation>Підложка &quot;%1&quot; була завантажена з папки карти, а не з міця її розташування відносно файлу карти, де вона знаходилася раніше.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
         <source>Failed to load template &apos;%1&apos;, reason: %2</source>
         <translation>Не вдалося завантажити підложку &apos;%1&apos;, причина: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
         <source>Warnings when loading template &apos;%1&apos;:
 %2</source>
         <translation>Попередження під час завантаження підложки &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
         <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
         <source>At least one template file could not be found.</source>
         <translation>Як мінімум одна підложка не знайдена.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
         <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
         <translation>Клацніть на червону назву підложки у меню Підложки -&gt; Вікно параметрів підложок щоб вказати нове розтшування файла підложки.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
         <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
         <translation>Цей файл має застарілий формат. Підтримка цього формату невдовзі буде припинена програмою. Щоб зберегти можливість відкривати цей файл у майбутньому, збережіть його ще раз.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
         <source>Invalid file format version.</source>
         <translation>Недійсний формат файла.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
         <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
         <translation>Непідтримуваний застарілий формат файла. Використайте старішу версію програми щоб відкрити і перезберегти цей файл.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
         <translation>Непідтримуваний новий формат файла. Деякі особливості карти неможливо обробити або зберегти цією версією програми. Подумайте про оновлення.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
         <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
         <translation>Була використана базова система географічних координат карти &quot;%1&quot;. Ця БСК не підтримується. Застосовано &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
         <source>Error while loading a symbol with type %2.</source>
         <translation>Помилка під час завантаження знаку типу %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
         <source>Error while loading a symbol.</source>
         <translation>Помилка під час завантаження знаку.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
         <source>Error while loading undo steps.</source>
         <translation>Помилка під час завантаження попередніх кроків.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
         <source>Error while reading map part count.</source>
         <translation>Помилка під час читання кількості частин карти.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
         <source>Error while loading map part %2.</source>
         <translation>Помилка при завгрузці частини карти %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
         <source>Could not read file: %1</source>
         <translation>Неможливо прочитати файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
         <source>Unsupported file format.</source>
         <translation>Непідтримуваний формат файла.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
         <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
         <translation>Непідтримуваний новий формат файла. Деякі особливості карти неможливо обробити або зберегти цією версією програми.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
         <source>Format (%1) does not support import</source>
         <translation>Формат (%1) не підтримує імпорт</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
         <source>Could not read &apos;%1&apos;: %2</source>
         <translation>Неможливо прочитати &apos;%1&apos;: %2</translation>
     </message>
 </context>
 <context>
-    <name>LineSymbolSettings</name>
+    <name>OpenOrienteering::LineSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
         <source>Line settings</source>
         <translation>Параметри лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
         <source>Line width:</source>
         <translation>Ширина лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
         <source>Line color:</source>
         <translation>Колір лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
         <source>Minimum line length:</source>
         <translation>Мінімальна довжина лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
         <source>Line cap:</source>
         <translation>Кінці лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
         <source>flat</source>
         <translation>плоскі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
         <source>round</source>
         <translation>круглі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
         <source>square</source>
         <translation>квадратні</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
         <source>pointed</source>
         <translation>загострені</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
         <source>Line join:</source>
         <translation>З’єднання відрізків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
         <source>miter</source>
         <translation>гострі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
         <source>bevel</source>
         <translation>фасочні</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
         <source>Cap length:</source>
         <translation>Довжина кінців:</translation>
     </message>
@@ -2373,334 +2386,335 @@
         <translation>Штрихова лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
         <source>Show at least one mid symbol</source>
         <translation>Показувати хочаб один серединний знак</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
         <source>Minimum mid symbol count:</source>
         <translation>Мінімальна кількість серединних знаків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
         <source>Minimum mid symbol count when closed:</source>
         <translation>Мінімум серединних знаків якщо лінія замкнена:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
         <source>Dash length:</source>
         <translation>Довжина штриха:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
         <source>Dashed line</source>
         <translation>Штрихова лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
         <source>Break length:</source>
         <translation>Проміжок:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
         <source>Dashes grouped together:</source>
         <translation>Групування штрихів:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
         <source>none</source>
         <translation>немає</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
         <source>2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
         <source>3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
         <source>4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
         <source>In-group break length:</source>
         <translation>Внутрішньогрупові проміжки:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
         <source>Half length of first and last dash</source>
         <translation>Перший і останній штрихи вдвічи коротші</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
         <source>Mid symbols</source>
         <translation>Серединні знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
         <source>Mid symbols per spot:</source>
         <translation>Серединних знаків на штриху:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
         <source>Mid symbol distance:</source>
         <translation>Відстань між серединними знаками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
         <source>Borders</source>
         <translation>Границі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
         <source>Different borders on left and right sides</source>
         <translation>Різні границі зліва і справа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
         <source>Left border:</source>
         <translation>Ліва границя:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
         <source>Right border:</source>
         <translation>Права границя:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
         <source>Suppress the dash symbol at line start and line end</source>
         <translation>Подавити знак кінця відрізку на початку та кінці лінії</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Start symbol</source>
         <translation>Початковий знак</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Mid symbol</source>
         <translation>Серединний знак</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>End symbol</source>
         <translation>Кінцевий знак</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
         <source>Dash symbol</source>
         <translation>Знак кінця відрізку</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
         <source>Enable border lines</source>
         <translation>Включити граничні лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
         <source>Distance between spots:</source>
         <translation>Відстань між точками:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
         <source>Distance from line end:</source>
         <translation>Відстань від кінця лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
         <source>Scale the dash symbol at corners</source>
         <translation>Масштабувати знак кінця відрізку у вуглах</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
         <source>Border width:</source>
         <translation>Ширина границі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
         <source>Border color:</source>
         <translation>Колір границі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
         <source>Border shift:</source>
         <translation>Зміщення границі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
         <source>Border is dashed</source>
         <translation>Границя штрихами</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
         <source>Border dash length:</source>
         <translation>Довжина штриха границі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
         <source>Border break length:</source>
         <translation>Проміжок між штрихами границі:</translation>
     </message>
 </context>
 <context>
-    <name>MainWindow</name>
+    <name>OpenOrienteering::MainWindow</name>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
         <source>&amp;New</source>
         <translation>&amp;Новий</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
         <source>Create a new map</source>
         <translation>Створити нову карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
         <source>&amp;Open...</source>
         <translation>&amp;Відкрити...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
         <source>Open an existing file</source>
         <translation>Відкрити існуючий файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
         <source>Open &amp;recent</source>
         <translation>Відкрити &amp;недавні</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
         <source>&amp;Save</source>
         <translation>&amp;Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
         <source>Save &amp;as...</source>
         <translation>Зберегти &amp;як...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
         <source>Settings...</source>
         <translation>Налаштування...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
         <source>Close this file</source>
         <translation>Закрити цей файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
         <source>E&amp;xit</source>
         <translation>В&amp;ихід</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
         <source>Exit the application</source>
         <translation>Вийти з програми</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
         <source>General</source>
         <translation>Загальне</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
         <source>Open &amp;Manual</source>
         <translation>Відкрити &amp;Довідку</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
         <source>Show the help file for this application</source>
         <translation>Показати файл довідки для цієї програми</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
         <source>&amp;About %1</source>
         <translation>&amp;Про %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
         <source>Show information about this application</source>
         <translation>Показати інформацію про цю програму</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
         <source>Show information about Qt</source>
         <translation>Показати інформацію про Qt</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
         <source>Do you want to remove the autosaved version?</source>
         <translation>Видалити версію, що збережена автоматично?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
         <source>The file has been modified.
 Do you want to save your changes?</source>
         <translation>Цей файл було змінено.
 Бажаєте зберегти зміни?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
         <source>Unsaved file</source>
         <translation>Незбережений файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
         <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
 
 Do you want to scale the symbols to the selected scale?</source>
@@ -2709,60 +2723,60 @@ Do you want to scale the symbols to the selected scale?</source>
 Ви хочете масштабувати набір знаків до обраного масштабу?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
         <source>Crash warning</source>
         <translation>Обережно, аварійне завершення</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
         <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
         <translation>Схоже що програма завершилась аварійно коли %1 був відкритий минулого разу:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Спробувати відкрити його ще раз?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
         <source>Autosaving...</source>
         <translation>Автозбереження...</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
         <source>Autosaving failed!</source>
         <translation>Автозбереження невдале!</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
         <source>All maps</source>
         <translation>Всі карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
         <source>All files</source>
         <translation>Всі файли</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>You must close the current file before you can open another one.</source>
         <translation>Потрібно закрити поточний файл перед тим як відкрити інший.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
         <source>Opening %1</source>
         <translation>Відкривається %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
         <source>Cannot open file:
 %1
 
@@ -2773,19 +2787,19 @@ File format not recognized.</source>
 Не розпізнано формат файлу.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
         <source>The file has been modified.
 Do you want to discard your changes?</source>
         <translation>Файл був змінений.
 Відхилити всі зміни?</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
         <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
 
 Press Yes to save in this format.
@@ -2796,44 +2810,44 @@ Press No to choose a different format.</source>
 Натисніть Ні щоб обрати інший формат.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
         <source>Save file</source>
         <translation>Зберегти файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
         <source>File could not be saved:</source>
         <translation>Файл неможливо зберегти:</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
         <source>There was a problem in determining the file format.</source>
         <translation>Виникла проблема при визначенні формату файла.</translation>
     </message>
     <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
         <source>Please report this as a bug.</source>
         <translation>Будь-ласка повідомте про цю помилку.</translation>
     </message>
 </context>
 <context>
-    <name>Map</name>
+    <name>OpenOrienteering::Map</name>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="667"/>
+        <location filename="../src/core/map.cpp" line="670"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because saving as %2 (.%3) is not supported.</source>
@@ -2842,7 +2856,7 @@ because saving as %2 (.%3) is not supported.</source>
 бо збереження як %2 (.%3) не підтримується.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="662"/>
+        <location filename="../src/core/map.cpp" line="665"/>
         <source>Cannot export the map as
 &quot;%1&quot;
 because the format is unknown.</source>
@@ -2851,25 +2865,25 @@ because the format is unknown.</source>
 томущо формат невідомий.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="704"/>
+        <location filename="../src/core/map.cpp" line="707"/>
         <source>The map export generated warnings.</source>
         <translation>Експорт карти містить попередження.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="685"/>
+        <location filename="../src/core/map.cpp" line="688"/>
         <source>Internal error while saving:
 %1</source>
         <translation>Внутрішня помилка під час збереження:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="697"/>
+        <location filename="../src/core/map.cpp" line="700"/>
         <source>Cannot save file
 %1:
 %2</source>
@@ -2878,13 +2892,13 @@ because the format is unknown.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="766"/>
+        <location filename="../src/core/map.cpp" line="769"/>
         <source>The map import generated warnings.</source>
         <translation>Імпорт карти містить попередження.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
         <source>Cannot open file:
 %1
 for reading.</source>
@@ -2893,12 +2907,12 @@ for reading.</source>
 для читання.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="735"/>
+        <location filename="../src/core/map.cpp" line="738"/>
         <source>Invalid file type.</source>
         <translation>Некоректний тип файлу.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="798"/>
+        <location filename="../src/core/map.cpp" line="801"/>
         <source>Cannot open file:
 %1
 
@@ -2909,17 +2923,17 @@ for reading.</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="825"/>
+        <location filename="../src/core/map.cpp" line="828"/>
         <source>Nothing to import.</source>
         <translation>Немає що імпортувати.</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="834"/>
+        <location filename="../src/core/map.cpp" line="837"/>
         <source>Question</source>
         <translation>Запит</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="835"/>
+        <location filename="../src/core/map.cpp" line="838"/>
         <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
 
 Rescale the imported data?</source>
@@ -2928,23 +2942,23 @@ Rescale the imported data?</source>
 Перемасштабувати імпортовані дані?</translation>
     </message>
     <message>
-        <location filename="../src/core/map.cpp" line="497"/>
+        <location filename="../src/core/map.cpp" line="500"/>
         <source>default part</source>
         <translation>Частина за замовченням</translation>
     </message>
     <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
         <source>New color</source>
         <translation>Новий колір</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
         <source>Import...</source>
         <translation>Імпорт...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
         <source>Symbol replacement was canceled.
 Import the data anyway?</source>
         <translation>Заміну знаку скасовано.
@@ -2952,205 +2966,205 @@ Import the data anyway?</source>
     </message>
 </context>
 <context>
-    <name>MapColor</name>
+    <name>OpenOrienteering::MapColor</name>
     <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
+        <location filename="../src/core/map_color.cpp" line="79"/>
         <source>Registration black (all printed colors)</source>
         <translation>Реєстраційний чорний (усі надруковані кольори)</translation>
     </message>
 </context>
 <context>
-    <name>MapCoord</name>
+    <name>OpenOrienteering::MapCoord</name>
     <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
         <source>Coordinates are out-of-bounds.</source>
         <translation>Координати поза межами.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorController</name>
+    <name>OpenOrienteering::MapEditorController</name>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
         <source>Print...</source>
         <translation>Друк...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo</source>
         <translation>Відмінити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
         <source>Undo the last step</source>
         <translation>Відмінити останній крок</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo</source>
         <translation>Повернути</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
         <source>Redo the last step</source>
         <translation>Повернути останній крок</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
         <source>Cu&amp;t</source>
         <translation>Ви&amp;різати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
         <source>C&amp;opy</source>
         <translation>К&amp;опіювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
         <source>&amp;Paste</source>
         <translation>&amp;Вставити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
         <source>Zoom in</source>
         <translation>Наблизити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
         <source>Zoom out</source>
         <translation>Віддалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
         <source>Toggle fullscreen mode</source>
         <translation>Перейти у повноекранний режим</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
         <source>Set custom zoom factor...</source>
         <translation>Задати коефіцієнт збільшення...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Symbol window</source>
         <translation>Вікно знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
         <source>Show/Hide the symbol window</source>
         <translation>Показати/Сховати вікно знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Color window</source>
         <translation>Вікно кольорів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
         <source>Show/Hide the color window</source>
         <translation>Показати/Сховати вікно кольорів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace the symbols with those from another map file</source>
         <translation>Замінити знак такими же з іншого файлу карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale all symbols...</source>
         <translation>Масштабувати всі знаки...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
         <source>Scale the whole symbol set</source>
         <translation>Масштабувати весь набір знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change map scale...</source>
         <translation>Змінити масштаб карти...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
         <source>Change the map scale and adjust map objects and symbol sizes</source>
         <translation>Змінити масштаб карти та підігнати розміри об’єктів і знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
         <source>Map notes...</source>
         <translation>Примітки до карти...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Template setup window</source>
         <translation>Вікно параметрів підложок</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
         <source>Show/Hide the template window</source>
         <translation>Показати/Сховати вікно підложок</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
         <source>Open template...</source>
         <translation>Відкрити підложку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
         <source>Show whole map</source>
         <translation>Показати всю карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
         <source>Edit objects</source>
         <translation>Редагувати об&apos;єкти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
         <source>Set point objects</source>
         <translation>Поставити точковий об&apos;єкт</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
         <source>Draw paths</source>
         <translation>Накреслити лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
         <source>Draw circles and ellipses</source>
         <translation>Накреслити кола чи еліпси</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
         <source>Write text</source>
         <translation>Написати текст</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
         <source>Duplicate</source>
         <translation>Дублювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
         <source>Switch symbol</source>
         <translation>Замінити знак</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
         <source>Fill / Create border</source>
         <translation>Заповнити / Створити межу</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
         <source>Switch dash direction</source>
         <translation>Розвернути штрихи</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
         <source>Connect paths</source>
         <translation>З’єднати лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
         <source>Cut object</source>
         <translation>Розрізати об&apos;єкт</translation>
     </message>
@@ -3159,126 +3173,126 @@ Import the data anyway?</source>
         <translation type="vanished">Обертати об&apos;єкт(и)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
         <source>Measure lengths and areas</source>
         <translation>Виміряти довжини і площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
         <source>Import...</source>
         <translation>Імпорт...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
         <source>&amp;View</source>
         <translation>&amp;Перегляд</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
         <source>&amp;Tools</source>
         <translation>&amp;Інструменти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
         <source>Sy&amp;mbols</source>
         <translation>З&amp;наки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
         <source>M&amp;ap</source>
         <translation>&amp;Карта</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
         <source>&amp;Templates</source>
         <translation>Пі&amp;дложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
         <source>Drawing</source>
         <translation>Креслити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
         <source>Paint on template</source>
         <translation>Малювати на підложці</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
         <source>Show grid</source>
         <translation>Показувати сітку</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
         <source>Configure grid...</source>
         <translation>Налаштувати сітку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
         <source>Hatch areas</source>
         <translation>Заштрихувати площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
         <source>Baseline view</source>
         <translation>Вид основних ліній</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
         <source>Hide all templates</source>
         <translation>Приховати всі підложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
         <source>Georeferencing...</source>
         <translation>Геоприв’язка...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate map...</source>
         <translation>Повернути карту...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
         <source>Rotate the whole map</source>
         <translation>Повернути всю карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
         <source>Reopen template...</source>
         <translation>Відкрити підложку знову...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
         <source>Draw rectangles</source>
         <translation>Накреслити прямокутники</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
         <source>Cut free form hole</source>
         <translation>Вирізати отвір довільної форми</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
         <source>Cut round hole</source>
         <translation>Вирізати круглий отвір</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
         <source>Cut rectangular hole</source>
         <translation>Вирізати прямокутний отвір</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
         <source>Rotate pattern</source>
         <translation>Повернути візерунок</translation>
     </message>
@@ -3287,88 +3301,88 @@ Import the data anyway?</source>
         <translation type="vanished">Масштабувати об’єкт(и)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
         <source>Unify areas</source>
         <translation>Об’єднати площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
         <source>Intersect areas</source>
         <translation>Перетин площ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
         <source>Area XOr</source>
         <translation>Взаємовиключення площ</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
         <source>Map coordinates</source>
         <translation>Координати на карті</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
         <source>Projected coordinates</source>
         <translation>Координати на проекції</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
         <source>Latitude/Longitude (Dec)</source>
         <translation>Широта/Довгота (Dec)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
         <source>Latitude/Longitude (DMS)</source>
         <translation>Широта/Довгота (° ′ ″)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
         <source>Display coordinates as...</source>
         <translation>Відображати координати як...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
         <source>Cut hole</source>
         <translation>Вирізати отвір</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
         <source>View</source>
         <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
         <source>Select template...</source>
         <translation>Вибрати підложку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
         <source>Editing</source>
         <translation>Редагування</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
         <source>Advanced editing</source>
         <translation>Розширене редагування</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
         <source>No undo steps available.</source>
         <translation>Попередні кроки відсутні.</translation>
     </message>
@@ -3378,8 +3392,8 @@ Import the data anyway?</source>
         <translation type="vanished">Вирізати %1 об’єкт(ів)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Сталася внутрішня помилка, вибачте!</translation>
     </message>
@@ -3388,7 +3402,7 @@ Import the data anyway?</source>
         <translation type="vanished">Скопійовано %1 об’єкт(ів)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
         <source>There are no objects in clipboard which could be pasted!</source>
         <translation>У буфері обміну немає об’єктів які можна було б вставити!</translation>
     </message>
@@ -3397,332 +3411,332 @@ Import the data anyway?</source>
         <translation type="vanished">Вставлено %1 об’єкт(ів)</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Set custom zoom factor</source>
         <translation>Встановити коефіцієнт збільшення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
         <source>Zoom factor:</source>
         <translation>Коефіцієнт збільшення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
         <source>Symbols</source>
         <translation>Знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
         <source>Colors</source>
         <translation>Кольори</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale all symbols</source>
         <translation>Масштабувати всі знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
         <source>Scale to percentage:</source>
         <translation>Масштаб у відсотках:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
         <source>Map notes</source>
         <translation>Примітки до карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
         <source>Templates</source>
         <translation>Підложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Place point objects on the map.</source>
         <translation>Розмістити точкові об’єкти на карті.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <source>Select a point symbol to be able to use this tool.</source>
         <translation>Оберіть точковий знак щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <source>Draw polygonal and curved lines.</source>
         <translation>Накреслити ламані чи криві лінії.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Select a line, area or combined symbol to be able to use this tool.</source>
         <translation>Оберіть лінійний, площадний або комбінований знак щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
         <source>Draw circles and ellipses.</source>
         <translation>Накреслити кола чи еліпси.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Set the direction of area fill patterns or point objects.</source>
         <translation>Встановити напрямок візерунка для заповнення площі, або точкового об&apos;єкта.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
         <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
         <translation>Виберіть площинний об&apos;єкт із заповненням або точковий об&apos;єкт, що можливо обертати для активації цього інструменту.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
         <source>Cannot import the selected map file because it could not be loaded.</source>
         <translation>Неможливо імпортувати вибраний файл карти бо його неможливо завантажити.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
         <source>Draw rectangles.</source>
         <translation>Накреслити прямокутники.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>Editing in progress</source>
         <translation>Редагування в процесі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
         <source>The map is currently being edited. Please finish the edit operation before saving.</source>
         <translation>Карта редагується. Збережіть карту після завершення операції редагування.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
         <source>Map saved</source>
         <translation>Карту збережено</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
         <source>&amp;Image</source>
         <translation>&amp;Зображення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
         <source>&amp;PDF</source>
         <translation>&amp;PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear undo / redo history</source>
         <translation>Очистити історію відмін / повернень</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
         <source>Clear the undo / redo history to reduce map file size.</source>
         <translation>Очистити історію відмін / повернень щоб зменшити розмір файла.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
         <source>Pan</source>
         <translation>Рухати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
         <source>Overprinting simulation</source>
         <translation>Емулювати overprinting</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
         <source>Replace symbol set...</source>
         <translation>Замінити набір знаків...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Tag editor</source>
         <translation>Редактор тегів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
         <source>Show/Hide the tag editor window</source>
         <translation>Показати/Приховати редактор тегів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
         <source>Edit lines</source>
         <translation>Редагувати лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
         <source>Draw free-handedly</source>
         <translation>Креслити від руки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
         <source>Fill bounded areas</source>
         <translation>Заповнити замкнені площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
         <source>Cut away from area</source>
         <translation>Виріз у площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
         <source>Merge area holes</source>
         <translation>Об&apos;єднати вирізи у площі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
         <source>Convert to curves</source>
         <translation>Перетворити на криві</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
         <source>Simplify path</source>
         <translation>Спростити лінію</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
         <source>Cutout</source>
         <translation>Вирізати і залишити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
         <source>Cut away</source>
         <translation>Вирізати і залишити решту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
         <source>Distribute points along path</source>
         <translation>Розподілити точки вздовж лінії</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
         <source>Paint on template settings</source>
         <translation>Настройки малювання по підложці</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
         <source>Enable touch cursor</source>
         <translation>Включити touch-курсор</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
         <source>Enable GPS display</source>
         <translation>Включити відображення GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
         <source>Enable GPS distance rings</source>
         <translation>Показувати кільце похибки GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
         <source>Set point object at GPS position</source>
         <translation>Поставити точковий об&apos;єкт у позиції з GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
         <source>Set temporary marker at GPS position</source>
         <translation>Поставити тимчасову мітку у позиції з GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
         <source>Create temporary path at GPS position</source>
         <translation>Створити тимчасову лінію за позицією GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
         <source>Clear temporary GPS markers</source>
         <translation>Очистити тимчасові мітки GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
         <source>Enable compass display</source>
         <translation>Показувати компас</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
         <source>Align map with north</source>
         <translation>Вирівняти карту по півночі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
         <source>Add new part...</source>
         <translation>Додати нову частину...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
         <source>Rename current part...</source>
         <translation>Переіменувати частину...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
         <source>Remove current part</source>
         <translation>Видалити частину</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
         <source>Merge all parts</source>
         <translation>З&apos;єднати всі частини</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
         <source>&amp;Export as...</source>
         <translation>&amp;Експортувати в...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
         <source>Map parts</source>
         <translation>Частини карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
         <source>Select symbol</source>
         <translation>Вибрати знак</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
         <source>Hide top bar</source>
         <translation>Приховати верхню панель</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
         <source>Show top bar</source>
         <translation>Показати верхню панель</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
         <source>Print / Export is not available in this program version!</source>
         <translation>Друк / Експорт неможливий у цій версії програми!</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
         <source>Tag Editor</source>
         <translation>Редактор тегів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
         <source>No
 symbol
 selected</source>
@@ -3732,7 +3746,7 @@ selected</source>
 знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
         <source>Multiple
 symbols
 selected</source>
@@ -3742,22 +3756,22 @@ selected</source>
 знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
         <source>Draw paths free-handedly.</source>
         <translation>Накреслити лінії від руки.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
         <source>Fill bounded areas.</source>
         <translation>Заповнити замкнені площі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Write text on the map.</source>
         <translation>Написати текст на карті.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
         <source>Select a text symbol to be able to use this tool.</source>
         <translation>Оберіть текстовий знак щоб скористатися цим інструментом.</translation>
     </message>
@@ -3770,31 +3784,31 @@ selected</source>
         <translation type="vanished">Дублювати виділений об’єкт(и).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
         <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
         <translation>Ви дійсно хочете видалити частину &quot;%1&quot; і усі об&apos;єкти при ній?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Select at least one object to activate this tool.</source>
         <translation>Виділіть хоч один об’єкт щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
         <source>Switch the direction of symbols on line objects.</source>
         <translation>Змінити спрямування знаків на лінійних об’єктах.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Select at least one line object to activate this tool.</source>
         <translation>Виділіть хоч один лінійний об’єкт щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
         <source>Connect endpoints of paths which are close together.</source>
         <translation>З’єднати кінці контурів що знаходяться близько один до одного.</translation>
     </message>
@@ -3803,17 +3817,17 @@ selected</source>
         <translation type="vanished">Розрізати виділений об’єкт(и) на менші частини.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Select at least one line or area object to activate this tool.</source>
         <translation>Виділіть хоч один лінійний чи площинний об’єкт щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Cut a hole into the selected area object.</source>
         <translation>Вирізати отвір у виділеному площинному об’єкті.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
         <source>Select a single area object to activate this tool.</source>
         <translation>Виділіть лише один площинний об’єкт щоб використати цей інструмент.</translation>
     </message>
@@ -3822,162 +3836,162 @@ selected</source>
         <translation type="vanished">Обертати виділений об’єкт(и).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
         <source>Ctrl+Shift+A</source>
         <translation>Ctrl+Shift+A</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
         <source>O</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
         <source>Select all</source>
         <translation>Вибрати всі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
         <source>Select nothing</source>
         <translation>Скасувати виділення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
         <source>Invert selection</source>
         <translation>Інвертувати вибір</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Symbol set ID...</source>
         <translation>ID набору умовних знаків...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
         <source>Edit the symbol set ID</source>
         <translation>Редагувати ID набору умовних знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Load CRT file...</source>
         <translation>Застосувати CRT файл...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
         <source>Assign new symbols by cross-reference table</source>
         <translation>Призначити новий знак у таблиці перехресних зв&apos;язків</translation>
     </message>
@@ -3990,22 +4004,22 @@ selected</source>
         <translation type="vanished">Показати/Сховати вікно виділення по тегам</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position</source>
         <translation>Скопіювати координати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
         <source>Copy position to clipboard.</source>
         <translation>Скопіювати координати в буфер обміну.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
         <source>Symbol set ID</source>
         <translation>ID набору умовних знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
         <source>Edit the symbol set ID:</source>
         <translation>Редагувати ID набору умовних знаків:</translation>
     </message>
@@ -4018,74 +4032,74 @@ selected</source>
         <translation type="vanished">Масштабувати виділений об’єкт(и).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
         <source>Turn paths made of straight segments into smooth bezier splines.</source>
         <translation>Включити лінії складені з прямих відрізків всередині кривих Безьє.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Select a path object to activate this tool.</source>
         <translation>Виберіть лінійний об&apos;єкт щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
         <source>Reduce the number of points in path objects while trying to retain their shape.</source>
         <translation>Зменшити кількість точок, намагаючись зберегти форму лінії.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
         <source>Resulting symbol: %1 %2.</source>
         <translation>Результуючий знак: %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
         <source>Select at least two area or path objects activate this tool.</source>
         <translation>Виділіть хочаб два площадних або лінійних об&apos;єкта щоб скористатися цим інструментом.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
         <source>Unify overlapping objects.</source>
         <translation>Об&apos;єднати об&apos;єкти що перекриваються.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
         <source>Remove all parts which are not overlaps with the first selected object.</source>
         <translation>Видалити всі частини, що не перекриваються першим виділеним об&apos;єктом.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
         <source>Remove overlapped parts of the first selected object.</source>
         <translation>Видалити перекриті першим виділеним об&apos;єктом частини.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
         <source>Remove all parts which overlap the first selected object.</source>
         <translation>Видалити всі частини, що перекривають перший виділений об&apos;кт.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
         <translation>З&apos;єднати вирізи у площадному об&apos;єкті, або з&apos;єднати виріз з межею об&apos;єкту щоб відрізати цю частину.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
         <source>Select one area object with holes to activate this tool.</source>
         <translation>Виділіть об&apos;єкт з отвором щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
         <source>Create a cutout of some objects or the whole map.</source>
         <translation>Створити виріз у кількох об&apos;єктах, або в усій карті.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Select a closed path object as cutout shape to activate this tool.</source>
         <translation>Виділіть замкнений об&apos;єкт, який можна застосуваи як форму для вирізу, щоб використати цей інструмент.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
         <source>Cut away some objects or everything in a limited area.</source>
         <translation>Відрізати деякі або всі об&apos;єкти в обмеженій області.</translation>
     </message>
@@ -4094,8 +4108,8 @@ selected</source>
         <translation type="vanished">Замінити знак виділеного об’єкта(ів) на виділений знак.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
         <translation>Виділіть хоч один об’єкт та підходящий, інший знак щоб використати цей інструмент.</translation>
     </message>
@@ -4104,12 +4118,12 @@ selected</source>
         <translation type="vanished">Заповнити виділену лінію(ії) чи створити межі для виділених площ(і).</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Places evenly spaced point objects along an existing path object</source>
         <translation>Розподілити рівномірно точкові обє&apos;кти вздовж існуючого лінійного об&apos;єкту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
         <source>Select at least one path object and a single point symbol to activate this tool.</source>
         <translation>Виділіть хочаб один лінійний об&apos;єкт і точковий знак щоб використати цей інструмент.</translation>
     </message>
@@ -4118,7 +4132,7 @@ selected</source>
         <translation type="vanished">%1 об’єкт(ів) продубльовано</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>Object selection</source>
         <translation>Виділення об’єкту</translation>
     </message>
@@ -4127,124 +4141,124 @@ selected</source>
         <translation type="vanished">Жоден об&apos;єкт не вибрано, оскільки нема об&apos;єктів намальованих цим знаком.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
         <source>Measure</source>
         <translation>Виміри</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
         <source>Unification failed.</source>
         <translation>Об’єднання невдале.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
         <source>Intersection failed.</source>
         <translation>Перетин невдалий.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
         <source>Difference failed.</source>
         <translation>Виключення невдале.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
         <source>XOr failed.</source>
         <translation>Взаємовиключення невдале.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
         <source>Merging holes failed.</source>
         <translation>Об&apos;єднання отворів невдале.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Clear temporary markers</source>
         <translation>Очистити тимчасові мітки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
         <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
         <translation>Ви дійсно хочете видалити всі тимчасові мітки GPS? Цю дію неможливо відмінити.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
         <source>Merge this part with</source>
         <translation>З&apos;єднати цю частину з</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
         <source>Move selected objects to</source>
         <translation>Перемістити виділені об&apos;єкти в</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
         <source>Enter the name of the map part:</source>
         <translation>Введіть назву частини карти:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
         <source>Switched to map part &apos;%1&apos;.</source>
         <translation>Переключено на частину карти &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
         <source>Merge map parts</source>
         <translation>Об&apos;єднати частини карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
         <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
         <translation>Ви дійсно хочете перемістити усі об&apos;єкти з частини &quot;%1&quot; в &quot;%2&quot; і видалии частину &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
         <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
         <translation>Ви дійсно хочете перемістити всі об&apos;єкти в частину карти &quot;%1&quot; і видалити решту частин карти?</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
         <source>Paint free-handedly on a template</source>
         <translation>Малювати від руки на підложці</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
         <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
         <translation>Малювати від руки на підложці. Створіть чи завантажте підложку на якій можна малювати щоб використати цей інструмент</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
         <source>Import %1, GPX, OSM or DXF file</source>
         <translation>Імпортувати %1, GPX, OSM або DXF файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>Importable files</source>
         <translation>Файли, що можливо імпортувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
         <source>All files</source>
         <translation>Усі файли</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
         <source>Cannot import the selected file because its file format is not supported.</source>
         <translation>Неможливо імпортувати обраний файл бо формат не підтримується.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
         <source>Rotate objects</source>
         <translation>Обертати об&apos;єкти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
         <source>Scale objects</source>
         <translation>Масштабувати об&apos;єкти</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
         <source>Cut %n object(s)</source>
         <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
         <translation>
@@ -4254,7 +4268,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
         <source>Copied %n object(s)</source>
         <translation>
             <numerusform>Скопійовано %n об&apos;єкт</numerusform>
@@ -4263,7 +4277,7 @@ selected</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
         <source>Pasted %n object(s)</source>
         <translation>
             <numerusform>Вставлено %n об&apos;єкт</numerusform>
@@ -4272,42 +4286,42 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
         <source>Deletes the selected objects.</source>
         <translation>Видалити виділені об&apos;єкти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
         <source>Duplicate the selected objects.</source>
         <translation>Дублювати виділені об&apos;єкти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
         <source>Rotate the selected objects.</source>
         <translation>Обертати виділені об&apos;єкти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
         <source>Scale the selected objects.</source>
         <translation>Масштабувати виділені об&apos;єкти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
         <source>Cut the selected objects into smaller parts.</source>
         <translation>Обрізати виділені об&apos;єкти на менші частини.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
         <source>Switches the symbol of the selected objects to the selected symbol.</source>
         <translation>Замінити знак виділених об&apos;єктів на виділений умовний знак.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
         <source>Fill the selected lines or create a border for the selected areas.</source>
         <translation>Заповнити виділені лінії або створити межу для виділених площ.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
         <source>Duplicated %n object(s)</source>
         <translation>
             <numerusform>Продубльовано %n об&apos;єкт</numerusform>
@@ -4316,180 +4330,180 @@ selected</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
         <source>No objects were selected because there are no objects with the selected symbols.</source>
         <translation>Не було виділено жодних об&apos;єктів, бо немає об&apos;єктів з виділеним знаком.</translation>
     </message>
 </context>
 <context>
-    <name>MapEditorTool</name>
+    <name>OpenOrienteering::MapEditorTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Відміна. </translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
         <source>More: %1, %2</source>
         <translation>Більше: %1, %2</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
         <source>More: %1</source>
         <translation>Більше: %1</translation>
     </message>
     <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
         <source>More: %1, %2, %3</source>
         <translation>Більше: %1, %2, %3</translation>
     </message>
 </context>
 <context>
-    <name>MapFindFeature</name>
+    <name>OpenOrienteering::MapFindFeature</name>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
         <source>&amp;Find...</source>
         <translation>&amp;Пошук...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
         <source>Find &amp;next</source>
         <translation>Знайти &amp;наступний</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
         <source>Find objects</source>
         <translation>Пошук обʼєктів</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
         <source>&amp;Find next</source>
         <translation>&amp;Знайти наступний</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
         <source>Find &amp;all</source>
         <translation>Знайти &amp;всі</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
         <source>Query editor</source>
         <translation>Редактор запитів</translation>
     </message>
 </context>
 <context>
-    <name>MapPrinter</name>
+    <name>OpenOrienteering::MapPrinter</name>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
         <source>Processing separations of page %1...</source>
         <translation>Обробка роздільників на сторінці %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
         <source>Processing page %1...</source>
         <translation>Обробка сторінки %1...</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
         <source>Canceled</source>
         <translation>Відмінено</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
         <source>Finished</source>
         <translation>Завершено</translation>
     </message>
 </context>
 <context>
-    <name>MapSymbolTranslation</name>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
         <source>Text source:</source>
         <translation>Джерело тексту:</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
         <source>Map (%1)</source>
         <translation>Карта (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
         <source>undefined language</source>
         <translation>невизначена мова</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
         <source>Translation (%1)</source>
         <translation>Переклад (%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
         <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
         <translation>Зверніть увагу, що збережений текст буде замінено на поточний переклад. Бажаєте продовжити?</translation>
     </message>
     <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
         <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
         <translation>Після редагування збереженого тексту, переклад більше не буде доступним. Бажаєте продовжити?</translation>
     </message>
 </context>
 <context>
-    <name>MapWidget</name>
+    <name>OpenOrienteering::MapWidget</name>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
         <translation>%1x</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>міліметри</translatorcomment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>метри</translatorcomment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
         <source>Empty map!
 
 Start by defining some colors:
@@ -4504,7 +4518,7 @@ define the colors there.</source>
 завдайте тут кольори.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
         <source>No symbols!
 
 Now define some symbols:
@@ -4519,7 +4533,7 @@ to create one.</source>
 щоб створити перший.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Ready to draw!
 
 Start drawing or load a base map.
@@ -4532,7 +4546,7 @@ Templates -&gt; Open template...</source>
 Підложки -&gt; Відкрити підложку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
         <source>Hint: Hold the middle mouse button to drag the map,
 zoom using the mouse wheel, if available.</source>
         <translation>Порада: Утримуйте середню клавішу миші для переміщення карти,
@@ -4540,127 +4554,127 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>MeasureWidget</name>
+    <name>OpenOrienteering::MeasureWidget</name>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
         <source>Boundary length:</source>
         <translation>Довжина периметру:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
         <source>Area:</source>
         <translation>Площа:</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
         <source>No object selected.</source>
         <translation>Немає виділених об’єктів.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
         <source>%1 objects selected.</source>
         <translation>%1 об’єкт виділено.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
         <source>The selected object is not a path.</source>
         <translation>Виділений об’єкт не є контуром.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translatorcomment>міліметри</translatorcomment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
         <source>m</source>
         <comment>meters</comment>
         <translatorcomment>метри</translatorcomment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
         <source>mm²</source>
         <comment>square millimeters</comment>
         <translatorcomment>квадратні міліметри</translatorcomment>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
         <source>m²</source>
         <comment>square meters</comment>
         <translatorcomment>квадратні метри</translatorcomment>
         <translation>м²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
         <source>This object is too small.</source>
         <translation>Цей об’єк замалий.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>The minimimum area is %1 %2.</source>
         <translation>Мінімальна площа становить %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
         <source>mm²</source>
         <translation>мм²</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
         <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
         <translation>Зверніть увагу: Довжина межі та площа коректні лише в разі відсутності самоперетинів і якщо отвори використовуються як такі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
         <source>This line is too short.</source>
         <translation>Ця лінія закоротка.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>The minimum length is %1 %2.</source>
         <translation>Мінімальна довжина становить %1 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
 </context>
 <context>
-    <name>NewMapDialog</name>
+    <name>OpenOrienteering::NewMapDialog</name>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
         <source>Create new map</source>
         <translation>Створити нову карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
         <source>Choose the scale and symbol set for the new map.</source>
         <translation>Виберіть масштаб і набір знаків для нової карти.</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
         <source>Scale:  1 : </source>
         <translation>Масштаб:  1 : </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
         <source>Symbol sets:</source>
         <translation>Набір знаків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
         <source>Only show symbol sets matching the selected scale</source>
         <translation>Відображати лише набори знаків для даного масштабу</translation>
     </message>
@@ -4669,140 +4683,140 @@ zoom using the mouse wheel, if available.</source>
         <translation type="vanished">Відмінити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
         <source>Create</source>
         <translation>Створити</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
         <source>Empty symbol set</source>
         <translation>Порожній набір знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
         <source>Load symbol set from a file...</source>
         <translation>Завантажити набір знаків з файлу...</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
         <source>All symbol set files</source>
         <translation>Усі файли наборів знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
         <source>All files</source>
         <translation>Усі файли</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileExport</name>
+    <name>OpenOrienteering::OCAD8FileExport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
         <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
         <translation>Карта містить понад 256 кольорів що не підтримується форматом ocd версії 8.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
         <source>libocad returned %1</source>
         <translation>libocad повернула %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
         <source>Registration black is exported as a regular color.</source>
         <translation>Реєстраційний чорний експортовано як звичайний колір.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
         <source>Unable to export fill pattern shift for an area object</source>
         <translation>Неможливо експортувати зміщення візеруноку заповнення для площадного об&apos;єкту</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
         <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
         <translation>Неможливо експортувати підложку: тип файлу &quot;%1&quot; поки що не підтримується</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
         <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
         <translation>Координати обмежено щоб вмістити в зону креслення OCAD 8 (-2 м ... 2 м).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
         <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
         <translation>Деякі координати виходять за межі зони креслення OCAD 8. Вони можуть бути недоступними в OCAD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
         <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
         <translation>Для лінійного знаку &quot;%1&quot;, неможливо відобразити комбінацію закінчення/з’єднання.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
         <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
         <translation>Для лінійного знаку &quot;%1&quot;, не виконано групування штрихів.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
         <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
         <translation>Для лінійного знаку &quot;%1&quot;, кількість штрихів у групі зменшено в 2 рази.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
         <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
         <translation>Для лінійного знаку %1, неможливо експортувати границі.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
         <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
         <translation>Для площинного знаку &quot;%1&quot;, пропущено заповнення візерунком.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
         <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
         <translation>Для площинного знаку &quot;%1&quot;, виявлено &quot;зміщення рядків&quot; точкового візерунку. Це може бути як добре так і погано.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
         <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Для текстового знаку %1: встановлений такий міжсимвольний інтервал, що покищо неможе бути збережений у форматі OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
         <source>In text symbol %1: ignoring underlining</source>
         <translation>Для текстового знаку %1: проігноровано підкреслення</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
         <source>In text symbol %1: ignoring kerning</source>
         <translation>Для текстового знаку %1: проігноровано кернінг</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
         <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
         <translation>Рядок обрізаний (обрізання позначено з допомогою потрійного &apos;|&apos;): %1</translation>
     </message>
 </context>
 <context>
-    <name>OCAD8FileImport</name>
+    <name>OpenOrienteering::OCAD8FileImport</name>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
         <source>Could not allocate buffer.</source>
         <translation>Неможливо виділити буфер.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
         <source>libocad returned %1</source>
         <translation>libocad повернула %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
         <source>OCAD files of version %1 are not supported!</source>
         <translation>OCAD файли версії %1 не підтримуються!</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
         <source>%n color separation(s) were skipped, reason: Import disabled.</source>
         <translation>
             <numerusform>%n виділення кольору пропущено, причина: Імпорт заборонений.</numerusform>
@@ -4811,391 +4825,391 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
         <source>Could not load the spot color definitions, error: %1</source>
         <translation>Не вдалося завантажити визначення планшетного кольору, помилка: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
         <source>Color &quot;Registration black&quot; is imported as a special color.</source>
         <translation>Колір &quot;Реєстраційний чорний&quot; імпортовано як спеціальний колір.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
         <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
         <translation>Неможливо імпортувати знак &quot;%3&quot; (%1.%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
         <source>OCAD import layer</source>
         <translation>Шар імпорту OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
         <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
         <translation>У штриховій лінії знака %1, довжина загострення на початку і кінці різні (%2 і %3). Використовується %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
         <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
         <translation>У штриховій лінії знака %1, довжина останнього штриха не може бути коректно імпортована.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
         <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
         <translation>У штриховій лінії знака %1, кінцевий проміжок не може бути коректно імпортований.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
         <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
         <translation>У штриховій лінії знака %1, довжина головного і кінцевого штриха різні (%2 і %3). Використовується %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
         <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
         <translation>У штриховій лінії знака %1, проміжки D та E різні (%2 і %3). Використовується %4.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
         <source>Line symbol %1: suppressing dash symbol at line ends.</source>
         <translation>Лінійний знак %1: подвляти штриховий знак на кінцях відрізку.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
         <source>During import of text symbol %1: ignoring justified alignment</source>
         <translation>Під час імпорту текстового знаку %1: проігноровано центрування</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
         <source>During import of text symbol %1: ignoring custom weight (%2)</source>
         <translation>Під час імпорту текстового знаку %1: проігноровано нестандартну ширину (%2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
         <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
         <translation>Під час імпорту текстового знаку %1: встановлено нестандартний міжсимвольний інтервал, його реалізація покищо не сумісна з OCAD</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
         <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
         <translation>Під час імпорту текстового знаку %1: проігноровано нестандартний інтервал між словами (%2%)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
         <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
         <translation>Під час імпорту текстового знаку %1: проігноровано користувацькі відступи (%2/%3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
         <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
         <translation>Під час імпорту текстового знаку %1: проігноровано обрамлення тексту (значення %2)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
         <source>Unable to load object</source>
         <translation>Неможливо завантажити об&apos;єкт</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
         <source>Unable to import rectangle object</source>
         <translation>Неможливо імпортувати прямокутний об&apos;єкт</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Не імпортовано текстовий знак, невдається відобразити зовнішній шлях&apos; (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
         <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
         <translation>Неможливо імпортувати підложку: схоже що фон &quot;%1&quot; не є растровим зображенням</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Спроба імпортувати текстовий об&apos;єкт з невідомим форматом координат</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Ідентифікатор кольору не знайдено: %1, цей колір проігноровано</translation>
     </message>
 </context>
 <context>
-    <name>ObjectQuery</name>
+    <name>OpenOrienteering::ObjectQuery</name>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
         <source>is</source>
         <extracomment>Very short label</extracomment>
         <translation>є</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
         <source>is not</source>
         <extracomment>Very short label</extracomment>
         <translation>не є</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
         <source>contains</source>
         <extracomment>Very short label</extracomment>
         <translation>містить</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
         <source>Search</source>
         <extracomment>Very short label</extracomment>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
         <source>Text</source>
         <extracomment>Very short label</extracomment>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
         <source>and</source>
         <extracomment>Very short label</extracomment>
         <translation>та</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
         <source>or</source>
         <extracomment>Very short label</extracomment>
         <translation>або</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
         <source>Symbol</source>
         <extracomment>Very short label</extracomment>
         <translation>Знак</translation>
     </message>
     <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
         <source>invalid</source>
         <extracomment>Very short label</extracomment>
         <translation>нечинний</translation>
     </message>
 </context>
 <context>
-    <name>OcdFileImport</name>
+    <name>OpenOrienteering::OcdFileImport</name>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
         <source>In line symbol %1 &apos;%2&apos;: %3</source>
         <translation>У лінійному знаці %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
         <source>In text symbol %1 &apos;%2&apos;: %3</source>
         <translation>У текстовому знаці %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
         <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
         <translation>Неможливо завантажити базову систему координат &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
         <source>Spot color information was ignored.</source>
         <translation>Інформація про планшетні кольори проігнорована.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
         <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
         <translation>Неможливо імпортувати знак %1.%2 &quot;%3&quot;: %4</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
         <source>Unsupported type &quot;%1&quot;.</source>
         <translation>Непідтримуваний шрифт &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
         <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
         <translation>Неможливо імпортувати підложку: підложки типу &quot;%1&quot; не підтримуються.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
         <source>Unsupported line style &apos;%1&apos;.</source>
         <translation>Непідтримуваний стиль лінії &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
         <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
         <translation>Різні довжини загострень на початку (%1 мм) і кінці (%2 мм) лінії - не підтримуються. Буде використано %3 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
         <source>The dash pattern cannot be imported correctly.</source>
         <translation>Неможливо коректно імпортувати штриховий візерунок.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
         <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Довжина кінцевого штриха у візерунку (%1 мм) не може бути коректно імпортована. Буде використано %2 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
         <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
         <translation>Відстань до кінцевого штриха у візерунку (%1 мм) не може бути коректно імпортована. Буде використано %2 мм.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
         <source>Unsupported framing line style &apos;%1&apos;.</source>
         <translation>Непідтримуваний стиль лінії обрамлення &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
         <source>Skipped secondary point symbol.</source>
         <translation>Пропущено вторинний точковий знак.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
         <source>Suppressing dash symbol at line ends.</source>
         <translation>Подавляти знаки на кінцях відрізку.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
         <source>This symbol cannot be saved as a proper OCD symbol again.</source>
         <translation>Цей знак не може бути збережений як правильний знак OCD.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
         <source>Justified alignment is not supported.</source>
         <translation>Вирівнювання по ширині не підтримується.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
         <source>Vertical alignment &apos;%1&apos; is not supported.</source>
         <translation>Вирівнювання по висоті &apos;%1&apos; не підтримується.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
         <source>Ignoring custom weight (%1).</source>
         <translation>Проігноровано нестандартну ширину (%1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
         <source>Custom character spacing may be incorrect.</source>
         <translation>Нестандартний міжсимвольний інтервал може відображатись некоректно.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
         <source>Ignoring custom word spacing (%1 %).</source>
         <translation>Проігноровано нестандартний міжслівний інтервал (%1 %).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
         <source>Ignoring custom indents (%1/%2).</source>
         <translation>Проігноровано нестандартні відступи (%1/%2).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
         <source>Ignoring text framing (mode %1).</source>
         <translation>Проігноровано фарматування тексту (режим %1).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
         <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
         <translation>Лінійні текстові знаки покищо не підтримуються. Цей знак приховано.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
         <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
         <translation>Кодування &apos;%1&apos; не доступне. Перевірте налаштування.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
         <source>In area symbol %1 &apos;%2&apos;: %3</source>
         <translation>У площадному знаку %1 &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
         <source>Unable to load object</source>
         <translation>Неможливо завантажити об&apos;єкт</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
         <source>Unable to import rectangle object</source>
         <translation>Неможливо імпортувати прямокутний об&apos;єкт</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
         <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
         <translation>Не імпортовано текстовий знак, не вдається відобразити зовнішній контур (npts=%1): %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
         <source>Trying to import a text object with unknown coordinate format</source>
         <translation>Спроба імпортувати текстовий об&apos;єкт з невідомим форматом координат</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
         <source>Invalid data.</source>
         <translation>Недійсні дані.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
         <source>OCD files of version %1 are not supported!</source>
         <translation>OCD файли версії %1 не підтримуються!</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
         <source>Color id not found: %1, ignoring this color</source>
         <translation>Не знайдено id кольору: %1, цей колір проігноровано</translation>
     </message>
 </context>
 <context>
-    <name>OgrFileImport</name>
+    <name>OpenOrienteering::OgrFileImport</name>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
         <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
         <translation>Неможливо встановити &quot;%1&quot; SRS для GDAL: %2</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
         <source>Purple</source>
         <translation>Пурпурний</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
         <source>Line</source>
         <translation>Лінія</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
         <source>Area</source>
         <translation>Площа</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
         <source>Unable to load layer %1.</source>
         <translation>Неможливо завантажити шар %1.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
         <source>Unable to load %n objects, reason: %1</source>
         <translation>
             <numerusform>Неможливо заватажити %n обʼєкт, причина: %1</numerusform>
@@ -5204,821 +5218,808 @@ zoom using the mouse wheel, if available.</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
         <source>Empty geometry.</source>
         <translation>Вісутня геометрія.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
         <source>Can&apos;t determine the coordinate transformation: %1</source>
         <translation>Неможливо визначити трансформацію координат: %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
         <source>Failed to transform the coordinates.</source>
         <translation>Невдається трасформувати координати.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
         <source>Unknown or unsupported geometry type.</source>
         <translation>Невідомий або непідримуваний тип геометрії.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
         <source>Not enough coordinates.</source>
         <translation>Недостатньо координат.</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
         <source>Cannot use this spatial reference:
 %1</source>
         <translation>Неможливо використати цю просторову прив&amp;apos;язку:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
         <source>The geospatial data has no suitable spatial reference.</source>
         <translation>Геодані не містять придатної просторової прив&amp;apos;язки.</translation>
     </message>
 </context>
 <context>
-    <name>OpenOrienteering</name>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
     <message>
-        <location filename="../packaging/translations.cpp" line="10"/>
-        <source>Orienteering map</source>
-        <translation>Спортивна карта</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="11"/>
-        <source>Software for drawing orienteering maps</source>
-        <translation>Програма для креслення спортивних карт</translation>
-    </message>
-</context>
-<context>
-    <name>PaintOnTemplateSelectDialog</name>
-    <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
         <source>Select template to draw onto</source>
         <translation>Оберіть підложку для малювання</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>Малювати</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;Клікніть і тягніть&lt;/b&gt; щоб малювати. &lt;b&gt;Правий клік і тягніть&lt;/b&gt; щоб витерти. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>Вибір кольору</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб рухати карту. </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation></translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Додати координату. &lt;b&gt;%1+Клік&lt;/b&gt;: Змінити вибрану координату. </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>Завжди зорієнтовано на північ (не обертається)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>Елементи</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>Лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>Площа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>Центрувати всі елементи</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>Поточний елемент</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>Діаметр &lt;b&gt;a&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>Внутрішній колір:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>Зовнішня ширина &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>Зовнішній колір:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>Ширина лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>Колір лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>Кінці лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>плоскі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>круглі</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>квадратні</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>З’єднання відрізків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>гостре</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>фасочне</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>Лінія замкнена</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>Колір площі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>Координати:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>Починати криву</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>Центр у початок координат</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[Серединна точка]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>Невідомо</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>Точковий знак</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>Виникла помилка під час виконання.</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб перемістити карту, область друку або межі області друку. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб рухати область друку. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб рухати карту. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб рухати межу області друку. </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб рухати межі області друку. </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>Відобразити підложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>Відобразити сітку</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>Орієнтація сторінки:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>Принтер:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>Портрет</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>Альбом</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>Формат сторінки:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>Копії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>Зліва:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>Зверху:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>Попередній перегляд...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>Єдина сторінка</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>Задати область вручну</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>Область друку карти:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>Центрувати область друку</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>Перекриття сторінок:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>Опції</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>Роздільна здатність:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>Друкувати в іншому масштабі:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>Піложка може виглядати інакше.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>Емулювати overprinting</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>За замовченням</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>Пристрій підтримує CMYK (експерементально)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>Кольорова схема:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>Експорт...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>Експорт в PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>Експорт у зображення</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>Зберегти як PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>dpi</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>Не підтримується в Android.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>Не вдалося підготувати попередній перегляд.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>Попередній перегляд готується</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>Активовано нестандартний режим перегляду. Виконати друк / експорт в цьому режимі?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>BMP</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>Не вдалося підготувати експорт в PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>Під час друку виникла помилка.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>Експорт карти ...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>Підготовка до друку зазнала невдачі.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>Друкується</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>Векторна
 графіка</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>Растрова
 графіка</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>Розділення
 кольорів</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>Не вдалося підготувати зображення. Не достатньо пам&apos;яті.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>Не вдалося зберегти зображення. Чи існує шлях? Ви маєте право на запис?</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>Експорт здійснено як %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>Не вдалося завершити експорт у PDF.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>Скасовано.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>Неможливо зупинити друк.</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>Задачу друку успішно сформовано</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>Незрозумілий</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>Область друку поржня. Вивід скасовано.</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>Відкрити підложку знову</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>Перетягніть елемент з лівої колонки у бажане місце в правій колонці, щоб перезавантажити його.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>Закриті підложки:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>Очистити журнал</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>Активні підложки:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>Замінити набір знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>Налаштувати як саме слід замінювати знаки і на які.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>Імпортувати всі нові знаки, навіть якщо вони не використовуються для заміщення</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>Видалити оригінальні знаки, що не використовуються після заміни</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>Видалити кольори, що не використовуються після заміни</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>Відображення знаків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>Зберегти статуси Прихований / Захищений з старого набору знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>Виконати заміну по співпадаючим кодам знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>Оригінал</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation>Редагувати ID набору умовних знаків:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>Заміна</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation>Співпадіння по імені знаку</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation>Застосувати нові знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation>Візерунок</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation>Очистити заміни</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation>Відкрити CRT файл...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation>Зберегти CRT файл...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation>Відображення знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation>CRT файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation>Виявлено кілька замін для знаку %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -6029,7 +6030,7 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -6040,468 +6041,468 @@ separations</source>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation>Таблицю перехресних зв&apos;язків було змінено.
 Бажаєте зберегти ці зміни?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>- Немає -</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>Взяти набір знаків з файлу карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>Неможливо завантажити файл карти, перервано.</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>Вибраний набір знаків має масштаб 1:%1, тоді як масштаб карти 1:%2. Застосувати цей набір знаків?</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation>Неможливо завантажити CRT файл, скасовано.</translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>Повернути карту</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>Кут (проти годинникової стрілки):</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>Параметри обертання</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>Обертати навколо:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>Початку координатної сітки карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>Опорної точки геоприв&apos;язки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>Іншої точки,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>Опції</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Підігнати опорну точку геоприв&apos;язки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>Підігнати геоприв&apos;язане схилення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>Повернути негеоприв&apos;язані підложки</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Кут:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фіксовані кути. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб задати напрямок візерунку заповнення, або повернути точковий об&apos;єкт. </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;Поворот:&lt;/b&gt; %1° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;: Фіксовані кути. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Задати центр обертання. </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб обертатии вибрані об&apos;єкти. </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>Змінити масштаб карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>Параетри масштабування</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>Новий масштаб:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>Центр масштабування:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>Початок координат карти</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>Опорна точка геоприв&apos;язки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>Інша точка,</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>Опції</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>Масштабувати розмір знаків</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>Масштабувати позиції об&apos;єктів на карті</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>Підігнати опорну точку геоприв&apos;язки</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>Масштабувати негеоприв&apos;язані підложки</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;Масштабування:&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Задати центр масштабування. </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб масштабувати вибраний об&apos;єкт. </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>Виберіть базову систему координат</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>Так само як на карті</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>Локально</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>Географічні координати (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>дійсний</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>Налашування</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; збережено у звичайній папці.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; розміщено у папці програми. Файли будуть видалені після видалення програми.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; захищено від запису. Зміни не будуть збережені.</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; не дійсне місце збереження.</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>- немає -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>- Немає -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>Номер:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>Назва:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>Опис:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>Допоміжний знак (не відображатиметься на кінцевій карті)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>Основне</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>Для знаків з описом, натисніть F1 щоб переглянути підказку</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>Новий знак</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>Лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>Площа</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>Комбінований</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>Дублювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>Масштаб...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
@@ -6514,118 +6515,118 @@ Do you want to save your changes?</source>
         <translation type="vanished">Заповнити / Створити границию для обраного об&apos;єкту(ів)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>Виділити знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>Дозволити drag and drop</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>Внутрішня непередбачена помилка, вибачте!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>У буфері обміну немає знаків які можна було б вставити!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>Виділити усі об’єкти з цим знаком</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>Видалити всі об&apos;єкти цього знаку з виділення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>Приховати об&apos;єкти з цим знаком</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>Захистити об&apos;єкти з цим знаком</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>Додати всі об&apos;єкти обраного знаку до виділення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>Видалити всі об&apos;єкти обраного знаку з виділення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>Приховати об’єкти виділеного знаку</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>Захистити об’єкти виділеного знаку</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>Інвертувати вибір</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>Вибрати всі</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>Вибрати ті що не використовуються</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>Сортувати знаки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>Сортувати за номером</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>Сортувати за головним кольором</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>Сортувати за пріоритетом головного кольору</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>Масштабувати у відсотках:</translation>
     </message>
@@ -6634,91 +6635,91 @@ Do you want to save your changes?</source>
         <translation type="vanished">Масштабувати знак(и)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>Підтвердження</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>Карта містить об&apos;єкти зі знаком &quot;%1&quot;. Видалення знаку призведе до видалення цих об&apos;єктів і очистки історії попередніх кроків! Ви впевнені що хочете зробити це?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>Додати всі об&apos;єкти цього знаку до виділення</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>Виділити всі об’єкти обраного знаку</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>Замінити умовний знак для виділених об&apos;єктів</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>Заповнити / Створити межу для виділених об&apos;єктів</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>Масштабувати знаки</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>Параметри знака</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>Підложка:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;Підложка:&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>(немає)</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>Відкрити...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>Центрувати підложку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>обмежуюча рамка на початок</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>центр мас на початок</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>Вибрати колір фону</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6734,58 +6735,58 @@ to jump over the lazy dog
 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>- без назви -</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>Опис відсутній!</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>Відношення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>Ключ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>Умова</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>Додати рядок</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>Видалити рядок</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>Підняти</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>Опустити</translation>
     </message>
@@ -6798,7 +6799,7 @@ to jump over the lazy dog
         <translation type="vanished">Довідка</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n об&apos;єкт виділено</numerusform>
@@ -6807,203 +6808,203 @@ to jump over the lazy dog
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>Помилковий запит</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>Ключ</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>Ключ існує</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>Ключ &quot;%1&quot; вже існує і не може використовуватись двічи.</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>Знайти переміщений файл підложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>Немає такого файлу.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>Чи вірний формат цього файлу для такого типу підложок?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation>Недостатньо вільної пам&apos;яті.</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>Суміщення підложки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>Обахунок суміщення зазнав невдачі!</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Вкажіть характерну точку на підложці. </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Вкажіть відповідну точку на карті. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;Клік&lt;/b&gt;: Видалити точку суміщення. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; щоб перемістити точку суміщення. </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>Точки суміщення:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>Нова</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>Змістити</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>Підложка по X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>Підложка по Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>Карта по X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>Карта по Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>Сумістити точки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>Сумістити &amp;&amp; очистити всі</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>Очистити всі</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>Не вистачає оперативної пам&apos;яті (розмір зображення: %1x%2 пікселів)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -7012,228 +7013,228 @@ If you do not intend to draw on this template however, that is no problem.</sour
 Це не проблема, якщо ви &lt;b&gt;не&lt;/b&gt; плануєте малювати з цієї підложки у майбутньому.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>Виберіть базову систему координат для координат у world file-і</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>Відкривається %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>Розмір зображення:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>Вкажіть як розмістити і змасштабувати зображення:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>World-файл</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>немає інформації щодо геоприв&apos;язки</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>Геоприв&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>Метрів на піксел:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>Скановано із</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>Масштаб підложки:  1 :</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>Відобразити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>Непрозорість</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>Група</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>Назва файлу</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>Ескіз</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>Відкрити...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>Геоприв&apos;язка: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>Дублювати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>Додати підложку...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>Підняти</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>Опустити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>Імпортувати і видалити</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>Перемістити вручну</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>Відкрити зображення, GPS трек чи DXF файл</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>Позиціонування...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>Файл підложки</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>Всі файли</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>Сумістити...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>Формат файлу не розпізнано.</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>Невдале завантаження підложки. Такий файл дійсно існує і він коректний?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>Введіть ціле число для встановлення групи або залиште поле пустим щоб розгрупувати підложку!</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>Не масштабувати</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>Масштабувати відносно номінального масштабу карти (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
@@ -7242,194 +7243,194 @@ If you do not intend to draw on this template however, that is no problem.</sour
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>Масштабувати відносно поточного масштабу карти (%1 %)</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>Імпортувати підложку</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>Як слід масштабувати знаки з підложки що імпортується?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>При емуляції overprinting підложку буде приховано. Переключитися в звичайний режим?</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>- Карта -</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;Потягніть&lt;/b&gt; для переміщення активної підложки</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>Позиціонування</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>Масштаб по X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Масштаб по Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>Обертання:</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>Позиціонування і масштабування треку</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>Система координат</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>Дійсні</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>Карта</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>Одна одиниця координат становить:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>Розмістити трек у отриманих координатах</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>Розмістити трек у центрі екрану</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation>Необхідно імпортувати цю підложку через GDAL/OGR.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>Виберіть базову систему координат для треку</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>Відкрити трек...</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>Завантажити трек у геоприв&apos;язаному чи негеоприв&apos;язаному режимі?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>Розмістити трек відповідно до налаштувань геоприв&apos;язки карти.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>Вони ще не налаштовані, тому будуть показані на наступному кроці.</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>Карта геоприв&apos;язана</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>Карта негеоприв&apos;язана</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>Трек є ортогональною проекцією з центром у точці усереднених координат треку. Це дозволить здійснити трансформацію карти і встановити її геоприв&apos;язку підгонкою відносно позиції треку.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>Контур порожній, немає чого імпортувати!</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>Проблема</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>Імпортувати точки шляху як лінію, що проходить через всі ці точки?</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>Є проблеми при імпорті</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>Неможливо імпортувати %n об&apos;єкт шляху (причина: відсутні координати).</numerusform>
@@ -7438,12 +7439,12 @@ If you do not intend to draw on this template however, that is no problem.</sour
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>Помилка читання</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
@@ -7452,39 +7453,39 @@ If you do not intend to draw on this template however, that is no problem.</sour
 %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1:
 Не є OSM файлом.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM файл має версію %1.
 Підтримуються версії починаючи з %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM файл має версію %1.
 Підтримуються версії не новіші від %2.</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>Проблеми</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>%1 вузлів неможливо правильно обробити.</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">Зовнішнє посилання: %1</translation>
@@ -7495,58 +7496,58 @@ The maximum supported version is %2.</source>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>Вирівнювання</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>Ліворуч</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>По центру</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>Праворуч</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>Згори</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>Базова лінія</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>Знизу</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>Параметри тексту</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>Шрифт:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>Розмір шрифту:</translation>
     </message>
@@ -7555,339 +7556,339 @@ The maximum supported version is %2.</source>
         <translation type="vanished">Задати розмір...</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>А</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>пт</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>Колір тексту:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>жирний</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>курсив</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>підкреслений</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>Стиль тексту:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>Міжрядковий інтервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>Інтервал між абзацами:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>Міжсимвольний інтервал:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>Кернінг</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>Текст на іконці:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>Обрамлення</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>Параметри сумісності з OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>Колір обрамлення:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>Лінійне обрамлення</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>Тінь</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>Лівий/Правий Відступ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>Верхній/Нижній Відступ:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>Сумісність з OCAD</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>увімкнено</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>Ширина лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>Колір лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>Позиція:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>Лінія під абзацом</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>Відстань від базової лінії:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>Нестандартна позиція табулятора</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>Додати нестандартний табулятор</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>Обчислення</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>Неможливо відмінити останній крок, бо він став непридатним. Це могло трапитися якщо ви змінили знак об&apos;єкту на інший, а потім видалили старий знак.</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>Підтвердження</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>Відміна цього кроку призведе до стану у якому файл був відкритий. Хочете зробити це?</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>Неможливо відмінити останній крок бо попередній крок став недоступним. Це могло трапитись, наприклад, якщо ви видалили знак щойно створеного об&apos;єкту.</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation>%1°</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation>%1 м</translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>Не вдалося знайти файли довідки.</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Не знайдено переглядач для довідки (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>Не вдалося запустити переглядач для довідки (&quot;Qt Assistant&quot;).</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>Більше...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>Старіші версії Mapper не підтримують частини карти. Для збереження карти у режимі сумісності вам доведеться об&apos;єднати усі частини карти.</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>Непідтримуваний елемент: %1 (рядок %2 стовбчик %3)</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>Деякі координати поза межами області друку. Вміст карти був підігнаний.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>невідомо</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>Частина цього файлу не може бути прочитана цією версією Mapper. Мінімальна необхідна версія: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>Помилка у рядку %1 колонка %2: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>Деякі помилкові текстові символи були видалені.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>Невідома помилка</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>Непідтримувана або недійсна специфікація геоприв&apos;язки &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>Неможливо встановити властивості перекривання для кольору %1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>Очікувався колір %1, а знайдено %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>Планшетний колір %1 не знайдений під час обробки %2 (%3).</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>Очікувався знак %1, а знайдено %2.</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>Очікувалася частина карти %1, а знайдено %2.</translation>
     </message>

--- a/translations/OpenOrienteering_zh_CN.ts
+++ b/translations/OpenOrienteering_zh_CN.ts
@@ -2,5173 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
-    <name>AboutDialog</name>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="101"/>
-        <location filename="../src/gui/about_dialog.cpp" line="168"/>
-        <source>About %1</source>
-        <translation>About %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="182"/>
-        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
-        <translation>&lt;a％1&gt;所有关于许可证，版权的告示，条件和免责声明</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="184"/>
-        <source>The OpenOrienteering developers in alphabetical order:</source>
-        <translation>按字母顺序排列的 OpenOrienteering 开发人员</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="185"/>
-        <source>(project initiator)</source>
-        <translation>（项目发起人）</translation>
-    </message>
-    <message>
-        <location filename="../packaging/translations.cpp" line="14"/>
-        <location filename="../src/gui/about_dialog.cpp" line="170"/>
-        <source>A free software for drawing orienteering maps</source>
-        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
-        <translation>用于绘制定向越野地图的免费开源软件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="172"/>
-        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
-        <translation>此程序是免费的软件︰ 你可以将它重新分发和/或修改根据 &lt;a %1&gt; GNU 通用公共许可证 (GPL)，版本 3&lt;/a&gt; 的条款，如由自由软件基金会出版。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="177"/>
-        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
-        <translation>请参阅GNU通用公共许可证（GPL），版本3，有关&lt;a %1&gt;更多详细信息&lt;/a&gt;。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/about_dialog.cpp" line="186"/>
-        <source>For contributions, thanks to:</source>
-        <translation>作出的贡献，感谢</translation>
-    </message>
-</context>
-<context>
-    <name>AbstractHomeScreenWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
-        <source>Open most recently used file</source>
-        <translation>打开最近使用的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="120"/>
-        <source>Show tip of the day</source>
-        <translation>显示每日提示</translation>
-    </message>
-</context>
-<context>
-    <name>ActionGridBar</name>
-    <message>
-        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="49"/>
-        <source>Show remaining items</source>
-        <translation>显示剩余项目</translation>
-    </message>
-</context>
-<context>
-    <name>AreaSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="86"/>
-        <source>Minimum size:</source>
-        <translation>最小尺寸</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="93"/>
-        <source>Fills</source>
-        <translation>填充</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="106"/>
-        <source>Line fill</source>
-        <translation>线条与填充</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="107"/>
-        <source>Pattern fill</source>
-        <translation>图案填充</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="145"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="156"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="163"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="182"/>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="187"/>
-        <source>mm</source>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="160"/>
-        <source>Single line</source>
-        <translation>单行</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
-        <source>Parallel lines</source>
-        <translation>两条平行线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
-        <source>Line spacing:</source>
-        <translation>行间距</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="179"/>
-        <source>Single row</source>
-        <translation>单排</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
-        <source>Pattern interval:</source>
-        <translation>模式间隔</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="186"/>
-        <source>Pattern offset:</source>
-        <translation>模式偏移量</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="191"/>
-        <source>Row offset:</source>
-        <translation>行偏移量</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
-        <source>Parallel rows</source>
-        <translation>平行的行</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
-        <source>Row spacing:</source>
-        <translation>行间距</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="201"/>
-        <source>Fill rotation</source>
-        <translation>填补旋转</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
-        <source>Angle:</source>
-        <translation>角度</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
-        <source>adjustable per object</source>
-        <translation>每个对象可调节</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="227"/>
-        <source>Element drawing at boundary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
-        <source>Clip elements at the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="230"/>
-        <source>Draw elements if the center is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
-        <source>Draw elements if any point is inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
-        <source>Draw elements if all points are inside the boundary.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="247"/>
-        <source>Area settings</source>
-        <translation>区域设置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="339"/>
-        <source>Pattern fill %1</source>
-        <translation>图案填充 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="348"/>
-        <source>Line fill %1</source>
-        <translation>线条与填充 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="367"/>
-        <source>No fill selected</source>
-        <translation>没有选定的填充</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="83"/>
-        <source>Area color:</source>
-        <translation>区域颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="172"/>
-        <source>Line offset:</source>
-        <translation>行偏移量</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="167"/>
-        <source>Line color:</source>
-        <translation>线条颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
-        <source>Line width:</source>
-        <translation>线宽</translation>
-    </message>
-</context>
-<context>
-    <name>AutosaveDialog</name>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="43"/>
-        <source>Autosaved file</source>
-        <translation>自动保存文件</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/autosave_dialog.cpp" line="45"/>
-        <location filename="../src/gui/autosave_dialog.cpp" line="51"/>
-        <source>%n bytes</source>
-        <translation>
-            <numerusform>%n 字节</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="49"/>
-        <source>File saved by the user</source>
-        <translation>由用户保存的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="56"/>
-        <source>File recovery</source>
-        <translation>文件恢复</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="58"/>
-        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
-        <translation>文件 %1 不正确地关闭。目前，有两个版本</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/autosave_dialog.cpp" line="72"/>
-        <source>Save the active file to remove the conflicting version.</source>
-        <translation>保存活动文件删除冲突的版本。</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDialog</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="83"/>
-        <source>Edit map color</source>
-        <translation>编辑地图颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="90"/>
-        <source>Edit</source>
-        <translation type="unfinished">编辑</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="103"/>
-        <source>Defines a spot color:</source>
-        <translation>定义专色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="112"/>
-        <source>Mixture of spot colors (screens and overprint):</source>
-        <translation>混合物的专色 （屏幕和叠印）</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="127"/>
-        <location filename="../src/gui/color_dialog.cpp" line="165"/>
-        <location filename="../src/gui/color_dialog.cpp" line="170"/>
-        <location filename="../src/gui/color_dialog.cpp" line="175"/>
-        <location filename="../src/gui/color_dialog.cpp" line="180"/>
-        <location filename="../src/gui/color_dialog.cpp" line="414"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="132"/>
-        <source>Knockout: erases lower colors</source>
-        <translation>挖空︰ 擦除低颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="150"/>
-        <location filename="../src/gui/color_dialog.cpp" line="207"/>
-        <source>Calculate from spot colors</source>
-        <translation>计算从专色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="155"/>
-        <source>Calculate from RGB color</source>
-        <translation>计算从 RGB 颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="160"/>
-        <source>Custom process color:</source>
-        <translation>自定义过程颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="166"/>
-        <source>Cyan</source>
-        <translation>青色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="171"/>
-        <source>Magenta</source>
-        <translation>洋红色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="176"/>
-        <source>Yellow</source>
-        <translation>黄色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="181"/>
-        <source>Black</source>
-        <translation>黑色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="212"/>
-        <source>Calculate from CMYK color</source>
-        <translation>计算从 CMYK 颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="217"/>
-        <source>Custom RGB color:</source>
-        <translation>自定义 RGB 颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="223"/>
-        <source>Red</source>
-        <translation>红色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="228"/>
-        <source>Green</source>
-        <translation>绿色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="233"/>
-        <source>Blue</source>
-        <translation>蓝色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="238"/>
-        <source>#RRGGBB</source>
-        <translation>#RRGGBB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="256"/>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="257"/>
-        <source>Professional printing</source>
-        <translation>专业印刷</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="276"/>
-        <source>Name</source>
-        <translation type="unfinished">名称</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="328"/>
-        <source>- unnamed -</source>
-        <translation type="unfinished">-未命名-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="597"/>
-        <source>Warning</source>
-        <translation type="unfinished">警告</translation>
-    </message>
-</context>
-<context>
-    <name>ColorDropDown</name>
-    <message>
-        <location filename="../src/gui/widgets/color_dropdown.cpp" line="40"/>
-        <source>- none -</source>
-        <translation>-无-</translation>
-    </message>
-</context>
-<context>
-    <name>ColorListWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Name</source>
-        <translation>名称</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Opacity</source>
-        <translation>不透明度</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>Spot color</source>
-        <translation>专色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>CMYK</source>
-        <translation>CMYK</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>RGB</source>
-        <translation>RGB</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="81"/>
-        <source>K.o.</source>
-        <translation>棍</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="87"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="92"/>
-        <source>New</source>
-        <translation>新增功能</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="95"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="88"/>
-        <source>Duplicate</source>
-        <translation>重复</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="101"/>
-        <source>Move Up</source>
-        <translation>向上移动</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
-        <source>Move Down</source>
-        <translation>向下移动</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="114"/>
-        <source>Help</source>
-        <translation>說明</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="135"/>
-        <source>Double-click a color value to open a dialog.</source>
-        <translation>双击要打开一个对话框的颜色值。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>Confirmation</source>
-        <translation>确认</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="230"/>
-        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
-        <translation>映射包含这种颜色的符号。删除它将从这些对象中删除颜色 ！你真的想要这样做？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="248"/>
-        <source>%1 (duplicate)</source>
-        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="249"/>
-        <source> (Duplicate)</source>
-        <translation> （重复）</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="407"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="456"/>
-        <source>Double click to define the color</source>
-        <translation>双击要定义的颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="415"/>
-        <source>Click to select the name and click again to edit.</source>
-        <translation>单击以选中名称，再次单击可编辑。</translation>
-    </message>
-</context>
-<context>
-    <name>CombinedSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="86"/>
-        <source>&amp;Number of parts:</source>
-        <translation>与零件数目</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="94"/>
-        <source>- Private line symbol -</source>
-        <translation>-私人线符号-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="95"/>
-        <source>- Private area symbol -</source>
-        <translation>-私人领域符号-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="98"/>
-        <source>Edit private symbol...</source>
-        <translation>编辑私有符号...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="112"/>
-        <source>Combination settings</source>
-        <translation>组合设置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="225"/>
-        <source>Change from public to private symbol</source>
-        <translation>从公共改为私有符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="226"/>
-        <source>Take the old symbol as template for the private symbol?</source>
-        <translation>把旧的符号作为私有符号模板吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="91"/>
-        <source>Symbol %1:</source>
-        <translation>%1 的符号</translation>
-    </message>
-</context>
-<context>
-    <name>ConfigureGridDialog</name>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="64"/>
-        <source>Configure grid</source>
-        <translation>配置网格</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="66"/>
-        <source>Show grid</source>
-        <translation>显示网格</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
-        <source>Snap to grid</source>
-        <translation>对齐网格</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="68"/>
-        <source>Choose...</source>
-        <translation>请选择...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
-        <source>All lines</source>
-        <translation>所有行</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="72"/>
-        <source>Horizontal lines</source>
-        <translation>水平线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="73"/>
-        <source>Vertical lines</source>
-        <translation>垂直线条</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
-        <source>Alignment</source>
-        <translation>对齐方式</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
-        <source>Align with magnetic north</source>
-        <translation>磁北与对齐</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
-        <source>Align with grid north</source>
-        <translation>与北方的网格对齐</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="77"/>
-        <source>Align with true north</source>
-        <translation>真北路与对齐</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
-        <source>Additional rotation (counter-clockwise):</source>
-        <translation>额外的旋转 （逆时针）</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="132"/>
-        <source>Positioning</source>
-        <translation>定位</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="85"/>
-        <source>meters in terrain</source>
-        <translation>在地形米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="86"/>
-        <source>millimeters on map</source>
-        <translation>在地图上的毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
-        <source>Horizontal spacing:</source>
-        <translation>水平间距</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="90"/>
-        <source>Vertical spacing:</source>
-        <translation>垂直间距</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="94"/>
-        <source>Horizontal offset:</source>
-        <translation>水平偏移量</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="96"/>
-        <source>Vertical offset:</source>
-        <translation>垂直偏移量</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="133"/>
-        <source>Unit:</source>
-        <comment>measurement unit</comment>
-        <translation>单位</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="121"/>
-        <source>Line color:</source>
-        <translation>线条颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="122"/>
-        <source>Display:</source>
-        <translation>显示︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="168"/>
-        <source>Choose grid line color</source>
-        <translation>选择网格线颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="252"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="258"/>
-        <source>Origin at: %1</source>
-        <translation>原点: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="260"/>
-        <source>paper coordinates origin</source>
-        <translation>本文坐标原点</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/configure_grid_dialog.cpp" line="262"/>
-        <source>projected coordinates origin</source>
-        <translation>投影的坐标原点</translation>
-    </message>
-</context>
-<context>
-    <name>CutHoleTool</name>
-    <message>
-        <location filename="../src/tools/cut_hole_tool.cpp" line="247"/>
-        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
-        <translation>&lt;b&gt;单击或拖动&lt;/b&gt;︰ 开始绘制孔。 </translation>
-    </message>
-</context>
-<context>
-    <name>CutTool</name>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="412"/>
-        <source>The split line must end on the area boundary!</source>
-        <translation>拆分线必须结束在区域边界上 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="418"/>
-        <source>Start and end of the split line are at different parts of the object!</source>
-        <translation>开始和结束的拆分线是在对象的不同部分 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="424"/>
-        <source>Start and end of the split line are at the same position!</source>
-        <translation>开始和结束的拆分线处于相同的位置 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="104"/>
-        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
-        <translation>在行上 &lt;b&gt;单击&lt;/b&gt;︰ 分成两个。沿着一条线 &lt;b&gt;拖&lt;/b&gt;︰ 删除此线部件。&lt;b&gt;单击或拖动&lt;/b&gt; 在区域边界︰ 开始拆分线。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cut_tool.cpp" line="364"/>
-        <source>Splitting holes of area objects is not supported yet!</source>
-        <translation>劈裂孔的区域对象尚不支持 ！</translation>
-    </message>
-</context>
-<context>
-    <name>CutoutTool</name>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="146"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 剪辑整个地图。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="147"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="151"/>
-        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
-        <translation>&lt;b&gt;%1 + 单击或拖动&lt;/b&gt;︰ 选择要被剪切的对象。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/cutout_tool.cpp" line="152"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 所选的对象的剪辑。 </translation>
-    </message>
-</context>
-<context>
-    <name>DXFParser</name>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="36"/>
-        <source>Could not open the file.</source>
-        <translation>无法打开该文件。</translation>
-    </message>
-    <message>
-        <location filename="../src/util/dxfparser.cpp" line="52"/>
-        <source>The file is not an DXF file.</source>
-        <translation>该文件不是 DXF 文件。</translation>
-    </message>
-</context>
-<context>
-    <name>DetermineFontSizeDialog</name>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="107"/>
-        <source>Letter:</source>
-        <translation>字：</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
-        <source>A</source>
-        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="115"/>
-        <source>Height:</source>
-        <translation>高度︰</translation>
-    </message>
-</context>
-<context>
-    <name>DistributePointsSettingsDialog</name>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="128"/>
-        <source>Distribute points evenly along path</source>
-        <translation>分发点沿路径均匀</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="134"/>
-        <source>Number of points per path:</source>
-        <translation>每个路径点的数目︰</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="136"/>
-        <source>Also place objects at line end points</source>
-        <translation>此外将对象置于线条端点</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="142"/>
-        <source>Rotation settings</source>
-        <translation>旋转设置</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="145"/>
-        <source>Align points with direction of line</source>
-        <translation>对齐点与线的方向</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="149"/>
-        <source>°</source>
-        <comment>degrees</comment>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/distribute_points_tool.cpp" line="151"/>
-        <source>Additional rotation angle (counter-clockwise):</source>
-        <translation>额外的旋转角度 （逆时针）︰</translation>
-    </message>
-</context>
-<context>
-    <name>DrawCircleTool</name>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="67"/>
-        <source>From center</source>
-        <comment>Draw circle starting from center</comment>
-        <translation>从中心</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="306"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 启动一个圆或椭圆。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="307"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
-        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 画一个圆。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
-        <source>Hold %1 to start drawing from the center.</source>
-        <translation>持有 %1 从中心开始绘制。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="313"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 完成圈。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="314"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
-        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 绘制一个椭圆。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawFreehandTool</name>
-    <message>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="287"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
-        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 绘制路径。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawLineAndAreaTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1170"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="723"/>
-        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
-        <translation>&lt;b&gt;破折号点。&lt;/b&gt; </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1178"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
-        <translation>&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 对齐或将追加到现有的对象。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1186"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="729"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
-        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt;︰ 选择从现有对象的方向。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1187"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1214"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1203"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="734"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="758"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 与现有对象对齐。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1213"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="748"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1223"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="764"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 撤消最后一点。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPathTool</name>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="100"/>
-        <source>Finish</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="101"/>
-        <source>Close</source>
-        <translation>关闭</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>角度</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
-        <source>Info</source>
-        <comment>Show segment azimuth and length</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="107"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>短划线</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="110"/>
-        <source>Undo</source>
-        <translation>撤消</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="111"/>
-        <source>Abort</source>
-        <translation>中止</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1165"/>
-        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
-        <translation>&lt;b&gt;长度︰&lt;/b&gt; %1 m </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1193"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 开始一条直线。&lt;b&gt;拖&lt;/b&gt;︰ 开始一条曲线。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1204"/>
-        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
-        <translation>&lt;b&gt;％1  拖动&lt;/b&gt; ：按照现有对象 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1220"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 绘制一条直线。&lt;b&gt;拖&lt;/b&gt;︰ 绘制一条曲线。&lt;b&gt;右或双点击&lt;/b&gt;︰ 完成路径。&lt;b&gt;%1&lt;/b&gt;︰ 闭合该路径。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointGPSTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="79"/>
-        <source>Touch the map to finish averaging</source>
-        <translation>轻触地图完成平均</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_gps_tool.cpp" line="191"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 完成设置对象。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawPointTool</name>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="80"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="81"/>
-        <source>Angle</source>
-        <comment>Using constrained angles</comment>
-        <translation>角度</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="82"/>
-        <source>Reset</source>
-        <comment>Reset rotation</comment>
-        <translation>重置</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="331"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="343"/>
-        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
-        <translation>&lt;b&gt;角︰&lt;/b&gt; %1 ° </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="332"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="337"/>
-        <location filename="../src/tools/draw_point_tool.cpp" line="351"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
-        <translation>&lt;b&gt;点击&lt;/b&gt; ：创建一个点对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="338"/>
-        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
-        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 创建一个对象并设置其方向。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_point_tool.cpp" line="344"/>
-        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
-        <translation>&lt;b&gt;0 %1&lt;/b&gt;︰ 重置旋转。</translation>
-    </message>
-</context>
-<context>
-    <name>DrawRectangleTool</name>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="88"/>
-        <source>Finish</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="89"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
-        <source>Line snap</source>
-        <comment>Snap to previous lines</comment>
-        <translation>线管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
-        <source>Dash</source>
-        <comment>Drawing dash points</comment>
-        <translation>短划线</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="94"/>
-        <source>Undo</source>
-        <translation>撤消</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="95"/>
-        <source>Abort</source>
-        <translation>中止</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="739"/>
-        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
-        <translation>&lt;b&gt;单击或拖动&lt;/b&gt;︰ 开始绘制一个矩形。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 与以前的行对齐。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="763"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置一个角点。&lt;b&gt;右或双点击&lt;/b&gt;︰ 完成该矩形。 </translation>
-    </message>
-</context>
-<context>
-    <name>DrawTextTool</name>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="111"/>
-        <source>Snap</source>
-        <extracomment>Snap to existing objects</extracomment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="474"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 完成编辑。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="475"/>
-        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
-        <translation>&lt;b&gt;%1 + %2&lt;/b&gt;︰ 取消编辑。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="480"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 创建具有单锚文本对象。&lt;b&gt;拖&lt;/b&gt;︰ 中创建一个文本框。 </translation>
-    </message>
-</context>
-<context>
-    <name>EditLineTool</name>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="404"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
-        <source>Toggle curve</source>
-        <comment>Toggle between curved and flat segment</comment>
-        <translation>切换曲线</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="517"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 自由流动。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_line_tool.cpp" line="533"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
-        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 段上︰ 直线和曲线之间切换。 </translation>
-    </message>
-</context>
-<context>
-    <name>EditPointTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="531"/>
-        <source>Snap</source>
-        <comment>Snap to existing objects</comment>
-        <translation>管理单元</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="532"/>
-        <source>Point / Angle</source>
-        <comment>Modify points or use constrained angles</comment>
-        <translation>点 / 角</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="533"/>
-        <source>Toggle dash</source>
-        <comment>Toggle dash points</comment>
-        <translation>切换破折号</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="712"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 完成编辑。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="731"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
-        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 保持相反的句柄位置。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="752"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
-        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 点︰ 删除它;在路径上︰ 添加一个新的破折号点;&lt;b&gt;%2&lt;/b&gt;︰ 添加一个正常点。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="755"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
-        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 点︰ 删除它;在路径上︰ 添加一个新的点;&lt;b&gt;%2&lt;/b&gt;︰ 添加一个破折号点。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
-        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
-        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 的点划线和正常点之间进行切换。 </translation>
-    </message>
-</context>
-<context>
-    <name>EditTool</name>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="717"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="510"/>
-        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
-        <translation>&lt;b&gt;坐标偏移量︰&lt;/b&gt; %1、 %2 毫米 &lt;b&gt;距离︰&lt;/b&gt; %3 m </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="724"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="519"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 与现有对象对齐。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="741"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="525"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 选择单个对象。&lt;b&gt;拖动&lt;/b&gt;︰ 选择多个对象。&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 切换选择。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/edit_point_tool.cpp" line="744"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="528"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 删除选定的对象。 </translation>
-    </message>
-</context>
-<context>
-    <name>EditorSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
-        <source>High quality map display (antialiasing)</source>
-        <translation>高质量地图显示 （抗锯齿）</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="47"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="51"/>
-        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
-        <translation>抗锯齿功能使地图看起来好多了，但也会减慢地图显示</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="50"/>
-        <source>High quality text display in map (antialiasing), slow</source>
-        <translation>高质量的文本显示在地图 （抗锯齿），缓慢</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="55"/>
-        <source>Click tolerance:</source>
-        <translation>请单击公差︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="43"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="54"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="58"/>
-        <source>Snap distance (%1):</source>
-        <translation>对齐距离 (%1):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="61"/>
-        <source>Stepping of fixed angle mode (%1):</source>
-        <translation>步进的固定的角模式 (%1):</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
-        <source>°</source>
-        <comment>Degree sign for angles</comment>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="44"/>
-        <source>Symbol icon size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
-        <source>When selecting an object, automatically select its symbol, too</source>
-        <translation>当选择一个对象，自动选择它的符号太</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="66"/>
-        <source>Zoom away from cursor when zooming out</source>
-        <translation>从光标放大，放大了</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="69"/>
-        <source>Drawing tools: set last point on finishing with right click</source>
-        <translation>绘图工具︰ 套上整理的最后一个点右键单击</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="72"/>
-        <source>Templates: keep settings of closed templates</source>
-        <translation>模板︰ 保持封闭模板设置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="77"/>
-        <source>Edit tool:</source>
-        <translation>编辑工具︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="80"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="86"/>
-        <source>Retain old shape</source>
-        <translation>保留旧的形状</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="81"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="87"/>
-        <source>Reset outer curve handles</source>
-        <translation>重置外曲线手柄</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
-        <source>Keep outer curve handles</source>
-        <translation>保持外曲线手柄</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
-        <source>Action on deleting a curve point with %1:</source>
-        <translation>有关删除 %1 曲线点的行动︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="92"/>
-        <source>Rectangle tool:</source>
-        <translation>矩形工具︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="95"/>
-        <source>Radius of helper cross:</source>
-        <translation>助手交叉半径：</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
-        <source>Preview the width of lines with helper cross</source>
-        <translation>预览与助手交叉线条的宽度</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="113"/>
-        <source>Editor</source>
-        <translation>编辑器</translation>
-    </message>
-</context>
-<context>
-    <name>Exporter</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>Could not create new file: %1</source>
-        <translation>不能创建新文件: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="82"/>
-        <source>Format (%1) does not support export</source>
-        <translation>格式 (%1) 不支持出口</translation>
-    </message>
-</context>
-<context>
-    <name>FillTool</name>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="154"/>
-        <source>Warning</source>
-        <translation>警告</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="155"/>
-        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
-        <translation>地图面积大。填充工具的使用可能会很慢。你想要使用它吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="140"/>
-        <location filename="../src/tools/fill_tool.cpp" line="174"/>
-        <location filename="../src/tools/fill_tool.cpp" line="228"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="141"/>
-        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
-        <translation>单击的区域不受线路或地区，不能填补这一领域。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="175"/>
-        <source>The clicked position is not free, cannot use the fill tool there.</source>
-        <translation>被单击的位置不是免费的不能那里使用填充工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="229"/>
-        <source>Failed to create the fill object.</source>
-        <translation>未能创建填充对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/fill_tool.cpp" line="240"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 用活动符号填充区域。要填充的区域必须有界的直线或地区，不考虑其他符号。 </translation>
-    </message>
-</context>
-<context>
-    <name>GPSDisplay</name>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="89"/>
-        <source>GPS is disabled in the device settings. Open settings now?</source>
-        <translation>GPS 在设备设置被禁用。现在打开设置吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="90"/>
-        <source>Yes</source>
-        <translation>是的</translation>
-    </message>
-    <message>
-        <location filename="../src/sensors/gps_display.cpp" line="91"/>
-        <source>No</source>
-        <translation>不</translation>
-    </message>
-</context>
-<context>
-    <name>GdalSettingsPage</name>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="49"/>
-        <source>Import with GDAL/OGR:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="51"/>
-        <source>DXF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="54"/>
-        <source>GPX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="57"/>
-        <source>OSM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="61"/>
-        <source>Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Parameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="69"/>
-        <source>Value</source>
-        <translation type="unfinished">价值</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/gdal_settings_page.cpp" line="88"/>
-        <source>GDAL/OGR</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GeneralSettingsPage</name>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="78"/>
-        <source>Appearance</source>
-        <translation>外观</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="83"/>
-        <source>Language:</source>
-        <translation>语言︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="100"/>
-        <source>Screen</source>
-        <translation>屏幕</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="105"/>
-        <source>Pixels per inch:</source>
-        <translation>每英寸的像素数︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="115"/>
-        <source>Program start</source>
-        <translation>启动程序</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="124"/>
-        <source>Saving files</source>
-        <translation>保存文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
-        <source>Retain compatibility with Mapper %1</source>
-        <translation>保留与映射程序 %1 的兼容性</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="137"/>
-        <source>Save information for automatic recovery</source>
-        <translation>保存自动恢复信息</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="141"/>
-        <source>Recovery information saving interval:</source>
-        <translation>恢复信息的保存时间间隔︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="140"/>
-        <source>min</source>
-        <comment>unit minutes</comment>
-        <translation>分钟</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="144"/>
-        <source>File import and export</source>
-        <translation>文件导入和导出</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="169"/>
-        <source>8-bit encoding:</source>
-        <translation>8 位编码︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="162"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="313"/>
-        <source>More...</source>
-        <translation>更多...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="134"/>
-        <source>Save undo/redo history</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="147"/>
-        <source>Default</source>
-        <translation>默认</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
-        <source>Use the new OCD importer also for version 8 files</source>
-        <translation>使用新的强迫症进口商也为版本 8 文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="190"/>
-        <source>General</source>
-        <translation>一般</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>Notice</source>
-        <translation>通知</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="214"/>
-        <source>The program must be restarted for the language change to take effect!</source>
-        <translation>语言更改生效，必须重新启动该程序 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="361"/>
-        <source>Open translation</source>
-        <translation>开放式翻译</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="355"/>
-        <source>Translation files (*.qm)</source>
-        <translation>翻译文件 (*.qm)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="362"/>
-        <source>The selected file is not a valid translation.</source>
-        <translation>所选的文件不是有效的翻译。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="392"/>
-        <source>%1 x %2</source>
-        <translation>%1 %2 x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="393"/>
-        <source>Primary screen resolution in pixels:</source>
-        <translation>以像素为单位的主屏幕分辨率︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/general_settings_page.cpp" line="397"/>
-        <source>Primary screen size in inches (diagonal):</source>
-        <translation>在英寸 （对角线） 的主屏幕大小︰</translation>
-    </message>
-</context>
-<context>
-    <name>Georeferencing</name>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="54"/>
-        <source>UTM</source>
-        <comment>UTM coordinate reference system</comment>
-        <translation>UTM</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
-        <source>UTM coordinates</source>
-        <translation>UTM 坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="58"/>
-        <source>UTM Zone (number north/south)</source>
-        <translation>UTM 区域 （编号南北）</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="65"/>
-        <source>Gauss-Krueger, datum: Potsdam</source>
-        <comment>Gauss-Krueger coordinate reference system</comment>
-        <translation>高斯-克鲁格、 基准︰ 波茨坦</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
-        <source>Gauss-Krueger coordinates</source>
-        <translation>高斯-克鲁格坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="69"/>
-        <source>Zone number (1 to 119)</source>
-        <comment>Zone number for Gauss-Krueger coordinates</comment>
-        <translation>区数 (1 到 119)</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="77"/>
-        <source>by EPSG code</source>
-        <comment>as in: The CRS is specified by EPSG code</comment>
-        <translation>通过对代码</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="79"/>
-        <source>EPSG @code@ coordinates</source>
-        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
-        <translation>对 @code @ 坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
-        <location filename="../src/core/georeferencing.cpp" line="555"/>
-        <source>Local coordinates</source>
-        <translation>局部坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="82"/>
-        <source>EPSG code</source>
-        <translation>对代码</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="89"/>
-        <source>Custom PROJ.4</source>
-        <comment>PROJ.4 specification</comment>
-        <translation>自定义 PROJ.4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/crs_template_implementation.cpp" line="93"/>
-        <source>Specification</source>
-        <comment>PROJ.4 specification</comment>
-        <translation>规格</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="251"/>
-        <source>Map scale specification invalid or missing.</source>
-        <translation>地图比例尺规范无效或丢失。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="257"/>
-        <source>Invalid grid scale factor: %1</source>
-        <translation>无效的网格尺度因子: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="294"/>
-        <location filename="../src/core/georeferencing.cpp" line="321"/>
-        <source>Unknown CRS specification language: %1</source>
-        <translation>未知的 CRS 规范语言: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="324"/>
-        <source>Unsupported geographic CRS specification: %1</source>
-        <translation>不受支持的地理 CRS 规格: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/georeferencing.cpp" line="546"/>
-        <source>Local</source>
-        <translation>本地</translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingDialog</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="111"/>
-        <source>Map Georeferencing</source>
-        <translation>地图地理参考坐标系</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="188"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Lookup...</source>
-        <translation>查找...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="148"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="149"/>
-        <source>m</source>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="222"/>
-        <source>Declination:</source>
-        <translation>赤纬︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="173"/>
-        <source>Projected coordinates</source>
-        <translation>投影的坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
-        <source>Status:</source>
-        <translation>状态︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="174"/>
-        <source>Geographic coordinates</source>
-        <translation>地理坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="169"/>
-        <source>Show reference point in:</source>
-        <translation>显示中的参考点︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="358"/>
-        <source>valid</source>
-        <translation>有效</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="352"/>
-        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;%1&quot;&gt; 开放&lt;/a&gt; |&lt;a href=&quot;%2&quot;&gt; O 地图世界&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="382"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="695"/>
-        <source>Online declination lookup</source>
-        <translation>在线的赤纬查找</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="115"/>
-        <source>Map coordinate reference system</source>
-        <translation>地图坐标参考系统</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="118"/>
-        <source>- local -</source>
-        <translation>-本地-</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="126"/>
-        <source>Grid scale factor:</source>
-        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
-        <translation>网格的缩放比例︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="129"/>
-        <source>Reference point</source>
-        <translation>参考点</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
-        <source>&amp;Pick on map</source>
-        <translation>与在地图上选择</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
-        <source>(Datum: WGS84)</source>
-        <translation>(基准︰ WGS84)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="136"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="137"/>
-        <source>mm</source>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="141"/>
-        <source>X</source>
-        <comment>x coordinate</comment>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
-        <source>Y</source>
-        <comment>y coordinate</comment>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="152"/>
-        <source>E</source>
-        <comment>west / east</comment>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
-        <source>N</source>
-        <comment>north / south</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="158"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="159"/>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
-        <source>°</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="162"/>
-        <source>N</source>
-        <comment>north</comment>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
-        <source>E</source>
-        <comment>east</comment>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="185"/>
-        <source>Map north</source>
-        <translation>北地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="205"/>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="88"/>
-        <source>&amp;Coordinate reference system:</source>
-        <translation>与参考坐标系︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="212"/>
-        <source>Map coordinates:</source>
-        <translation>地图坐标︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
-        <source>Geographic coordinates:</source>
-        <translation>地理坐标︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="217"/>
-        <source>On CRS changes, keep:</source>
-        <translation>CRS 的变化，保持︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="223"/>
-        <source>Grivation:</source>
-        <translation>Grivation:</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="383"/>
-        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
-        <translation>磁偏角为参考点 %1 %2 ° 现在将从 &lt;a href=&quot;%3&quot;&gt; %3&lt;/a&gt; 中检索。你想要继续吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>Declination change</source>
-        <translation>赤纬变化</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="462"/>
-        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
-        <translation>赤纬已被更改。你想要旋转地图内容因此，太吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="492"/>
-        <source>Local coordinates:</source>
-        <translation>局部坐标︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="519"/>
-        <source>Loading...</source>
-        <translation>正在加载...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
-        <source>locked</source>
-        <translation>已锁定</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="666"/>
-        <source>Could not parse data.</source>
-        <translation>不能分析数据。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="691"/>
-        <source>Declination value not found.</source>
-        <translation>找不到的赤纬值。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="696"/>
-        <source>The online declination lookup failed:
-%1</source>
-        <translation>在线的赤纬查找失败: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="524"/>
-        <source>%1 °</source>
-        <comment>degree value</comment>
-        <translation>%1 °</translation>
-    </message>
-</context>
-<context>
-    <name>GeoreferencingTool</name>
-    <message>
-        <location filename="../src/gui/georeferencing_dialog.cpp" line="724"/>
-        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
-        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置的参考点。&lt;b&gt;右键单击&lt;/b&gt;︰ 取消。</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenController</name>
-    <message>
-        <location filename="../src/gui/home_screen_controller.cpp" line="148"/>
-        <source>Welcome to OpenOrienteering Mapper!</source>
-        <translation>欢迎来到 OpenOrienteering 映射器 ！</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetDesktop</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="141"/>
-        <source>Activities</source>
-        <translation>活动</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="144"/>
-        <source>Create a new map ...</source>
-        <translation>创建一张新的地图...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="147"/>
-        <source>Open map ...</source>
-        <translation>打开地图...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="153"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
-        <source>Settings</source>
-        <translation>設定</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="156"/>
-        <source>About %1</source>
-        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
-        <translation>关于 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="159"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
-        <source>Help</source>
-        <translation>說明</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="162"/>
-        <source>Exit</source>
-        <translation>結束</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="182"/>
-        <source>Recent maps</source>
-        <translation>最近地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="207"/>
-        <source>Open most recently used file on start</source>
-        <translation>打开最近使用的文件启动</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="210"/>
-        <source>Clear list</source>
-        <translation>清除列表</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="229"/>
-        <source>Tip of the day</source>
-        <translation>每日提示</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="234"/>
-        <source>Show tip of the day</source>
-        <translation>显示每日提示</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="238"/>
-        <source>Previous</source>
-        <translation>上一页</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
-        <source>Next</source>
-        <translation>下一个</translation>
-    </message>
-</context>
-<context>
-    <name>HomeScreenWidgetMobile</name>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="332"/>
-        <source>Examples</source>
-        <translation>例子</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
-        <source>About Mapper</source>
-        <translation>关于映射器</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="459"/>
-        <source>File list</source>
-        <translation>文件列表</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="543"/>
-        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
-        <translation>没有找到的地图文件 ！ &lt;br/&gt; &lt;br/&gt;将地图文件复制到名为 &apos;OOMapper&apos; 在设备或存储卡上的顶级文件夹。</translation>
-    </message>
-</context>
-<context>
-    <name>ImportExport</name>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="245"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
-        <translation>加载在列行 %2%3 %1 类型的符号时的错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="253"/>
-        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
-        <translation>符号 ID &apos;%1&apos; 不是唯一的在行 %2 列 %3。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/symbol.cpp" line="301"/>
-        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
-        <translation>加载类型 %1 在 %2 线列 %3 的象征时出现错误: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="407"/>
-        <source>Error while loading an object of type %1.</source>
-        <translation>加载类型 %1 的对象时出现错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="471"/>
-        <source>Error while loading an object of type %1 at %2:%3: %4</source>
-        <translation>加载类型 %1 在 %2 的对象时出现错误: %3: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="439"/>
-        <source>Unable to find symbol for object at %1:%2.</source>
-        <translation>无法找到符号对象在 %1: %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object.cpp" line="451"/>
-        <source>Point object with undefined or wrong symbol at %1:%2.</source>
-        <translation>点对象未定义或错符号在 %1: %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="93"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="71"/>
-        <source>OpenOrienteering Mapper</source>
-        <translation>OpenOrienteering 映射器</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="60"/>
-        <source>OCAD Versions 7, 8</source>
-        <translation>OCAD 版本 7 8</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_format.cpp" line="32"/>
-        <source>OCAD</source>
-        <translation>遗漏</translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="199"/>
-        <location filename="../src/util/xml_stream_util.cpp" line="215"/>
-        <source>Could not parse the coordinates.</source>
-        <translation>无法解析坐标。</translation>
-    </message>
-    <message>
-        <location filename="../src/util/xml_stream_util.cpp" line="239"/>
-        <source>Expected %1 coordinates, found %2.</source>
-        <translation>预期的 %1 坐标，找到 %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="962"/>
-        <source>Error while loading the printing configuration at %1:%2: %3</source>
-        <translation>在 %1 的打印配置加载时出错: %2: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="1001"/>
-        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
-        <translation>撤消/重复加载时的错误步骤在 %1: %2: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="45"/>
-        <source>No such option: %1</source>
-        <comment>No such import / export option</comment>
-        <translation>没有这样的选项: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="291"/>
-        <source>Geospatial vector data</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Importer</name>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="75"/>
-        <source>Found an object without symbol.</source>
-        <translation>发现一个无符号的对象。</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/file_import_export.cpp" line="103"/>
-        <source>Dropped %n irregular object(s).</source>
-        <translation>
-            <numerusform>首字下沉 %n 不规则对象。</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="110"/>
-        <source>Error during symbol post-processing.</source>
-        <translation>符号后加工过程中的错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="138"/>
-        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
-        <translation>模板&quot;%1&quot;已从地图的目录而不是相对位置加载到它那里以前的映射文件。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="129"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="700"/>
-        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
-        <translation>未能加载模板&quot;%1&quot;，原因: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="146"/>
-        <source>Warnings when loading template &apos;%1&apos;:
-%2</source>
-        <translation>警告当加载模板 &apos;%1&apos;: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="156"/>
-        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
-        <source>At least one template file could not be found.</source>
-        <translation>找不到至少一个模板文件。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_import_export.cpp" line="159"/>
-        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
-        <translation>单击模板-模板安装窗口 &gt; 查找模板文件名称中的红色模板名称。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="124"/>
-        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
-        <translation>此文件使用过时的格式。支持这种格式是从中删除此程序很快。为了能在将来打开该文件，请重新保存。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="137"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="490"/>
-        <source>Invalid file format version.</source>
-        <translation>无效的文件格式版本。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="141"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
-        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
-        <translation>旧版本的文件格式不受支持。请使用较旧的程序版本加载和更新该文件。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="145"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
-        <translation>新版本的文件格式不受支持。一些地图功能将不会加载或保存此版本的程序。考虑更新。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="201"/>
-        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
-        <translation>地图的地理坐标参考系为&quot;%1&quot;。不支持此 CRS。使用&quot;%2&quot;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="319"/>
-        <source>Error while loading a symbol with type %2.</source>
-        <translation>%2 型加载符号时的错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="324"/>
-        <source>Error while loading a symbol.</source>
-        <translation>加载符号时的错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="396"/>
-        <source>Error while loading undo steps.</source>
-        <translation>装入撤消步骤时出错。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="406"/>
-        <source>Error while reading map part count.</source>
-        <translation>读取地图部分计数时出错。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/native_file_format.cpp" line="417"/>
-        <source>Error while loading map part %2.</source>
-        <translation>加载地图部分 %2 时出现错误。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2045"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2082"/>
-        <source>Could not read file: %1</source>
-        <translation>无法读取文件: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="484"/>
-        <source>Unsupported file format.</source>
-        <translation>不支持的文件格式。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="494"/>
-        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
-        <translation>新版本的文件格式不受支持。一些地图功能将不会加载或保存此版本的程序。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/file_format.cpp" line="74"/>
-        <source>Format (%1) does not support import</source>
-        <translation>格式 (%1) 不支持导入</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="412"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1281"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="1334"/>
-        <source>Could not read &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>LineSymbolSettings</name>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="308"/>
-        <source>Line settings</source>
-        <translation>行的设置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="73"/>
-        <source>Line width:</source>
-        <translation>线宽︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="74"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="89"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="197"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="213"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="546"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="571"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="574"/>
-        <source>mm</source>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
-        <source>Line color:</source>
-        <translation>线条颜色︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="88"/>
-        <source>Minimum line length:</source>
-        <translation>最小线长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
-        <source>Line cap:</source>
-        <translation>线帽︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
-        <source>flat</source>
-        <translation>平</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="94"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
-        <source>round</source>
-        <translation>一轮</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
-        <source>square</source>
-        <translation>广场</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
-        <source>pointed</source>
-        <translation>指出</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="102"/>
-        <source>Line join:</source>
-        <translation>线条联接︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="104"/>
-        <source>miter</source>
-        <translation>斜角</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
-        <source>bevel</source>
-        <translation>斜角</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="99"/>
-        <source>Cap length:</source>
-        <translation>帽长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
-        <source>Line is dashed</source>
-        <translation>线为虚线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="218"/>
-        <source>Show at least one mid symbol</source>
-        <translation>至少显示一个中期符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="221"/>
-        <source>Minimum mid symbol count:</source>
-        <translation>中旬符号计数的最低要求︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="224"/>
-        <source>Minimum mid symbol count when closed:</source>
-        <translation>中旬符号计数关闭时的最低要求︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="143"/>
-        <source>Dash length:</source>
-        <translation>短划线的长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="139"/>
-        <source>Dashed line</source>
-        <translation>虚线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="146"/>
-        <source>Break length:</source>
-        <translation>打破长度：</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
-        <source>Dashes grouped together:</source>
-        <translation>短划线组合在一起︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
-        <source>none</source>
-        <translation>没有一个</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
-        <source>2</source>
-        <translation>2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="153"/>
-        <source>3</source>
-        <translation>3</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
-        <source>4</source>
-        <translation>4</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
-        <source>In-group break length:</source>
-        <translation>圈内裂断长︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="160"/>
-        <source>Half length of first and last dash</source>
-        <translation>第一个和最后一个短划线的长度的一半</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="190"/>
-        <source>Mid symbols</source>
-        <translation>中期的符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
-        <source>Mid symbols per spot:</source>
-        <translation>每一地点的中期符号︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="196"/>
-        <source>Mid symbol distance:</source>
-        <translation>中期的符号距离︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="254"/>
-        <source>Borders</source>
-        <translation>边框</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="258"/>
-        <source>Different borders on left and right sides</source>
-        <translation>在左、 右两边的不同边框</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="263"/>
-        <source>Left border:</source>
-        <translation>左边的框︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="268"/>
-        <source>Right border:</source>
-        <translation>右边框︰</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1705"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="599"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1209"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Start symbol</source>
-        <translation>开始符号</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1709"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Mid symbol</source>
-        <translation>中期的符号</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1713"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1216"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>End symbol</source>
-        <translation>结束符号</translation>
-    </message>
-    <message>
-        <location filename="../src/core/symbols/line_symbol.cpp" line="1717"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="593"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1202"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="313"/>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="780"/>
-        <source>Dash symbol</source>
-        <translation>破折号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="112"/>
-        <source>Enable border lines</source>
-        <translation>使边框线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
-        <source>Distance between spots:</source>
-        <translation>点之间的距离︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="215"/>
-        <source>Distance from line end:</source>
-        <translation>线端的距离︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="288"/>
-        <source>Suppress the dash symbol at line start and line end</source>
-        <translation>在压制线的起点和终点线的划线标志</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="293"/>
-        <source>Scale the dash symbol at corners</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="539"/>
-        <source>Border width:</source>
-        <translation>边框宽度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="542"/>
-        <source>Border color:</source>
-        <translation>边框颜色︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="545"/>
-        <source>Border shift:</source>
-        <translation>边境的转变︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="548"/>
-        <source>Border is dashed</source>
-        <translation>虚线边框</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="570"/>
-        <source>Border dash length:</source>
-        <translation>边界划线长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="573"/>
-        <source>Border break length:</source>
-        <translation>边界断裂长度︰</translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="271"/>
-        <source>&amp;New</source>
-        <translation>与新</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="273"/>
-        <source>Create a new map</source>
-        <translation>创建一个新的映射</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="277"/>
-        <source>&amp;Open...</source>
-        <translation>与打开......</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="279"/>
-        <source>Open an existing file</source>
-        <translation>打开现有的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="283"/>
-        <source>Open &amp;recent</source>
-        <translation>开放与最近</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="294"/>
-        <source>&amp;Save</source>
-        <translation>与保存</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="299"/>
-        <source>Save &amp;as...</source>
-        <translation>保存与作为...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="301"/>
-        <source>Ctrl+Shift+S</source>
-        <translation>Ctrl + Shift + S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="307"/>
-        <source>Settings...</source>
-        <translation>设置。。。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="312"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="105"/>
-        <source>Close</source>
-        <translation>关闭</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="314"/>
-        <source>Close this file</source>
-        <translation>关闭此文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="318"/>
-        <source>E&amp;xit</source>
-        <translation>E &amp; xit</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="320"/>
-        <source>Exit the application</source>
-        <translation>退出应用程序</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="327"/>
-        <source>&amp;File</source>
-        <translation>与文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="346"/>
-        <source>General</source>
-        <translation>一般</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="361"/>
-        <source>Open &amp;Manual</source>
-        <translation>打开 &amp; 手册</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="362"/>
-        <source>Show the help file for this application</source>
-        <translation>显示此应用程序的帮助文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="366"/>
-        <source>&amp;About %1</source>
-        <translation>&amp; 大约 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="367"/>
-        <source>Show information about this application</source>
-        <translation>显示有关此应用程序的信息</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="371"/>
-        <source>About &amp;Qt</source>
-        <translation>关于与 qt 离散度</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="372"/>
-        <source>Show information about Qt</source>
-        <translation>显示有关 qt 离散度的信息</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="378"/>
-        <source>&amp;Help</source>
-        <translation>与帮助</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="558"/>
-        <source>Do you want to remove the autosaved version?</source>
-        <translation>你想要删除自动保存的版本？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="564"/>
-        <source>The file has been modified.
-Do you want to save your changes?</source>
-        <translation>该文件已被修改。
-你想要保存您的更改吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="399"/>
-        <source>Unsaved file</source>
-        <translation>未保存的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <location filename="../src/gui/main_window.cpp" line="972"/>
-        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="443"/>
-        <source>Warning</source>
-        <translation>警告</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="678"/>
-        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
-
-Do you want to scale the symbols to the selected scale?</source>
-        <translation>选定的比例尺是 1:%1，但选的符号集只有 1:%2 名义尺度。
-
-你想要缩放到选定的比例符号吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="747"/>
-        <source>Crash warning</source>
-        <translation>崩溃的警告</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="748"/>
-        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
-        <translation>看来这 %1 坠毁最后一次打开此文件时间: &lt; br / &gt; &lt;tt&gt;%2&lt;/tt&gt; &lt; br / &gt; &lt; br / &gt; 真的重新尝试打开它吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="939"/>
-        <source>Autosaving...</source>
-        <translation>自动保存...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="949"/>
-        <source>Autosaving failed!</source>
-        <translation>自动保存失败 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1024"/>
-        <source>All maps</source>
-        <translation>所有的地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1028"/>
-        <source>All files</source>
-        <translation>所有文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="716"/>
-        <source>Open file</source>
-        <translation>打开的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="153"/>
-        <source>You must close the current file before you can open another one.</source>
-        <translation>你可以打开另一个之前，必须关闭当前文件。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="728"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="686"/>
-        <source>Opening %1</source>
-        <translation>打开 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <location filename="../src/gui/main_window.cpp" line="1084"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="699"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="764"/>
-        <source>Cannot open file:
-%1
-
-File format not recognized.</source>
-        <translation>无法打开文件: %1 文件格式无法识别。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="841"/>
-        <source>The file has been modified.
-Do you want to discard your changes?</source>
-        <translation>该文件已被修改。
-你想要放弃您的更改吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="892"/>
-        <source>&amp;%1 %2</source>
-        <translation>与 %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="971"/>
-        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
-
-Press Yes to save in this format.
-Press No to choose a different format.</source>
-        <translation>这张地图是被保存为&quot;%1&quot;的文件。信息可能会丢失。
-
-按是保存为此格式。
-按无选择不同的格式。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1064"/>
-        <source>Save file</source>
-        <translation>保存文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1085"/>
-        <source>File could not be saved:</source>
-        <translation>无法保存文件︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1086"/>
-        <source>There was a problem in determining the file format.</source>
-        <translation>还有一个问题中确定的文件格式。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/main_window.cpp" line="1087"/>
-        <source>Please report this as a bug.</source>
-        <translation>请当作一个 bug 报告这。</translation>
-    </message>
-</context>
-<context>
-    <name>Map</name>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <location filename="../src/core/map.cpp" line="696"/>
-        <location filename="../src/core/map.cpp" line="720"/>
-        <location filename="../src/core/map.cpp" line="797"/>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3947"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="343"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="667"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because saving as %2 (.%3) is not supported.</source>
-        <translation>不能导出该映射为&quot;%1&quot;，因为另存为 %2 (.%3) 不受支持。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="662"/>
-        <source>Cannot export the map as
-&quot;%1&quot;
-because the format is unknown.</source>
-        <translation>不能导出该映射为&quot;%1&quot;，因为该格式是未知。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="703"/>
-        <location filename="../src/core/map.cpp" line="765"/>
-        <source>Warning</source>
-        <translation>警告</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="704"/>
-        <source>The map export generated warnings.</source>
-        <translation>地图出口将生成警告。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="685"/>
-        <source>Internal error while saving:
-%1</source>
-        <translation>保存时出现内部错误: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="766"/>
-        <source>The map import generated warnings.</source>
-        <translation>导入映射生成警告。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="721"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3948"/>
-        <source>Cannot open file:
-%1
-for reading.</source>
-        <translation>无法打开文件: %1 的阅读。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="735"/>
-        <source>Invalid file type.</source>
-        <translation>无效的文件类型。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="798"/>
-        <source>Cannot open file:
-%1
-
-%2</source>
-        <translation>无法打开文件: %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="697"/>
-        <source>Cannot save file
-%1:
-%2</source>
-        <translation>无法保存文件 %1: %2</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="825"/>
-        <source>Nothing to import.</source>
-        <translation>没有要导入。</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="834"/>
-        <source>Question</source>
-        <translation>问题</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="835"/>
-        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
-
-Rescale the imported data?</source>
-        <translation>导入的数据规模 1:%1 是从 1:%2 本地图规模不同。
-
-重新缩放导入的数据吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map.cpp" line="497"/>
-        <source>default part</source>
-        <translation>默认部分</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="34"/>
-        <location filename="../src/core/map_color.cpp" line="48"/>
-        <source>New color</source>
-        <translation>新颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
-        <source>Import...</source>
-        <translation type="unfinished">导入...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3954"/>
-        <source>Symbol replacement was canceled.
-Import the data anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapColor</name>
-    <message>
-        <location filename="../src/core/map_color.cpp" line="77"/>
-        <source>Registration black (all printed colors)</source>
-        <translation>注册黑色 （所有打印颜色）</translation>
-    </message>
-</context>
-<context>
-    <name>MapCoord</name>
-    <message>
-        <location filename="../src/core/map_coord.cpp" line="180"/>
-        <source>Coordinates are out-of-bounds.</source>
-        <translation>坐标是出界。</translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorController</name>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo</source>
-        <translation>撤消</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="853"/>
-        <source>Undo the last step</source>
-        <translation>撤消最后一步</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo</source>
-        <translation>重做</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="854"/>
-        <source>Redo the last step</source>
-        <translation>重做的最后一步</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="855"/>
-        <source>Cu&amp;t</source>
-        <translation>Cu&amp;t</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="856"/>
-        <source>C&amp;opy</source>
-        <translation>C 与复制</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
-        <source>&amp;Paste</source>
-        <translation>与粘贴</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="873"/>
-        <source>Zoom in</source>
-        <translation>放大</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="874"/>
-        <source>Zoom out</source>
-        <translation>缩小</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
-        <source>Toggle fullscreen mode</source>
-        <translation>切换全屏模式</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
-        <source>Set custom zoom factor...</source>
-        <translation>设置自定义的缩放因子......</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Symbol window</source>
-        <translation>符号窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
-        <source>Show/Hide the symbol window</source>
-        <translation>显示/隐藏符号窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Color window</source>
-        <translation>颜色窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
-        <source>Show/Hide the color window</source>
-        <translation>显示/隐藏颜色窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace the symbols with those from another map file</source>
-        <translation>符号替换那些来自另一个映射文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale all symbols...</source>
-        <translation>缩放所有符号...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
-        <source>Scale the whole symbol set</source>
-        <translation>缩放整个符号集</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change map scale...</source>
-        <translation>更改地图规模......</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="893"/>
-        <source>Change the map scale and adjust map objects and symbol sizes</source>
-        <translation>改变地图规模和调整地图对象和符号尺寸</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
-        <source>Map notes...</source>
-        <translation>注意到地图...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Template setup window</source>
-        <translation>模板安装程序窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
-        <source>Show/Hide the template window</source>
-        <translation>显示/隐藏模板窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="900"/>
-        <source>Open template...</source>
-        <translation>打开模板...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="875"/>
-        <source>Show whole map</source>
-        <translation>显示整个地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
-        <source>Edit objects</source>
-        <translation>编辑对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
-        <source>Set point objects</source>
-        <translation>设置点对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="908"/>
-        <source>Draw paths</source>
-        <translation>绘制路径</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
-        <source>Draw circles and ellipses</source>
-        <translation>绘制圆和椭圆</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
-        <source>Write text</source>
-        <translation>写入文本</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
-        <source>Duplicate</source>
-        <translation>重复</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
-        <source>Switch symbol</source>
-        <translation>开关符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
-        <source>Fill / Create border</source>
-        <translation>填充/创建边框</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
-        <source>Switch dash direction</source>
-        <translation>破折号方向切换</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
-        <source>Connect paths</source>
-        <translation>连接路径</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
-        <source>Cut object</source>
-        <translation>剪切对象</translation>
-    </message>
-    <message>
-        <source>Rotate object(s)</source>
-        <translation type="vanished">旋转对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="933"/>
-        <source>Measure lengths and areas</source>
-        <translation>测量长度和面积</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
-        <source>Cut away from area</source>
-        <translation>切离地区</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
-        <source>Merge area holes</source>
-        <translation>合并区孔</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="950"/>
-        <source>Paint on template settings</source>
-        <translation>画上模板设置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="956"/>
-        <source>Enable touch cursor</source>
-        <translation>启用触摸光标</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="957"/>
-        <source>Enable GPS display</source>
-        <translation>启用 GPS 显示</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="959"/>
-        <source>Enable GPS distance rings</source>
-        <translation>启用 GPS 距离环</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
-        <source>Set point object at GPS position</source>
-        <translation>在 GPS 定位设置点对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
-        <source>Set temporary marker at GPS position</source>
-        <translation>在 GPS 定位设置临时记号笔</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
-        <source>Create temporary path at GPS position</source>
-        <translation>在 GPS 位置创建临时路径</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
-        <source>Clear temporary GPS markers</source>
-        <translation>清除临时 GPS 标记</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="970"/>
-        <source>Enable compass display</source>
-        <translation>启用指南针显示</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
-        <source>Align map with north</source>
-        <translation>对齐与北地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="973"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3557"/>
-        <source>Add new part...</source>
-        <translation>添加新的部分...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3617"/>
-        <source>Rename current part...</source>
-        <translation>重命名当前部分...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3578"/>
-        <source>Remove current part</source>
-        <translation>删除当前部分</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="976"/>
-        <source>Merge all parts</source>
-        <translation>合并所有零件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
-        <source>Import...</source>
-        <translation>导入...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1030"/>
-        <location filename="../src/gui/widgets/color_list_widget.cpp" line="111"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
-        <source>&amp;Edit</source>
-        <translation>与编辑</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1051"/>
-        <source>&amp;View</source>
-        <translation>与视图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1080"/>
-        <source>&amp;Tools</source>
-        <translation>与工具</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1133"/>
-        <source>Sy&amp;mbols</source>
-        <translation>Sy &amp; mbols</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1115"/>
-        <source>M&amp;ap</source>
-        <translation>购 ap</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1145"/>
-        <source>&amp;Templates</source>
-        <translation>与模板</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1201"/>
-        <source>Drawing</source>
-        <translation>绘图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
-        <source>Paint on template</source>
-        <translation>在模板上画</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>Editing in progress</source>
-        <translation>在进展中编辑</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="546"/>
-        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
-        <translation>当前正在编辑的地图。请完成编辑操作然后再进行保存。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="551"/>
-        <source>Map saved</source>
-        <translation>保存地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="867"/>
-        <source>Show grid</source>
-        <translation>显示网格</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="868"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1176"/>
-        <source>Configure grid...</source>
-        <translation>配置网格...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
-        <source>Hatch areas</source>
-        <translation>剖面线区域</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
-        <source>Baseline view</source>
-        <translation>基线视图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="100"/>
-        <source>Hide all templates</source>
-        <translation>隐藏所有模板</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="887"/>
-        <source>Replace symbol set...</source>
-        <translation>替换符号集...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
-        <source>Georeferencing...</source>
-        <translation>小基......</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate map...</source>
-        <translation>旋转地图...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="894"/>
-        <source>Rotate the whole map</source>
-        <translation>旋转整个地图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
-        <source>Reopen template...</source>
-        <translation>重新打开模板...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Tag editor</source>
-        <translation>标签编辑器</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="903"/>
-        <source>Show/Hide the tag editor window</source>
-        <translation>显示/隐藏标记编辑器窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
-        <source>Draw rectangles</source>
-        <translation>绘制矩形</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
-        <source>Draw free-handedly</source>
-        <translation>单枪匹马的自由绘制</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
-        <source>Fill bounded areas</source>
-        <translation>填充有界的区域</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
-        <source>Cut free form hole</source>
-        <translation>挖了自由形式</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
-        <source>Cut round hole</source>
-        <translation>切圆孔</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="923"/>
-        <source>Cut rectangular hole</source>
-        <translation>剪切矩形孔</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="931"/>
-        <source>Rotate pattern</source>
-        <translation>旋转模式</translation>
-    </message>
-    <message>
-        <source>Scale object(s)</source>
-        <translation type="vanished">规模对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
-        <source>Unify areas</source>
-        <translation>统一的领域</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
-        <source>Intersect areas</source>
-        <translation>相交区域</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
-        <source>Area XOr</source>
-        <translation>异或地区</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
-        <source>Cutout</source>
-        <translation>剪影</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
-        <source>Cut away</source>
-        <translation>切掉了</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
-        <source>Distribute points along path</source>
-        <translation>分发点沿路径</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
-        <source>Map coordinates</source>
-        <translation>地图坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
-        <source>Projected coordinates</source>
-        <translation>投影的坐标</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
-        <source>Latitude/Longitude (Dec)</source>
-        <translation>经纬度 （12 月）</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
-        <source>Latitude/Longitude (DMS)</source>
-        <translation>经纬度 (DMS)</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1065"/>
-        <source>Display coordinates as...</source>
-        <translation>显示坐标作为...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
-        <source>Cut hole</source>
-        <translation>挖洞</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="794"/>
-        <source>Ctrl+A</source>
-        <translation>按 Ctrl + A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="795"/>
-        <source>Ctrl+Shift+A</source>
-        <translation>Ctrl + Shift + A</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="796"/>
-        <source>Ctrl+I</source>
-        <translation>Ctrl + I</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="811"/>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="812"/>
-        <source>L</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="813"/>
-        <source>S</source>
-        <translation>S</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="814"/>
-        <source>P</source>
-        <translation>P</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
-        <source>O</source>
-        <translation>O</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
-        <source>Ctrl+R</source>
-        <translation>Ctrl + R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
-        <source>T</source>
-        <translation>T</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
-        <source>Ctrl+G</source>
-        <translation>Ctrl + G</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
-        <source>Ctrl+F</source>
-        <translation>Ctrl + F</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="823"/>
-        <source>Ctrl+D</source>
-        <translation>按 Ctrl + D</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
-        <source>C</source>
-        <translation>C</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
-        <source>R</source>
-        <translation>R</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
-        <source>Z</source>
-        <translation>Z</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
-        <source>K</source>
-        <translation>K</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
-        <source>M</source>
-        <translation>M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
-        <source>U</source>
-        <translation>U</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
-        <source>N</source>
-        <translation>N</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
-        <source>Ctrl+M</source>
-        <translation>Ctrl + M</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
-        <source>Select all</source>
-        <translation>选择所有</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
-        <source>Select nothing</source>
-        <translation>不选择任何内容</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
-        <source>Invert selection</source>
-        <translation>反向选择</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Symbol set ID...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
-        <source>Edit the symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Load CRT file...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
-        <source>Assign new symbols by cross-reference table</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tag Selection</source>
-        <translation type="vanished">标记选择</translation>
-    </message>
-    <message>
-        <source>Show/Hide the tag selection window</source>
-        <translation type="vanished">显示/隐藏标记选择窗口</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position</source>
-        <translation>副本位置</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="998"/>
-        <source>Copy position to clipboard.</source>
-        <translation>将位置复制到剪贴板。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1169"/>
-        <source>View</source>
-        <translation>视图</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1187"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1192"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3492"/>
-        <source>Map parts</source>
-        <translation>地图部分</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1219"/>
-        <source>Select template...</source>
-        <translation>选择模板...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1225"/>
-        <source>Editing</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1250"/>
-        <source>Advanced editing</source>
-        <translation>高级编辑</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1277"/>
-        <source>Select symbol</source>
-        <translation>选择符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1317"/>
-        <source>Hide top bar</source>
-        <translation>隐藏顶栏</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1320"/>
-        <source>Show top bar</source>
-        <translation>显示顶部栏</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1585"/>
-        <source>Print / Export is not available in this program version!</source>
-        <translation>打印 / 导出此程序版本中不可用 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1605"/>
-        <source>No undo steps available.</source>
-        <translation>没有可用的撤消步骤。</translation>
-    </message>
-    <message>
-        <source>Cut %1 object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation type="vanished">切断 %1 对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1662"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="1695"/>
-        <source>An internal error occurred, sorry!</source>
-        <translation>发生内部错误，抱歉 ！</translation>
-    </message>
-    <message>
-        <source>Copied %1 object(s)</source>
-        <translation type="vanished">复制 %1 对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1682"/>
-        <source>There are no objects in clipboard which could be pasted!</source>
-        <translation>可以粘贴的剪贴板中没有对象 ！</translation>
-    </message>
-    <message>
-        <source>Pasted %1 object(s)</source>
-        <translation type="vanished">粘贴的 %1 对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Set custom zoom factor</source>
-        <translation>设置自定义的缩放因子</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1770"/>
-        <source>Zoom factor:</source>
-        <translation>缩放因子︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1844"/>
-        <source>Symbols</source>
-        <translation>符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1858"/>
-        <source>Colors</source>
-        <translation>颜色</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1879"/>
-        <source>Symbol set ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1880"/>
-        <source>Edit the symbol set ID:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale all symbols</source>
-        <translation>缩放所有符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1907"/>
-        <source>Scale to percentage:</source>
-        <translation>按百分比缩放︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1931"/>
-        <source>Map notes</source>
-        <translation>地图说明</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1936"/>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1937"/>
-        <source>OK</source>
-        <translation>还行</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1977"/>
-        <source>Templates</source>
-        <translation>模板</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2039"/>
-        <source>Tag Editor</source>
-        <translation>标签编辑器</translation>
-    </message>
-    <message>
-        <source>Tag Selector</source>
-        <translation type="vanished">标签选择器</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2102"/>
-        <source>No
-symbol
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation>没有选定的符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2103"/>
-        <source>Multiple
-symbols
-selected</source>
-        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
-        <translation>选定的多个符号</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Place point objects on the map.</source>
-        <translation>在地图上放置点对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2191"/>
-        <source>Select a point symbol to be able to use this tool.</source>
-        <translation>选择一个点符号，以便能够使用此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <source>Draw polygonal and curved lines.</source>
-        <translation>绘制多边形和曲线。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2193"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Select a line, area or combined symbol to be able to use this tool.</source>
-        <translation>选择线条、 地区或联合的象征，必须能够使用此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
-        <source>Draw circles and ellipses.</source>
-        <translation>绘制圆和椭圆。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
-        <source>Draw paths free-handedly.</source>
-        <translation>绘制路径免费单枪匹马。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
-        <source>Fill bounded areas.</source>
-        <translation>填充有界的区域。</translation>
-    </message>
-    <message>
-        <source>Deletes the selected object(s).</source>
-        <translation type="vanished">删除所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Set the direction of area fill patterns or point objects.</source>
-        <translation>设置区域的方向填充图案或点对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2306"/>
-        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
-        <translation>选择区域对象与旋转填充图案或要激活此工具可旋转点对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2336"/>
-        <source>Resulting symbol: %1 %2.</source>
-        <translation>生成的符号: %1 %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2337"/>
-        <source>Select at least two area or path objects activate this tool.</source>
-        <translation>选择至少两个区域或路径对象激活此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2339"/>
-        <source>Unify overlapping objects.</source>
-        <translation>统一重叠对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
-        <source>Remove all parts which are not overlaps with the first selected object.</source>
-        <translation>删除不是重叠与第一个选定对象的所有部分。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
-        <source>Remove overlapped parts of the first selected object.</source>
-        <translation>删除第一个选定对象的重叠的部分。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
-        <source>Remove all parts which overlap the first selected object.</source>
-        <translation>删除重叠的第一个选定的对象的所有部分。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
-        <translation>将地区孔合并在一起，或合并对象边界裁剪这一部分孔。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
-        <source>Select one area object with holes to activate this tool.</source>
-        <translation>选择一个区域对象与孔来激活此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <source>Create a cutout of some objects or the whole map.</source>
-        <translation>创建某些对象或整个地图的一个保险开关。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2354"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Select a closed path object as cutout shape to activate this tool.</source>
-        <translation>作为抠出形状来激活此工具选择一个封闭的路径对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2356"/>
-        <source>Cut away some objects or everything in a limited area.</source>
-        <translation>砍掉某些对象或一个有限的区域中的所有内容。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Places evenly spaced point objects along an existing path object</source>
-        <translation>点对象沿现有路径对象间隔均匀的地方</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2375"/>
-        <source>Select at least one path object and a single point symbol to activate this tool.</source>
-        <translation>选择至少一个路径对象和一个单点符号来激活此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3100"/>
-        <source>Merging holes failed.</source>
-        <translation>合并孔失败。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Clear temporary markers</source>
-        <translation>清除临时标记</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3384"/>
-        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
-        <translation>你确定你想要删除所有临时 GPS 标记？这不能撤消。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3498"/>
-        <source>Merge this part with</source>
-        <translation>合并与这部分</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3504"/>
-        <source>Move selected objects to</source>
-        <translation>移动到所选的对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3558"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3618"/>
-        <source>Enter the name of the map part:</source>
-        <translation>输入地图部分的名称︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3634"/>
-        <source>Switched to map part &apos;%1&apos;.</source>
-        <translation>切换到地图部分 &apos;%1&apos;。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3656"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="3688"/>
-        <source>Merge map parts</source>
-        <translation>合并地图部分</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3657"/>
-        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
-        <translation>你想要将所有对象从地图部分&quot;%1&quot;都移动到&quot;%2&quot;，并删除&quot;%1&quot;吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3689"/>
-        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
-        <translation>你想要移动所有对象映射部分&quot;%1&quot;，并删除所有其他地图部分吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3914"/>
-        <source>Cannot import the selected map file because it could not be loaded.</source>
-        <translation>无法导入所选的映射文件，因为它不能被加载。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
-        <source>Draw rectangles.</source>
-        <translation>绘制矩形。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="841"/>
-        <source>Print...</source>
-        <translation>打印......</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="843"/>
-        <source>&amp;Image</source>
-        <translation>与图像</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
-        <source>&amp;PDF</source>
-        <translation>&amp; PDF</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear undo / redo history</source>
-        <translation>清除撤消/重做历史</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
-        <source>Clear the undo / redo history to reduce map file size.</source>
-        <translation>清楚的撤消/重做历史记录为了减少地图文件大小。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
-        <source>Pan</source>
-        <translation>潘</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="882"/>
-        <source>Overprinting simulation</source>
-        <translation>叠印模拟</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="906"/>
-        <source>Edit lines</source>
-        <translation>编辑行</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
-        <source>Convert to curves</source>
-        <translation>转换为曲线</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
-        <source>Simplify path</source>
-        <translation>简化路径</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1022"/>
-        <source>&amp;Export as...</source>
-        <translation>与作为出口...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Write text on the map.</source>
-        <translation>在地图上写的文本。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
-        <source>Select a text symbol to be able to use this tool.</source>
-        <translation>选择一个文本符号，以便能够使用此工具。</translation>
-    </message>
-    <message>
-        <source>Duplicate the selected object(s).</source>
-        <translation type="vanished">复制所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Select at least one object to activate this tool.</source>
-        <translation>选择至少一个对象来激活此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <source>Switch the direction of symbols on line objects.</source>
-        <translation>切换行对象的符号的方向。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Select at least one line object to activate this tool.</source>
-        <translation>选择至少一个要激活此工具的线对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2312"/>
-        <source>Connect endpoints of paths which are close together.</source>
-        <translation>将终结点的路径，都是紧密连接。</translation>
-    </message>
-    <message>
-        <source>Cut the selected object(s) into smaller parts.</source>
-        <translation type="vanished">剪切所选的对象分成较小部分。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Select at least one line or area object to activate this tool.</source>
-        <translation>选择至少一个线或区域的对象来激活此工具。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Cut a hole into the selected area object.</source>
-        <translation>剪一个洞到选定的区域的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2325"/>
-        <source>Select a single area object to activate this tool.</source>
-        <translation>选择要激活此工具的单个区域对象。</translation>
-    </message>
-    <message>
-        <source>Rotate the selected object(s).</source>
-        <translation type="vanished">旋转所选的对象。</translation>
-    </message>
-    <message>
-        <source>Scale the selected object(s).</source>
-        <translation type="vanished">缩放所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <source>Turn paths made of straight segments into smooth bezier splines.</source>
-        <translation>轮到路径的直线段做成光滑贝塞尔样条。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2318"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Select a path object to activate this tool.</source>
-        <translation>选择要激活此工具的路径对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
-        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
-        <translation>减少路径对象的点的数量，同时设法留住他们的形状。</translation>
-    </message>
-    <message>
-        <source>Switches the symbol of the selected object(s) to the selected symbol.</source>
-        <translation type="vanished">将所选对象的符号切换到所选符号。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
-        <translation>选择至少一个对象和一个拟合、 不同的符号来激活此工具。</translation>
-    </message>
-    <message>
-        <source>Fill the selected line(s) or create a border for the selected area(s).</source>
-        <translation type="vanished">填充选定的线路或创建选取区域的边框。</translation>
-    </message>
-    <message>
-        <source>%1 object(s) duplicated</source>
-        <translation type="vanished">%1 对象复制</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>Object selection</source>
-        <translation>选取对象</translation>
-    </message>
-    <message>
-        <source>No objects were selected because there are no objects with the selected symbol(s).</source>
-        <translation type="vanished">因为没有与所选符号的对象选择的对象没有。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3059"/>
-        <source>Measure</source>
-        <translation>措施</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3073"/>
-        <source>Unification failed.</source>
-        <translation>失败的统一。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3079"/>
-        <source>Intersection failed.</source>
-        <translation>失败的十字路口。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3085"/>
-        <source>Difference failed.</source>
-        <translation>失败的差异。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3091"/>
-        <source>XOr failed.</source>
-        <translation>异或失败。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3579"/>
-        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
-        <translation>你想要删除地图部分&quot;%1&quot;及其所有对象吗？</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3743"/>
-        <source>Paint free-handedly on a template</source>
-        <translation>自由-单枪匹马在模板上画</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3745"/>
-        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
-        <translation>自由-单枪匹马在模板上油漆。创建或加载一个模板，可以上绘制以激活此按钮</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3874"/>
-        <source>Import %1, GPX, OSM or DXF file</source>
-        <translation>%1，GPX，OSM 或 DXF 文件导入</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>Importable files</source>
-        <translation>可导入文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
-        <source>All files</source>
-        <translation>所有文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="3907"/>
-        <source>Cannot import the selected file because its file format is not supported.</source>
-        <translation>无法导入所选的文件，因为其文件格式不受支持。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="930"/>
-        <source>Rotate objects</source>
-        <translation>旋转对象</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="932"/>
-        <source>Scale objects</source>
-        <translation>缩放对象</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1619"/>
-        <source>Cut %n object(s)</source>
-        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
-        <translation>
-            <numerusform>切 %n 对象</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1672"/>
-        <source>Copied %n object(s)</source>
-        <translation>
-            <numerusform>%N 复制的对象</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="1712"/>
-        <source>Pasted %n object(s)</source>
-        <translation>
-            <numerusform>%N 粘贴的对象</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2295"/>
-        <source>Deletes the selected objects.</source>
-        <translation>删除所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2297"/>
-        <source>Duplicate the selected objects.</source>
-        <translation>复制选定的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
-        <source>Rotate the selected objects.</source>
-        <translation>旋转所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
-        <source>Scale the selected objects.</source>
-        <translation>缩放所选的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
-        <source>Cut the selected objects into smaller parts.</source>
-        <translation>切成更小的部分选定的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2370"/>
-        <source>Switches the symbol of the selected objects to the selected symbol.</source>
-        <translation>切换到所选符号的所选对象的符号。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2372"/>
-        <source>Fill the selected lines or create a border for the selected areas.</source>
-        <translation>创建所选区域的边框或填充选定的行。</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gui/map/map_editor.cpp" line="2491"/>
-        <source>Duplicated %n object(s)</source>
-        <translation>
-            <numerusform>%N 重复的对象</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="2701"/>
-        <source>No objects were selected because there are no objects with the selected symbols.</source>
-        <translation>未选中对象因为没有对象与选定的符号。</translation>
-    </message>
-</context>
-<context>
-    <name>MapEditorTool</name>
-    <message>
-        <location filename="../src/templates/template_adjust.cpp" line="617"/>
-        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1224"/>
-        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
-        <location filename="../src/tools/draw_freehand_tool.cpp" line="288"/>
-        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
-        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 中止。 </translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1243"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="718"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
-        <location filename="../src/tools/edit_point_tool.cpp" line="761"/>
-        <source>More: %1, %2</source>
-        <translation>更多: %1、 %2</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1240"/>
-        <location filename="../src/tools/edit_line_tool.cpp" line="535"/>
-        <source>More: %1</source>
-        <translation>更多: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/tools/draw_path_tool.cpp" line="1246"/>
-        <location filename="../src/tools/draw_rectangle_tool.cpp" line="717"/>
-        <source>More: %1, %2, %3</source>
-        <translation>更多: %1、 %2 和 %3</translation>
-    </message>
-</context>
-<context>
-    <name>MapFindFeature</name>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="53"/>
-        <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="60"/>
-        <source>Find &amp;next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="90"/>
-        <source>Find objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="97"/>
-        <source>&amp;Find next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="100"/>
-        <source>Find &amp;all</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="103"/>
-        <source>Query editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapPrinter</name>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="487"/>
-        <source>- Map -</source>
-        <translation>-地图-</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1238"/>
-        <source>Processing separations of page %1...</source>
-        <translation>分色处理的页 %1...</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1239"/>
-        <source>Processing page %1...</source>
-        <translation>处理页 %1...</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1289"/>
-        <source>Canceled</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1293"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/core/map_printer.cpp" line="1298"/>
-        <source>Finished</source>
-        <translation>完成</translation>
-    </message>
-</context>
-<context>
-    <name>MapSymbolTranslation</name>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="272"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="81"/>
-        <source>Text source:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="514"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="323"/>
-        <source>Map (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="515"/>
-        <location filename="../src/gui/color_dialog.cpp" line="530"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="324"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="337"/>
-        <source>undefined language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="533"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="340"/>
-        <source>Translation (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="585"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="214"/>
-        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/color_dialog.cpp" line="592"/>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="221"/>
-        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MapWidget</name>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="578"/>
-        <source>%1x</source>
-        <comment>Zoom factor</comment>
-        <translation>%1 x</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="600"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="616"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="653"/>
-        <source>Error</source>
-        <translation>错误</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="835"/>
-        <source>Empty map!
-
-Start by defining some colors:
-Select Symbols -&gt; Color window to
-open the color dialog and
-define the colors there.</source>
-        <translation>空的地图 ！
-
-首先定义一些颜色︰ 选择符号-&gt; 颜色窗口打开颜色对话框并定义那里的颜色。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
-        <source>No symbols!
-
-Now define some symbols:
-Right-click in the symbol bar
-and select &quot;New symbol&quot;
-to create one.</source>
-        <translation>没有符号 ！
-
-现在定义一些符号︰ 符号栏中用鼠标右键单击并选择&quot;新符号&quot;来创建一个。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Ready to draw!
-
-Start drawing or load a base map.
-To load a base map, click
-Templates -&gt; Open template...</source>
-        <translation>准备好画 ！
-
-开始绘制或加载底图。
-若要加载底图，单击模板-&gt; 打开模板...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
-        <source>Hint: Hold the middle mouse button to drag the map,
-zoom using the mouse wheel, if available.</source>
-        <translation>提示︰ 按住鼠标按钮拖动地图，使用鼠标滚轮缩放如果可用。</translation>
-    </message>
-</context>
-<context>
-    <name>MeasureWidget</name>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="96"/>
-        <source>Boundary length:</source>
-        <translation>边界长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="134"/>
-        <source>Length:</source>
-        <translation>长度︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="112"/>
-        <source>Area:</source>
-        <translation>区域︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="59"/>
-        <source>No object selected.</source>
-        <translation>没有选定的对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="63"/>
-        <source>%1 objects selected.</source>
-        <translation>选择 %1 对象。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="73"/>
-        <source>The selected object is not a path.</source>
-        <translation>所选的对象不是一个路径。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="97"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="135"/>
-        <source>mm</source>
-        <comment>millimeters</comment>
-        <translation>毫米</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
-        <source>m</source>
-        <comment>meters</comment>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="113"/>
-        <source>mm²</source>
-        <comment>square millimeters</comment>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
-        <source>m²</source>
-        <comment>square meters</comment>
-        <translation>m ²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="126"/>
-        <source>This object is too small.</source>
-        <translation>此对象是太小了。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>The minimimum area is %1 %2.</source>
-        <translation>管网地区是 %1 %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="127"/>
-        <source>mm²</source>
-        <translation>mm²</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="130"/>
-        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
-        <translation>注︰ 边界长度和面积是正确的才有没有自交和孔同样地使用。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="148"/>
-        <source>This line is too short.</source>
-        <translation>这条线是太短。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>The minimum length is %1 %2.</source>
-        <translation>最小长度是 %1 %2。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/widgets/measure_widget.cpp" line="149"/>
-        <source>mm</source>
-        <translation>毫米</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="64"/>
-        <source>Create new map</source>
-        <translation>创建新的映射</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="68"/>
-        <source>Choose the scale and symbol set for the new map.</source>
-        <translation>选择的规模和符号集的新地图。</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="75"/>
-        <source>Scale:  1 : </source>
-        <translation>规模︰ 1: </translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="80"/>
-        <source>Symbol sets:</source>
-        <translation>符号集︰</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="85"/>
-        <source>Only show symbol sets matching the selected scale</source>
-        <translation>只显示符号集的选定的规模相匹配</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">取消</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="93"/>
-        <source>Create</source>
-        <translation>创建</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="169"/>
-        <source>Empty symbol set</source>
-        <translation>空符号集</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="207"/>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
-        <source>Load symbol set from a file...</source>
-        <translation>从文件中加载符号集...</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="258"/>
-        <source>All symbol set files</source>
-        <translation>所有符号设置的文件</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
-        <source>All files</source>
-        <translation>所有文件</translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileExport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1557"/>
-        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
-        <translation>映射包含 256 种以上颜色的强迫症版本 8 中找不到支持。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1561"/>
-        <source>libocad returned %1</source>
-        <translation>libocad 返回 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1606"/>
-        <source>Registration black is exported as a regular color.</source>
-        <translation>注册黑色导出为定期的颜色。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1714"/>
-        <source>Unable to export fill pattern shift for an area object</source>
-        <translation>无法导出区域对象的填充模式转变</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1864"/>
-        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
-        <translation>无法导出模板:&quot;%1&quot;的文件类型尚不支持</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1887"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1898"/>
-        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1909"/>
-        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2180"/>
-        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
-        <translation>在行的符号&quot;%1&quot;，不能代表帽/联接组合。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2204"/>
-        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
-        <translation>行中的符号&quot;%1&quot;，忽视了短跑分组。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2215"/>
-        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
-        <translation>线符号&quot;%1&quot;，在有了破折号在一群数目减少到 2。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2271"/>
-        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
-        <translation>在行的符号&quot;%1&quot;，不能正确导出边界。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2330"/>
-        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
-        <translation>在地区的符号&quot;%1&quot;，跳过填充图案。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2377"/>
-        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
-        <translation>在地区的符号&quot;%1&quot;，假设&quot;转移的行&quot;点模式。这可能是正确的以及不正确。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2416"/>
-        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation>在文本中的符号 %1︰ 设置自定义字符间距，其执行尚未不符遗漏的行为</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2423"/>
-        <source>In text symbol %1: ignoring underlining</source>
-        <translation>在文本中的符号 %1︰ 忽略下划线</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
-        <source>In text symbol %1: ignoring kerning</source>
-        <translation>在文本中的符号 %1︰ 忽略字偶间距调整</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2849"/>
-        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
-        <translation>字符串被截断 (截断标记三个 &apos; |&apos;): %1</translation>
-    </message>
-</context>
-<context>
-    <name>OCAD8FileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="116"/>
-        <source>Could not allocate buffer.</source>
-        <translation>无法分配缓冲区。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
-        <source>libocad returned %1</source>
-        <translation>libocad 返回 %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="123"/>
-        <source>OCAD files of version %1 are not supported!</source>
-        <translation>不支持 OCAD 文件的版本是 %1 ！</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="147"/>
-        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
-        <translation>
-            <numerusform>%n 颜色 separation(s) 被跳过，原因︰ 导入已禁用。</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="152"/>
-        <source>Could not load the spot color definitions, error: %1</source>
-        <translation>不能加载专色定义，错误: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="213"/>
-        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
-        <translation>作为特殊的颜色，导入颜色&quot;注册黑&quot;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="277"/>
-        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
-        <translation>无法导入符号&quot;%3&quot;(%1.%2)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="290"/>
-        <source>OCAD import layer</source>
-        <translation>OCAD 导入图层</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="430"/>
-        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
-        <translation>在虚线符号 %1，尖尖的帽长度为开始和结束都不同 （%2 和 %3）。使用 %4。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="447"/>
-        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
-        <translation>在虚线符号 %1，末端长度不能正确导入。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
-        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
-        <translation>在虚线符号 %1，结束差距无法正确导入。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="458"/>
-        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
-        <translation>在虚线符号 %1，主要和结束长度是不同 （%2 和 %3）。使用 %4。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="468"/>
-        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
-        <translation>在虚线符号 %1，D 和 E 的差距是不同 （%2 和 %3）。使用 %4。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="618"/>
-        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
-        <translation>线符号 %1︰ 抑制线两端破折号。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="756"/>
-        <source>During import of text symbol %1: ignoring justified alignment</source>
-        <translation>文本导入过程中符号 %1︰ 忽略两端的对齐</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="762"/>
-        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
-        <translation>文本导入过程中符号 %1︰ 忽略自定义权重 (%2)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="767"/>
-        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
-        <translation>文本导入过程中符号 %1︰ 设置自定义字符间距，其执行尚未不符遗漏的行为</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="772"/>
-        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
-        <translation>文本导入过程中符号 %1︰ 忽略自定义单词间距 （%2%)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="777"/>
-        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
-        <translation>文本导入过程中符号 %1︰ 忽略自定义缩进 (%2 / 3%)</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="798"/>
-        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
-        <translation>文本导入过程中符号 %1︰ 忽略文本框架 （模式 %2）</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="952"/>
-        <source>Unable to load object</source>
-        <translation>无法加载对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="959"/>
-        <source>Unable to import rectangle object</source>
-        <translation>无法导入矩形对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1006"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation>不导入文本符号，找不出路径 &apos; (npts = %1): %2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1198"/>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1305"/>
-        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
-        <translation>无法导入模板︰ 背景&quot;%1&quot;似乎不是一个光栅图像</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1410"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation>尝试导入具有未知坐标格式的文本对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1521"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation>找不到的颜色 id: %1，无视这种颜色</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectQuery</name>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="293"/>
-        <source>is</source>
-        <extracomment>Very short label</extracomment>
-        <translation>是</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="296"/>
-        <source>is not</source>
-        <extracomment>Very short label</extracomment>
-        <translation>不是</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="299"/>
-        <source>contains</source>
-        <extracomment>Very short label</extracomment>
-        <translation>包含</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="302"/>
-        <source>Search</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="305"/>
-        <source>Text</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished">文本</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="309"/>
-        <source>and</source>
-        <extracomment>Very short label</extracomment>
-        <translation>和</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="312"/>
-        <source>or</source>
-        <extracomment>Very short label</extracomment>
-        <translation>或</translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="316"/>
-        <source>Symbol</source>
-        <extracomment>Very short label</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/objects/object_query.cpp" line="320"/>
-        <source>invalid</source>
-        <extracomment>Very short label</extracomment>
-        <translation>无效</translation>
-    </message>
-</context>
-<context>
-    <name>OcdFileImport</name>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="127"/>
-        <source>In line symbol %1 &apos;%2&apos;: %3</source>
-        <translation>线符号 %1 &apos;%2&apos; 中: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="133"/>
-        <source>In text symbol %1 &apos;%2&apos;: %3</source>
-        <translation>在文本符号 %1 &apos;%2&apos;: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="391"/>
-        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
-        <translation>无法加载坐标参照系统 &apos;%1&apos;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="425"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="432"/>
-        <source>Spot color information was ignored.</source>
-        <translation>专色信息被忽略了。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="560"/>
-        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
-        <translation>无法导入符号 %1.%2&quot;%3&quot;: %4</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="564"/>
-        <source>Unsupported type &quot;%1&quot;.</source>
-        <translation>不支持的类型&quot;%1&quot;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="657"/>
-        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
-        <translation>无法导入模板:&quot;%1&quot;不是一种支持的模板类型。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="905"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="967"/>
-        <source>Unsupported line style &apos;%1&apos;.</source>
-        <translation>不受支持的线条样式 &apos;%1&apos;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1004"/>
-        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
-        <translation>不支持不同长度的尖帽 （%1 毫米） 开始和结尾 （%2 毫米）。使用 %3 毫米。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1020"/>
-        <source>The dash pattern cannot be imported correctly.</source>
-        <translation>短划线图案无法正确导入。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1035"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1067"/>
-        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation>短划线图案末端长度 （%1 毫米） 无法正确导入。使用 %2 毫米。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1042"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1082"/>
-        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
-        <translation>短划线图案结束间隙 （%1 毫米） 无法正确导入。使用 %2 毫米。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1124"/>
-        <source>Unsupported framing line style &apos;%1&apos;.</source>
-        <translation>不支持的帧线条样式 &apos;%1&apos;。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1196"/>
-        <source>Skipped secondary point symbol.</source>
-        <translation>跳过二次点符号。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1232"/>
-        <source>Suppressing dash symbol at line ends.</source>
-        <translation>抑制破折号在行结束。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="948"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1301"/>
-        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
-        <translation>这个符号不能再保存为相应的强迫症符号。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1956"/>
-        <source>Justified alignment is not supported.</source>
-        <translation>不支持两端的对齐。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1971"/>
-        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
-        <translation>垂直对齐方式 &apos;%1&apos; 不受支持。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1943"/>
-        <source>Ignoring custom weight (%1).</source>
-        <translation>忽略自定义权重 (%1)。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1980"/>
-        <source>Custom character spacing may be incorrect.</source>
-        <translation>自定义字符间距可能不正确。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1985"/>
-        <source>Ignoring custom word spacing (%1 %).</source>
-        <translation>忽略自定义单词间距 （%1%）。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2009"/>
-        <source>Ignoring custom indents (%1/%2).</source>
-        <translation>忽略自定义缩进 (%1 / %2)。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2031"/>
-        <source>Ignoring text framing (mode %1).</source>
-        <translation>忽略文本框架 （模式 %1）。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1390"/>
-        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
-        <translation>尚不支持行文本符号。标记为隐藏的符号。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="84"/>
-        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
-        <translation>编码 &apos;%1&apos; 不是可用的。请检查设置。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="121"/>
-        <source>In area symbol %1 &apos;%2&apos;: %3</source>
-        <translation>在地区符号 %1 &apos;%2&apos;: %3</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1567"/>
-        <source>Unable to load object</source>
-        <translation>无法加载对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1577"/>
-        <source>Unable to import rectangle object</source>
-        <translation>无法导入矩形对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1618"/>
-        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
-        <translation>不导入文本符号，找不出路径 &apos; (npts = %1): %2</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="1918"/>
-        <source>Trying to import a text object with unknown coordinate format</source>
-        <translation>尝试导入具有未知坐标格式的文本对象</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2048"/>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
-        <source>Invalid data.</source>
-        <translation>无效的数据。</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.cpp" line="2083"/>
-        <source>OCD files of version %1 are not supported!</source>
-        <translation>不支持的版本 %1 的强迫症文件 ！</translation>
-    </message>
-    <message>
-        <location filename="../src/fileformats/ocd_file_import.h" line="454"/>
-        <source>Color id not found: %1, ignoring this color</source>
-        <translation>找不到的颜色 id: %1，无视这种颜色</translation>
-    </message>
-</context>
-<context>
-    <name>OgrFileImport</name>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="388"/>
-        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="322"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="335"/>
-        <source>Point</source>
-        <translation type="unfinished">点</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="342"/>
-        <source>Line</source>
-        <translation type="unfinished">线</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="351"/>
-        <source>Area</source>
-        <translation type="unfinished">地区</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="357"/>
-        <source>Text</source>
-        <translation type="unfinished">文本</translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="448"/>
-        <source>Unable to load layer %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../src/gdal/ogr_file_format.cpp" line="496"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
-        <source>Unable to load %n objects, reason: %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="497"/>
-        <source>Empty geometry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="502"/>
-        <source>Can&apos;t determine the coordinate transformation: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="507"/>
-        <source>Failed to transform the coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="512"/>
-        <source>Unknown or unsupported geometry type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="517"/>
-        <source>Not enough coordinates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="560"/>
-        <source>Cannot use this spatial reference:
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gdal/ogr_file_format.cpp" line="619"/>
-        <source>The geospatial data has no suitable spatial reference.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OpenOrienteering</name>
     <message>
         <location filename="../packaging/translations.cpp" line="10"/>
@@ -5182,767 +15,5935 @@ zoom using the mouse wheel, if available.</source>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateSelectDialog</name>
+    <name>OpenOrienteering::AboutDialog</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="348"/>
-        <source>Select template to draw onto</source>
-        <translation>选择要绘图模板</translation>
+        <location filename="../src/gui/about_dialog.cpp" line="105"/>
+        <location filename="../src/gui/about_dialog.cpp" line="172"/>
+        <source>About %1</source>
+        <translation>About %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="362"/>
+        <location filename="../src/gui/about_dialog.cpp" line="186"/>
+        <source>&lt;a %1&gt;All about licenses, copyright notices, conditions and disclaimers.&lt;/a&gt;</source>
+        <translation>&lt;a％1&gt;所有关于许可证，版权的告示，条件和免责声明</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="188"/>
+        <source>The OpenOrienteering developers in alphabetical order:</source>
+        <translation>按字母顺序排列的 OpenOrienteering 开发人员</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="189"/>
+        <source>(project initiator)</source>
+        <translation>（项目发起人）</translation>
+    </message>
+    <message>
+        <location filename="../packaging/translations.cpp" line="14"/>
+        <location filename="../src/gui/about_dialog.cpp" line="174"/>
+        <source>A free software for drawing orienteering maps</source>
+        <extracomment>For the moment, we use this existing translation instead of the previous one.</extracomment>
+        <translation>用于绘制定向越野地图的免费开源软件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="176"/>
+        <source>This program is free software: you can redistribute it and/or modify it under the terms of the &lt;a %1&gt;GNU General Public License (GPL), version&amp;nbsp;3&lt;/a&gt;, as published by the Free Software Foundation.</source>
+        <translation>此程序是免费的软件︰ 你可以将它重新分发和/或修改根据 &lt;a %1&gt; GNU 通用公共许可证 (GPL)，版本 3&lt;/a&gt; 的条款，如由自由软件基金会出版。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="181"/>
+        <source>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License (GPL), version&amp;nbsp;3, for &lt;a %1&gt;more details&lt;/a&gt;.</source>
+        <translation>请参阅GNU通用公共许可证（GPL），版本3，有关&lt;a %1&gt;更多详细信息&lt;/a&gt;。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/about_dialog.cpp" line="190"/>
+        <source>For contributions, thanks to:</source>
+        <translation>作出的贡献，感谢</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AbstractHomeScreenWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="119"/>
+        <source>Open most recently used file</source>
+        <translation>打开最近使用的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="122"/>
+        <source>Show tip of the day</source>
+        <translation>显示每日提示</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ActionGridBar</name>
+    <message>
+        <location filename="../src/gui/widgets/action_grid_bar.cpp" line="52"/>
+        <source>Show remaining items</source>
+        <translation>显示剩余项目</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AreaSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="87"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="88"/>
+        <source>Minimum size:</source>
+        <translation>最小尺寸</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="95"/>
+        <source>Fills</source>
+        <translation>填充</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="108"/>
+        <source>Line fill</source>
+        <translation>线条与填充</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="109"/>
+        <source>Pattern fill</source>
+        <translation>图案填充</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="158"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="165"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="189"/>
+        <source>mm</source>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="162"/>
+        <source>Single line</source>
+        <translation>单行</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="176"/>
+        <source>Parallel lines</source>
+        <translation>两条平行线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="178"/>
+        <source>Line spacing:</source>
+        <translation>行间距</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="181"/>
+        <source>Single row</source>
+        <translation>单排</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="183"/>
+        <source>Pattern interval:</source>
+        <translation>模式间隔</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="188"/>
+        <source>Pattern offset:</source>
+        <translation>模式偏移量</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="193"/>
+        <source>Row offset:</source>
+        <translation>行偏移量</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="195"/>
+        <source>Parallel rows</source>
+        <translation>平行的行</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="197"/>
+        <source>Row spacing:</source>
+        <translation>行间距</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="203"/>
+        <source>Fill rotation</source>
+        <translation>填补旋转</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="205"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="207"/>
+        <source>Angle:</source>
+        <translation>角度</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="209"/>
+        <source>adjustable per object</source>
+        <translation>每个对象可调节</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="229"/>
+        <source>Element drawing at boundary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="231"/>
+        <source>Clip elements at the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="232"/>
+        <source>Draw elements if the center is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="233"/>
+        <source>Draw elements if any point is inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="234"/>
+        <source>Draw elements if all points are inside the boundary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="249"/>
+        <source>Area settings</source>
+        <translation>区域设置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="341"/>
+        <source>Pattern fill %1</source>
+        <translation>图案填充 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="350"/>
+        <source>Line fill %1</source>
+        <translation>线条与填充 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="369"/>
+        <source>No fill selected</source>
+        <translation>没有选定的填充</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="85"/>
+        <source>Area color:</source>
+        <translation>区域颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="174"/>
+        <source>Line offset:</source>
+        <translation>行偏移量</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="169"/>
+        <source>Line color:</source>
+        <translation>线条颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/area_symbol_settings.cpp" line="164"/>
+        <source>Line width:</source>
+        <translation>线宽</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::AutosaveDialog</name>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="46"/>
+        <source>Autosaved file</source>
+        <translation>自动保存文件</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/autosave_dialog.cpp" line="48"/>
+        <location filename="../src/gui/autosave_dialog.cpp" line="54"/>
+        <source>%n bytes</source>
+        <translation>
+            <numerusform>%n 字节</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="52"/>
+        <source>File saved by the user</source>
+        <translation>由用户保存的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="59"/>
+        <source>File recovery</source>
+        <translation>文件恢复</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="61"/>
+        <source>File %1 was not properly closed. At the moment, there are two versions:</source>
+        <translation>文件 %1 不正确地关闭。目前，有两个版本</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/autosave_dialog.cpp" line="75"/>
+        <source>Save the active file to remove the conflicting version.</source>
+        <translation>保存活动文件删除冲突的版本。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDialog</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="86"/>
+        <source>Edit map color</source>
+        <translation>编辑地图颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="93"/>
+        <source>Edit</source>
+        <translation type="unfinished">编辑</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="106"/>
+        <source>Defines a spot color:</source>
+        <translation>定义专色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="115"/>
+        <source>Mixture of spot colors (screens and overprint):</source>
+        <translation>混合物的专色 （屏幕和叠印）</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="130"/>
+        <location filename="../src/gui/color_dialog.cpp" line="168"/>
+        <location filename="../src/gui/color_dialog.cpp" line="173"/>
+        <location filename="../src/gui/color_dialog.cpp" line="178"/>
+        <location filename="../src/gui/color_dialog.cpp" line="183"/>
+        <location filename="../src/gui/color_dialog.cpp" line="417"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="135"/>
+        <source>Knockout: erases lower colors</source>
+        <translation>挖空︰ 擦除低颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="153"/>
+        <location filename="../src/gui/color_dialog.cpp" line="210"/>
+        <source>Calculate from spot colors</source>
+        <translation>计算从专色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="158"/>
+        <source>Calculate from RGB color</source>
+        <translation>计算从 RGB 颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="163"/>
+        <source>Custom process color:</source>
+        <translation>自定义过程颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="169"/>
+        <source>Cyan</source>
+        <translation>青色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="174"/>
+        <source>Magenta</source>
+        <translation>洋红色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="179"/>
+        <source>Yellow</source>
+        <translation>黄色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="184"/>
+        <source>Black</source>
+        <translation>黑色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="215"/>
+        <source>Calculate from CMYK color</source>
+        <translation>计算从 CMYK 颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="220"/>
+        <source>Custom RGB color:</source>
+        <translation>自定义 RGB 颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="226"/>
+        <source>Red</source>
+        <translation>红色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="231"/>
+        <source>Green</source>
+        <translation>绿色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="236"/>
+        <source>Blue</source>
+        <translation>蓝色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="241"/>
+        <source>#RRGGBB</source>
+        <translation>#RRGGBB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="259"/>
+        <source>Desktop</source>
+        <translation>桌面</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="260"/>
+        <source>Professional printing</source>
+        <translation>专业印刷</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="279"/>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="331"/>
+        <source>- unnamed -</source>
+        <translation type="unfinished">-未命名-</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="600"/>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorDropDown</name>
+    <message>
+        <location filename="../src/gui/widgets/color_dropdown.cpp" line="42"/>
+        <source>- none -</source>
+        <translation>-无-</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ColorListWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Opacity</source>
+        <translation>不透明度</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>Spot color</source>
+        <translation>专色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>CMYK</source>
+        <translation>CMYK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="83"/>
+        <source>K.o.</source>
+        <translation>棍</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="94"/>
+        <source>New</source>
+        <translation>新增功能</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="97"/>
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="90"/>
+        <source>Duplicate</source>
+        <translation>重复</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="103"/>
+        <source>Move Up</source>
+        <translation>向上移动</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="105"/>
+        <source>Move Down</source>
+        <translation>向下移动</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>說明</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="137"/>
+        <source>Double-click a color value to open a dialog.</source>
+        <translation>双击要打开一个对话框的颜色值。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>Confirmation</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="232"/>
+        <source>The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?</source>
+        <translation>映射包含这种颜色的符号。删除它将从这些对象中删除颜色 ！你真的想要这样做？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="250"/>
+        <source>%1 (duplicate)</source>
+        <extracomment>Future replacement for COLOR_NAME + &quot; (Duplicate)&quot;, for better localization.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="251"/>
+        <source> (Duplicate)</source>
+        <translation> （重复）</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="409"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="458"/>
+        <source>Double click to define the color</source>
+        <translation>双击要定义的颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="417"/>
+        <source>Click to select the name and click again to edit.</source>
+        <translation>单击以选中名称，再次单击可编辑。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CombinedSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="88"/>
+        <source>&amp;Number of parts:</source>
+        <translation>与零件数目</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="96"/>
+        <source>- Private line symbol -</source>
+        <translation>-私人线符号-</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="97"/>
+        <source>- Private area symbol -</source>
+        <translation>-私人领域符号-</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="100"/>
+        <source>Edit private symbol...</source>
+        <translation>编辑私有符号...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="114"/>
+        <source>Combination settings</source>
+        <translation>组合设置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="227"/>
+        <source>Change from public to private symbol</source>
+        <translation>从公共改为私有符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="228"/>
+        <source>Take the old symbol as template for the private symbol?</source>
+        <translation>把旧的符号作为私有符号模板吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/combined_symbol_settings.cpp" line="93"/>
+        <source>Symbol %1:</source>
+        <translation>%1 的符号</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ConfigureGridDialog</name>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="67"/>
+        <source>Configure grid</source>
+        <translation>配置网格</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="69"/>
+        <source>Show grid</source>
+        <translation>显示网格</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="70"/>
+        <source>Snap to grid</source>
+        <translation>对齐网格</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="71"/>
+        <source>Choose...</source>
+        <translation>请选择...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="74"/>
+        <source>All lines</source>
+        <translation>所有行</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="75"/>
+        <source>Horizontal lines</source>
+        <translation>水平线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="76"/>
+        <source>Vertical lines</source>
+        <translation>垂直线条</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="128"/>
+        <source>Alignment</source>
+        <translation>对齐方式</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="78"/>
+        <source>Align with magnetic north</source>
+        <translation>磁北与对齐</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="79"/>
+        <source>Align with grid north</source>
+        <translation>与北方的网格对齐</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="80"/>
+        <source>Align with true north</source>
+        <translation>真北路与对齐</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="82"/>
+        <source>Additional rotation (counter-clockwise):</source>
+        <translation>额外的旋转 （逆时针）</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="83"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="135"/>
+        <source>Positioning</source>
+        <translation>定位</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="88"/>
+        <source>meters in terrain</source>
+        <translation>在地形米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="89"/>
+        <source>millimeters on map</source>
+        <translation>在地图上的毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="91"/>
+        <source>Horizontal spacing:</source>
+        <translation>水平间距</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="93"/>
+        <source>Vertical spacing:</source>
+        <translation>垂直间距</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="97"/>
+        <source>Horizontal offset:</source>
+        <translation>水平偏移量</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="99"/>
+        <source>Vertical offset:</source>
+        <translation>垂直偏移量</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="136"/>
+        <source>Unit:</source>
+        <comment>measurement unit</comment>
+        <translation>单位</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="124"/>
+        <source>Line color:</source>
+        <translation>线条颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="125"/>
+        <source>Display:</source>
+        <translation>显示︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="171"/>
+        <source>Choose grid line color</source>
+        <translation>选择网格线颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="255"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="261"/>
+        <source>Origin at: %1</source>
+        <translation>原点: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="263"/>
+        <source>paper coordinates origin</source>
+        <translation>本文坐标原点</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/configure_grid_dialog.cpp" line="265"/>
+        <source>projected coordinates origin</source>
+        <translation>投影的坐标原点</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutHoleTool</name>
+    <message>
+        <location filename="../src/tools/cut_hole_tool.cpp" line="249"/>
+        <source>&lt;b&gt;Click or drag&lt;/b&gt;: Start drawing the hole. </source>
+        <translation>&lt;b&gt;单击或拖动&lt;/b&gt;︰ 开始绘制孔。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutTool</name>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="416"/>
+        <source>The split line must end on the area boundary!</source>
+        <translation>拆分线必须结束在区域边界上 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="422"/>
+        <source>Start and end of the split line are at different parts of the object!</source>
+        <translation>开始和结束的拆分线是在对象的不同部分 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="428"/>
+        <source>Start and end of the split line are at the same position!</source>
+        <translation>开始和结束的拆分线处于相同的位置 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="108"/>
+        <source>&lt;b&gt;Click&lt;/b&gt; on a line: Split it into two. &lt;b&gt;Drag&lt;/b&gt; along a line: Remove this line part. &lt;b&gt;Click or Drag&lt;/b&gt; at an area boundary: Start a split line. </source>
+        <translation>在行上 &lt;b&gt;单击&lt;/b&gt;︰ 分成两个。沿着一条线 &lt;b&gt;拖&lt;/b&gt;︰ 删除此线部件。&lt;b&gt;单击或拖动&lt;/b&gt; 在区域边界︰ 开始拆分线。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cut_tool.cpp" line="368"/>
+        <source>Splitting holes of area objects is not supported yet!</source>
+        <translation>劈裂孔的区域对象尚不支持 ！</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::CutoutTool</name>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="148"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the whole map. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 剪辑整个地图。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="149"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="153"/>
+        <source>&lt;b&gt;%1+Click or drag&lt;/b&gt;: Select the objects to be clipped. </source>
+        <translation>&lt;b&gt;%1 + 单击或拖动&lt;/b&gt;︰ 选择要被剪切的对象。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/cutout_tool.cpp" line="154"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Clip the selected objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 所选的对象的剪辑。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DXFParser</name>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="38"/>
+        <source>Could not open the file.</source>
+        <translation>无法打开该文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/util/dxfparser.cpp" line="54"/>
+        <source>The file is not an DXF file.</source>
+        <translation>该文件不是 DXF 文件。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DetermineFontSizeDialog</name>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="109"/>
+        <source>Letter:</source>
+        <translation>字：</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="111"/>
+        <source>A</source>
+        <extracomment>&quot;A&quot; is the default letter which is used for determining letter height.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="117"/>
+        <source>Height:</source>
+        <translation>高度︰</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DistributePointsSettingsDialog</name>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="129"/>
+        <source>Distribute points evenly along path</source>
+        <translation>分发点沿路径均匀</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="135"/>
+        <source>Number of points per path:</source>
+        <translation>每个路径点的数目︰</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="137"/>
+        <source>Also place objects at line end points</source>
+        <translation>此外将对象置于线条端点</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="143"/>
+        <source>Rotation settings</source>
+        <translation>旋转设置</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="146"/>
+        <source>Align points with direction of line</source>
+        <translation>对齐点与线的方向</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="150"/>
+        <source>°</source>
+        <comment>degrees</comment>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/distribute_points_tool.cpp" line="152"/>
+        <source>Additional rotation angle (counter-clockwise):</source>
+        <translation>额外的旋转角度 （逆时针）︰</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawCircleTool</name>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="69"/>
+        <source>From center</source>
+        <comment>Draw circle starting from center</comment>
+        <translation>从中心</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="308"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a circle or ellipse. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 启动一个圆或椭圆。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="309"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a circle. </source>
+        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 画一个圆。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="311"/>
+        <source>Hold %1 to start drawing from the center.</source>
+        <translation>持有 %1 从中心开始绘制。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="315"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish the circle. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 完成圈。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="316"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw an ellipse. </source>
+        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 绘制一个椭圆。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawFreehandTool</name>
+    <message>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="289"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Draw a path. </source>
+        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 绘制路径。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawLineAndAreaTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1172"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="725"/>
+        <source>&lt;b&gt;Dash points on.&lt;/b&gt; </source>
+        <translation>&lt;b&gt;破折号点。&lt;/b&gt; </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1180"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap or append to existing objects. </source>
+        <translation>&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 对齐或将追加到现有的对象。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1188"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="731"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Pick direction from existing objects. </source>
+        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt;︰ 选择从现有对象的方向。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1189"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1216"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Segment azimuth and length. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1205"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="736"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="760"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 与现有对象对齐。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1215"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="750"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1225"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="766"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Undo last point. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 撤消最后一点。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPathTool</name>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="102"/>
+        <source>Finish</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="103"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="104"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="105"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>角度</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="106"/>
+        <source>Info</source>
+        <comment>Show segment azimuth and length</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="109"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>短划线</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="112"/>
+        <source>Undo</source>
+        <translation>撤消</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="113"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1167"/>
+        <source>&lt;b&gt;Length:&lt;/b&gt; %1 m </source>
+        <translation>&lt;b&gt;长度︰&lt;/b&gt; %1 m </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1195"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Start a straight line. &lt;b&gt;Drag&lt;/b&gt;: Start a curve. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 开始一条直线。&lt;b&gt;拖&lt;/b&gt;︰ 开始一条曲线。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1206"/>
+        <source>&lt;b&gt;%1+Drag&lt;/b&gt;: Follow existing objects. </source>
+        <translation>&lt;b&gt;％1  拖动&lt;/b&gt; ：按照现有对象 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1222"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Draw a straight line. &lt;b&gt;Drag&lt;/b&gt;: Draw a curve. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the path. &lt;b&gt;%1&lt;/b&gt;: Close the path. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 绘制一条直线。&lt;b&gt;拖&lt;/b&gt;︰ 绘制一条曲线。&lt;b&gt;右或双点击&lt;/b&gt;︰ 完成路径。&lt;b&gt;%1&lt;/b&gt;︰ 闭合该路径。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointGPSTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="81"/>
+        <source>Touch the map to finish averaging</source>
+        <translation>轻触地图完成平均</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_gps_tool.cpp" line="193"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Finish setting the object. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 完成设置对象。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawPointTool</name>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="83"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="84"/>
+        <source>Angle</source>
+        <comment>Using constrained angles</comment>
+        <translation>角度</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="85"/>
+        <source>Reset</source>
+        <comment>Reset rotation</comment>
+        <translation>重置</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="334"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="346"/>
+        <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
+        <translation>&lt;b&gt;角︰&lt;/b&gt; %1 ° </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="335"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="340"/>
+        <location filename="../src/tools/draw_point_tool.cpp" line="354"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a point object.</source>
+        <translation>&lt;b&gt;点击&lt;/b&gt; ：创建一个点对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="341"/>
+        <source>&lt;b&gt;Drag&lt;/b&gt;: Create an object and set its orientation.</source>
+        <translation>&lt;b&gt;拖&lt;/b&gt;︰ 创建一个对象并设置其方向。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_point_tool.cpp" line="347"/>
+        <source>&lt;b&gt;%1, 0&lt;/b&gt;: Reset rotation.</source>
+        <translation>&lt;b&gt;0 %1&lt;/b&gt;︰ 重置旋转。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawRectangleTool</name>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="90"/>
+        <source>Finish</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="91"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="92"/>
+        <source>Line snap</source>
+        <comment>Snap to previous lines</comment>
+        <translation>线管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="93"/>
+        <source>Dash</source>
+        <comment>Drawing dash points</comment>
+        <translation>短划线</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="96"/>
+        <source>Undo</source>
+        <translation>撤消</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="97"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="741"/>
+        <source>&lt;b&gt;Click or Drag&lt;/b&gt;: Start drawing a rectangle. </source>
+        <translation>&lt;b&gt;单击或拖动&lt;/b&gt;︰ 开始绘制一个矩形。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="754"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to previous lines. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 与以前的行对齐。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="765"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set a corner point. &lt;b&gt;Right or double click&lt;/b&gt;: Finish the rectangle. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置一个角点。&lt;b&gt;右或双点击&lt;/b&gt;︰ 完成该矩形。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::DrawTextTool</name>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="113"/>
+        <source>Snap</source>
+        <extracomment>Snap to existing objects</extracomment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="476"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 完成编辑。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="477"/>
+        <source>&lt;b&gt;%1+%2&lt;/b&gt;: Cancel editing. </source>
+        <translation>&lt;b&gt;%1 + %2&lt;/b&gt;︰ 取消编辑。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="482"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Create a text object with a single anchor. &lt;b&gt;Drag&lt;/b&gt;: Create a text box. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 创建具有单锚文本对象。&lt;b&gt;拖&lt;/b&gt;︰ 中创建一个文本框。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditLineTool</name>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="405"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="406"/>
+        <source>Toggle curve</source>
+        <comment>Toggle between curved and flat segment</comment>
+        <translation>切换曲线</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="518"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Free movement. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 自由流动。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_line_tool.cpp" line="534"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on segment: Toggle between straight and curved. </source>
+        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 段上︰ 直线和曲线之间切换。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditPointTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="535"/>
+        <source>Snap</source>
+        <comment>Snap to existing objects</comment>
+        <translation>管理单元</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="536"/>
+        <source>Point / Angle</source>
+        <comment>Modify points or use constrained angles</comment>
+        <translation>点 / 角</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="537"/>
+        <source>Toggle dash</source>
+        <comment>Toggle dash points</comment>
+        <translation>切换破折号</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="716"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Finish editing. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 完成编辑。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="735"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Keep opposite handle positions. </source>
+        <extracomment>Actually, this means: &quot;Keep the opposite handle&apos;s position. &quot;</extracomment>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 保持相反的句柄位置。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="756"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new dash point; with &lt;b&gt;%2&lt;/b&gt;: Add a normal point. </source>
+        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 点︰ 删除它;在路径上︰ 添加一个新的破折号点;&lt;b&gt;%2&lt;/b&gt;︰ 添加一个正常点。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="759"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point: Delete it; on path: Add a new point; with &lt;b&gt;%2&lt;/b&gt;: Add a dash point. </source>
+        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 点︰ 删除它;在路径上︰ 添加一个新的点;&lt;b&gt;%2&lt;/b&gt;︰ 添加一个破折号点。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="763"/>
+        <source>&lt;b&gt;%1+Click&lt;/b&gt; on point to switch between dash and normal point. </source>
+        <translation>&lt;b&gt;%1 + 单击&lt;/b&gt; 的点划线和正常点之间进行切换。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditTool</name>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="511"/>
+        <source>&lt;b&gt;Coordinate offset:&lt;/b&gt; %1, %2 mm  &lt;b&gt;Distance:&lt;/b&gt; %3 m </source>
+        <translation>&lt;b&gt;坐标偏移量︰&lt;/b&gt; %1、 %2 毫米 &lt;b&gt;距离︰&lt;/b&gt; %3 m </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="728"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_text_tool.cpp" line="484"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="739"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="520"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Snap to existing objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 与现有对象对齐。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="745"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="526"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Select a single object. &lt;b&gt;Drag&lt;/b&gt;: Select multiple objects. &lt;b&gt;%1+Click&lt;/b&gt;: Toggle selection. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 选择单个对象。&lt;b&gt;拖动&lt;/b&gt;︰ 选择多个对象。&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 切换选择。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/edit_point_tool.cpp" line="748"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="529"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Delete selected objects. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 删除选定的对象。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::EditorSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="48"/>
+        <source>High quality map display (antialiasing)</source>
+        <translation>高质量地图显示 （抗锯齿）</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="49"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="53"/>
+        <source>Antialiasing makes the map look much better, but also slows down the map display</source>
+        <translation>抗锯齿功能使地图看起来好多了，但也会减慢地图显示</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="52"/>
+        <source>High quality text display in map (antialiasing), slow</source>
+        <translation>高质量的文本显示在地图 （抗锯齿），缓慢</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="57"/>
+        <source>Click tolerance:</source>
+        <translation>请单击公差︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="45"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="56"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="59"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="96"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="60"/>
+        <source>Snap distance (%1):</source>
+        <translation>对齐距离 (%1):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="63"/>
+        <source>Stepping of fixed angle mode (%1):</source>
+        <translation>步进的固定的角模式 (%1):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="62"/>
+        <source>°</source>
+        <comment>Degree sign for angles</comment>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="46"/>
+        <source>Symbol icon size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="65"/>
+        <source>When selecting an object, automatically select its symbol, too</source>
+        <translation>当选择一个对象，自动选择它的符号太</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="68"/>
+        <source>Zoom away from cursor when zooming out</source>
+        <translation>从光标放大，放大了</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="71"/>
+        <source>Drawing tools: set last point on finishing with right click</source>
+        <translation>绘图工具︰ 套上整理的最后一个点右键单击</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="74"/>
+        <source>Templates: keep settings of closed templates</source>
+        <translation>模板︰ 保持封闭模板设置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="79"/>
+        <source>Edit tool:</source>
+        <translation>编辑工具︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="82"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="88"/>
+        <source>Retain old shape</source>
+        <translation>保留旧的形状</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="83"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="89"/>
+        <source>Reset outer curve handles</source>
+        <translation>重置外曲线手柄</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="84"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="90"/>
+        <source>Keep outer curve handles</source>
+        <translation>保持外曲线手柄</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="85"/>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="91"/>
+        <source>Action on deleting a curve point with %1:</source>
+        <translation>有关删除 %1 曲线点的行动︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="94"/>
+        <source>Rectangle tool:</source>
+        <translation>矩形工具︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="97"/>
+        <source>Radius of helper cross:</source>
+        <translation>助手交叉半径：</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="99"/>
+        <source>Preview the width of lines with helper cross</source>
+        <translation>预览与助手交叉线条的宽度</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/editor_settings_page.cpp" line="115"/>
+        <source>Editor</source>
+        <translation>编辑器</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Exporter</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>Could not create new file: %1</source>
+        <translation>不能创建新文件: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="84"/>
+        <source>Format (%1) does not support export</source>
+        <translation>格式 (%1) 不支持出口</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::FillTool</name>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="156"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="157"/>
+        <source>The map area is large. Use of the fill tool may be very slow. Do you want to use it anyway?</source>
+        <translation>地图面积大。填充工具的使用可能会很慢。你想要使用它吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="142"/>
+        <location filename="../src/tools/fill_tool.cpp" line="176"/>
+        <location filename="../src/tools/fill_tool.cpp" line="230"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="143"/>
+        <source>The clicked area is not bounded by lines or areas, cannot fill this area.</source>
+        <translation>单击的区域不受线路或地区，不能填补这一领域。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="177"/>
+        <source>The clicked position is not free, cannot use the fill tool there.</source>
+        <translation>被单击的位置不是免费的不能那里使用填充工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="231"/>
+        <source>Failed to create the fill object.</source>
+        <translation>未能创建填充对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/fill_tool.cpp" line="242"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Fill area with active symbol. The area to be filled must be bounded by lines or areas, other symbols are not taken into account. </source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 用活动符号填充区域。要填充的区域必须有界的直线或地区，不考虑其他符号。 </translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GPSDisplay</name>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="91"/>
+        <source>GPS is disabled in the device settings. Open settings now?</source>
+        <translation>GPS 在设备设置被禁用。现在打开设置吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="92"/>
+        <source>Yes</source>
+        <translation>是的</translation>
+    </message>
+    <message>
+        <location filename="../src/sensors/gps_display.cpp" line="93"/>
+        <source>No</source>
+        <translation>不</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GdalSettingsPage</name>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="50"/>
+        <source>Import with GDAL/OGR:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="52"/>
+        <source>DXF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="55"/>
+        <source>GPX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="58"/>
+        <source>OSM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="62"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="70"/>
+        <source>Value</source>
+        <translation type="unfinished">价值</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/gdal_settings_page.cpp" line="89"/>
+        <source>GDAL/OGR</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeneralSettingsPage</name>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="80"/>
+        <source>Appearance</source>
+        <translation>外观</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="85"/>
+        <source>Language:</source>
+        <translation>语言︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="102"/>
+        <source>Screen</source>
+        <translation>屏幕</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="107"/>
+        <source>Pixels per inch:</source>
+        <translation>每英寸的像素数︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="117"/>
+        <source>Program start</source>
+        <translation>启动程序</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="126"/>
+        <source>Saving files</source>
+        <translation>保存文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="128"/>
+        <source>Retain compatibility with Mapper %1</source>
+        <translation>保留与映射程序 %1 的兼容性</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="139"/>
+        <source>Save information for automatic recovery</source>
+        <translation>保存自动恢复信息</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="143"/>
+        <source>Recovery information saving interval:</source>
+        <translation>恢复信息的保存时间间隔︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="142"/>
+        <source>min</source>
+        <comment>unit minutes</comment>
+        <translation>分钟</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="146"/>
+        <source>File import and export</source>
+        <translation>文件导入和导出</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="171"/>
+        <source>8-bit encoding:</source>
+        <translation>8 位编码︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="164"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="315"/>
+        <source>More...</source>
+        <translation>更多...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="136"/>
+        <source>Save undo/redo history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="149"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="173"/>
+        <source>Use the new OCD importer also for version 8 files</source>
+        <translation>使用新的强迫症进口商也为版本 8 文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="192"/>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>Notice</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="216"/>
+        <source>The program must be restarted for the language change to take effect!</source>
+        <translation>语言更改生效，必须重新启动该程序 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="363"/>
+        <source>Open translation</source>
+        <translation>开放式翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="357"/>
+        <source>Translation files (*.qm)</source>
+        <translation>翻译文件 (*.qm)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="364"/>
+        <source>The selected file is not a valid translation.</source>
+        <translation>所选的文件不是有效的翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="394"/>
+        <source>%1 x %2</source>
+        <translation>%1 %2 x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="395"/>
+        <source>Primary screen resolution in pixels:</source>
+        <translation>以像素为单位的主屏幕分辨率︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/general_settings_page.cpp" line="399"/>
+        <source>Primary screen size in inches (diagonal):</source>
+        <translation>在英寸 （对角线） 的主屏幕大小︰</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Georeferencing</name>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="55"/>
+        <source>UTM</source>
+        <comment>UTM coordinate reference system</comment>
+        <translation>UTM</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="56"/>
+        <source>UTM coordinates</source>
+        <translation>UTM 坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="59"/>
+        <source>UTM Zone (number north/south)</source>
+        <translation>UTM 区域 （编号南北）</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="66"/>
+        <source>Gauss-Krueger, datum: Potsdam</source>
+        <comment>Gauss-Krueger coordinate reference system</comment>
+        <translation>高斯-克鲁格、 基准︰ 波茨坦</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="67"/>
+        <source>Gauss-Krueger coordinates</source>
+        <translation>高斯-克鲁格坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="70"/>
+        <source>Zone number (1 to 119)</source>
+        <comment>Zone number for Gauss-Krueger coordinates</comment>
+        <translation>区数 (1 到 119)</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="78"/>
+        <source>by EPSG code</source>
+        <comment>as in: The CRS is specified by EPSG code</comment>
+        <translation>通过对代码</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="80"/>
+        <source>EPSG @code@ coordinates</source>
+        <extracomment>Don&apos;t translate @code@. It is placeholder.</extracomment>
+        <translation>对 @code @ 坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="91"/>
+        <location filename="../src/core/georeferencing.cpp" line="562"/>
+        <source>Local coordinates</source>
+        <translation>局部坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="83"/>
+        <source>EPSG code</source>
+        <translation>对代码</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="90"/>
+        <source>Custom PROJ.4</source>
+        <comment>PROJ.4 specification</comment>
+        <translation>自定义 PROJ.4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/crs_template_implementation.cpp" line="94"/>
+        <source>Specification</source>
+        <comment>PROJ.4 specification</comment>
+        <translation>规格</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="258"/>
+        <source>Map scale specification invalid or missing.</source>
+        <translation>地图比例尺规范无效或丢失。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="264"/>
+        <source>Invalid grid scale factor: %1</source>
+        <translation>无效的网格尺度因子: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="301"/>
+        <location filename="../src/core/georeferencing.cpp" line="328"/>
+        <source>Unknown CRS specification language: %1</source>
+        <translation>未知的 CRS 规范语言: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="331"/>
+        <source>Unsupported geographic CRS specification: %1</source>
+        <translation>不受支持的地理 CRS 规格: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/georeferencing.cpp" line="553"/>
+        <source>Local</source>
+        <translation>本地</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingDialog</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="113"/>
+        <source>Map Georeferencing</source>
+        <translation>地图地理参考坐标系</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="190"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Lookup...</source>
+        <translation>查找...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="150"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="151"/>
+        <source>m</source>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="224"/>
+        <source>Declination:</source>
+        <translation>赤纬︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="175"/>
+        <source>Projected coordinates</source>
+        <translation>投影的坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="122"/>
+        <source>Status:</source>
+        <translation>状态︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="176"/>
+        <source>Geographic coordinates</source>
+        <translation>地理坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="171"/>
+        <source>Show reference point in:</source>
+        <translation>显示中的参考点︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="360"/>
+        <source>valid</source>
+        <translation>有效</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="354"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;OpenStreetMap&lt;/a&gt; | &lt;a href=&quot;%2&quot;&gt;World of O Maps&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;%1&quot;&gt; 开放&lt;/a&gt; |&lt;a href=&quot;%2&quot;&gt; O 地图世界&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="384"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="697"/>
+        <source>Online declination lookup</source>
+        <translation>在线的赤纬查找</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="117"/>
+        <source>Map coordinate reference system</source>
+        <translation>地图坐标参考系统</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="120"/>
+        <source>- local -</source>
+        <translation>-本地-</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="128"/>
+        <source>Grid scale factor:</source>
+        <extracomment>The grid scale factor is the ratio between a length in the grid plane and the corresponding length on the curved earth model. It is applied as a factor to ground distances to get grid plane distances.</extracomment>
+        <translation>网格的缩放比例︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="131"/>
+        <source>Reference point</source>
+        <translation>参考点</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="133"/>
+        <source>&amp;Pick on map</source>
+        <translation>与在地图上选择</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="135"/>
+        <source>(Datum: WGS84)</source>
+        <translation>(基准︰ WGS84)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="138"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="139"/>
+        <source>mm</source>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="143"/>
+        <source>X</source>
+        <comment>x coordinate</comment>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="145"/>
+        <source>Y</source>
+        <comment>y coordinate</comment>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="154"/>
+        <source>E</source>
+        <comment>west / east</comment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="156"/>
+        <source>N</source>
+        <comment>north / south</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="160"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="161"/>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="189"/>
+        <source>°</source>
+        <translation>°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="164"/>
+        <source>N</source>
+        <comment>north</comment>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="166"/>
+        <source>E</source>
+        <comment>east</comment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="187"/>
+        <source>Map north</source>
+        <translation>北地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="207"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="93"/>
+        <source>&amp;Coordinate reference system:</source>
+        <translation>与参考坐标系︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="214"/>
+        <source>Map coordinates:</source>
+        <translation>地图坐标︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="216"/>
+        <source>Geographic coordinates:</source>
+        <translation>地理坐标︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="219"/>
+        <source>On CRS changes, keep:</source>
+        <translation>CRS 的变化，保持︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="225"/>
+        <source>Grivation:</source>
+        <translation>Grivation:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="385"/>
+        <source>The magnetic declination for the reference point %1° %2° will now be retrieved from &lt;a href=&quot;%3&quot;&gt;%3&lt;/a&gt;. Do you want to continue?</source>
+        <translation>磁偏角为参考点 %1 %2 ° 现在将从 &lt;a href=&quot;%3&quot;&gt; %3&lt;/a&gt; 中检索。你想要继续吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>Declination change</source>
+        <translation>赤纬变化</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="464"/>
+        <source>The declination has been changed. Do you want to rotate the map content accordingly, too?</source>
+        <translation>赤纬已被更改。你想要旋转地图内容因此，太吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="494"/>
+        <source>Local coordinates:</source>
+        <translation>局部坐标︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="521"/>
+        <source>Loading...</source>
+        <translation>正在加载...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="528"/>
+        <source>locked</source>
+        <translation>已锁定</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="668"/>
+        <source>Could not parse data.</source>
+        <translation>不能分析数据。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="693"/>
+        <source>Declination value not found.</source>
+        <translation>找不到的赤纬值。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="698"/>
+        <source>The online declination lookup failed:
+%1</source>
+        <translation>在线的赤纬查找失败: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="526"/>
+        <source>%1 °</source>
+        <comment>degree value</comment>
+        <translation>%1 °</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::GeoreferencingTool</name>
+    <message>
+        <location filename="../src/gui/georeferencing_dialog.cpp" line="726"/>
+        <source>&lt;b&gt;Click&lt;/b&gt;: Set the reference point. &lt;b&gt;Right click&lt;/b&gt;: Cancel.</source>
+        <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置的参考点。&lt;b&gt;右键单击&lt;/b&gt;︰ 取消。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenController</name>
+    <message>
+        <location filename="../src/gui/home_screen_controller.cpp" line="150"/>
+        <source>Welcome to OpenOrienteering Mapper!</source>
+        <translation>欢迎来到 OpenOrienteering 映射器 ！</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetDesktop</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="143"/>
+        <source>Activities</source>
+        <translation>活动</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="146"/>
+        <source>Create a new map ...</source>
+        <translation>创建一张新的地图...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="149"/>
+        <source>Open map ...</source>
+        <translation>打开地图...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="155"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="336"/>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="158"/>
+        <source>About %1</source>
+        <comment>As in &apos;About OpenOrienteering Mapper&apos;</comment>
+        <translation>关于 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="161"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="338"/>
+        <source>Help</source>
+        <translation>說明</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="164"/>
+        <source>Exit</source>
+        <translation>結束</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="184"/>
+        <source>Recent maps</source>
+        <translation>最近地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="209"/>
+        <source>Open most recently used file on start</source>
+        <translation>打开最近使用的文件启动</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="212"/>
+        <source>Clear list</source>
+        <translation>清除列表</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="231"/>
+        <source>Tip of the day</source>
+        <translation>每日提示</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="236"/>
+        <source>Show tip of the day</source>
+        <translation>显示每日提示</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="240"/>
+        <source>Previous</source>
+        <translation>上一页</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="242"/>
+        <source>Next</source>
+        <translation>下一个</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::HomeScreenWidgetMobile</name>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="334"/>
+        <source>Examples</source>
+        <translation>例子</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="340"/>
+        <source>About Mapper</source>
+        <translation>关于映射器</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="461"/>
+        <source>File list</source>
+        <translation>文件列表</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="545"/>
+        <source>No map files found!&lt;br/&gt;&lt;br/&gt;Copy map files to a top-level folder named &apos;OOMapper&apos; on the device or a memory card.</source>
+        <translation>没有找到的地图文件 ！ &lt;br/&gt; &lt;br/&gt;将地图文件复制到名为 &apos;OOMapper&apos; 在设备或存储卡上的顶级文件夹。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ImportExport</name>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="247"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3.</source>
+        <translation>加载在列行 %2%3 %1 类型的符号时的错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="255"/>
+        <source>Symbol ID &apos;%1&apos; not unique at line %2 column %3.</source>
+        <translation>符号 ID &apos;%1&apos; 不是唯一的在行 %2 列 %3。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/symbol.cpp" line="303"/>
+        <source>Error while loading a symbol of type %1 at line %2 column %3: %4</source>
+        <translation>加载类型 %1 在 %2 线列 %3 的象征时出现错误: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="409"/>
+        <source>Error while loading an object of type %1.</source>
+        <translation>加载类型 %1 的对象时出现错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="473"/>
+        <source>Error while loading an object of type %1 at %2:%3: %4</source>
+        <translation>加载类型 %1 在 %2 的对象时出现错误: %3: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="441"/>
+        <source>Unable to find symbol for object at %1:%2.</source>
+        <translation>无法找到符号对象在 %1: %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object.cpp" line="453"/>
+        <source>Point object with undefined or wrong symbol at %1:%2.</source>
+        <translation>点对象未定义或错符号在 %1: %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="95"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="90"/>
+        <source>OpenOrienteering Mapper</source>
+        <translation>OpenOrienteering 映射器</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="62"/>
+        <source>OCAD Versions 7, 8</source>
+        <translation>OCAD 版本 7 8</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_format.cpp" line="40"/>
+        <source>OCAD</source>
+        <translation>遗漏</translation>
+    </message>
+    <message>
+        <location filename="../src/util/xml_stream_util.cpp" line="201"/>
+        <location filename="../src/util/xml_stream_util.cpp" line="217"/>
+        <source>Could not parse the coordinates.</source>
+        <translation>无法解析坐标。</translation>
+    </message>
+    <message>
+        <location filename="../src/util/xml_stream_util.cpp" line="241"/>
+        <source>Expected %1 coordinates, found %2.</source>
+        <translation>预期的 %1 坐标，找到 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="981"/>
+        <source>Error while loading the printing configuration at %1:%2: %3</source>
+        <translation>在 %1 的打印配置加载时出错: %2: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1000"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="1020"/>
+        <source>Error while loading the undo/redo steps at %1:%2: %3</source>
+        <translation>撤消/重复加载时的错误步骤在 %1: %2: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="47"/>
+        <source>No such option: %1</source>
+        <comment>No such import / export option</comment>
+        <translation>没有这样的选项: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="295"/>
+        <source>Geospatial vector data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Importer</name>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="77"/>
+        <source>Found an object without symbol.</source>
+        <translation>发现一个无符号的对象。</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/file_import_export.cpp" line="105"/>
+        <source>Dropped %n irregular object(s).</source>
+        <translation>
+            <numerusform>首字下沉 %n 不规则对象。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="112"/>
+        <source>Error during symbol post-processing.</source>
+        <translation>符号后加工过程中的错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="140"/>
+        <source>Template &quot;%1&quot; has been loaded from the map&apos;s directory instead of the relative location to the map file where it was previously.</source>
+        <translation>模板&quot;%1&quot;已从地图的目录而不是相对位置加载到它那里以前的映射文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="131"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="708"/>
+        <source>Failed to load template &apos;%1&apos;, reason: %2</source>
+        <translation>未能加载模板&quot;%1&quot;，原因: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="148"/>
+        <source>Warnings when loading template &apos;%1&apos;:
+%2</source>
+        <translation>警告当加载模板 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="158"/>
+        <location filename="../src/fileformats/file_import_export.cpp" line="160"/>
+        <source>At least one template file could not be found.</source>
+        <translation>找不到至少一个模板文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_import_export.cpp" line="161"/>
+        <source>Click the red template name(s) in the Templates -&gt; Template setup window to locate the template file name(s).</source>
+        <translation>单击模板-模板安装窗口 &gt; 查找模板文件名称中的红色模板名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="126"/>
+        <source>This file uses an obsolete format. Support for this format is to be removed from this program soon. To be able to open the file in the future, save it again.</source>
+        <translation>此文件使用过时的格式。支持这种格式是从中删除此程序很快。为了能在将来打开该文件，请重新保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="139"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="509"/>
+        <source>Invalid file format version.</source>
+        <translation>无效的文件格式版本。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="143"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="511"/>
+        <source>Unsupported old file format version. Please use an older program version to load and update the file.</source>
+        <translation>旧版本的文件格式不受支持。请使用较旧的程序版本加载和更新该文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="147"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program. Consider updating.</source>
+        <translation>新版本的文件格式不受支持。一些地图功能将不会加载或保存此版本的程序。考虑更新。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="203"/>
+        <source>The geographic coordinate reference system of the map was &quot;%1&quot;. This CRS is not supported. Using &quot;%2&quot;.</source>
+        <translation>地图的地理坐标参考系为&quot;%1&quot;。不支持此 CRS。使用&quot;%2&quot;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="321"/>
+        <source>Error while loading a symbol with type %2.</source>
+        <translation>%2 型加载符号时的错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="326"/>
+        <source>Error while loading a symbol.</source>
+        <translation>加载符号时的错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="398"/>
+        <source>Error while loading undo steps.</source>
+        <translation>装入撤消步骤时出错。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="408"/>
+        <source>Error while reading map part count.</source>
+        <translation>读取地图部分计数时出错。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/native_file_format.cpp" line="419"/>
+        <source>Error while loading map part %2.</source>
+        <translation>加载地图部分 %2 时出现错误。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="120"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2066"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2103"/>
+        <source>Could not read file: %1</source>
+        <translation>无法读取文件: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="503"/>
+        <source>Unsupported file format.</source>
+        <translation>不支持的文件格式。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="513"/>
+        <source>Unsupported new file format version. Some map features will not be loaded or saved by this version of the program.</source>
+        <translation>新版本的文件格式不受支持。一些地图功能将不会加载或保存此版本的程序。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/file_format.cpp" line="76"/>
+        <source>Format (%1) does not support import</source>
+        <translation>格式 (%1) 不支持导入</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="416"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1285"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="1338"/>
+        <source>Could not read &apos;%1&apos;: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::LineSymbolSettings</name>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="300"/>
+        <source>Line settings</source>
+        <translation>行的设置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="75"/>
+        <source>Line width:</source>
+        <translation>线宽︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="76"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="91"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="155"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="193"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="532"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="538"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="563"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="566"/>
+        <source>mm</source>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="78"/>
+        <source>Line color:</source>
+        <translation>线条颜色︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="90"/>
+        <source>Minimum line length:</source>
+        <translation>最小线长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="93"/>
+        <source>Line cap:</source>
+        <translation>线帽︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="95"/>
+        <source>flat</source>
+        <translation>平</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="96"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="106"/>
+        <source>round</source>
+        <translation>一轮</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="97"/>
+        <source>square</source>
+        <translation>广场</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="98"/>
+        <source>pointed</source>
+        <translation>指出</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="103"/>
+        <source>Line join:</source>
+        <translation>线条联接︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="105"/>
+        <source>miter</source>
+        <translation>斜角</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="107"/>
+        <source>bevel</source>
+        <translation>斜角</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="100"/>
+        <source>Cap length:</source>
+        <translation>帽长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="109"/>
+        <source>Line is dashed</source>
+        <translation>线为虚线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="214"/>
+        <source>Show at least one mid symbol</source>
+        <translation>至少显示一个中期符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="216"/>
+        <source>Minimum mid symbol count:</source>
+        <translation>中旬符号计数的最低要求︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="219"/>
+        <source>Minimum mid symbol count when closed:</source>
+        <translation>中旬符号计数关闭时的最低要求︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="141"/>
+        <source>Dash length:</source>
+        <translation>短划线的长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="137"/>
+        <source>Dashed line</source>
+        <translation>虚线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="144"/>
+        <source>Break length:</source>
+        <translation>打破长度：</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="147"/>
+        <source>Dashes grouped together:</source>
+        <translation>短划线组合在一起︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="149"/>
+        <source>none</source>
+        <translation>没有一个</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="150"/>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="151"/>
+        <source>3</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="152"/>
+        <source>4</source>
+        <translation>4</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="154"/>
+        <source>In-group break length:</source>
+        <translation>圈内裂断长︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="157"/>
+        <source>Half length of first and last dash</source>
+        <translation>第一个和最后一个短划线的长度的一半</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="186"/>
+        <source>Mid symbols</source>
+        <translation>中期的符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="189"/>
+        <source>Mid symbols per spot:</source>
+        <translation>每一地点的中期符号︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="192"/>
+        <source>Mid symbol distance:</source>
+        <translation>中期的符号距离︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="249"/>
+        <source>Borders</source>
+        <translation>边框</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="253"/>
+        <source>Different borders on left and right sides</source>
+        <translation>在左、 右两边的不同边框</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="257"/>
+        <source>Left border:</source>
+        <translation>左边的框︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="262"/>
+        <source>Right border:</source>
+        <translation>右边框︰</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1707"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="601"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1230"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Start symbol</source>
+        <translation>开始符号</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1711"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Mid symbol</source>
+        <translation>中期的符号</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1715"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1237"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>End symbol</source>
+        <translation>结束符号</translation>
+    </message>
+    <message>
+        <location filename="../src/core/symbols/line_symbol.cpp" line="1719"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="595"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1223"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="280"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="305"/>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="773"/>
+        <source>Dash symbol</source>
+        <translation>破折号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="111"/>
+        <source>Enable border lines</source>
+        <translation>使边框线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="208"/>
+        <source>Distance between spots:</source>
+        <translation>点之间的距离︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="211"/>
+        <source>Distance from line end:</source>
+        <translation>线端的距离︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="282"/>
+        <source>Suppress the dash symbol at line start and line end</source>
+        <translation>在压制线的起点和终点线的划线标志</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="286"/>
+        <source>Scale the dash symbol at corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="531"/>
+        <source>Border width:</source>
+        <translation>边框宽度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="534"/>
+        <source>Border color:</source>
+        <translation>边框颜色︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="537"/>
+        <source>Border shift:</source>
+        <translation>边境的转变︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="540"/>
+        <source>Border is dashed</source>
+        <translation>虚线边框</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="562"/>
+        <source>Border dash length:</source>
+        <translation>边界划线长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/symbols/line_symbol_settings.cpp" line="565"/>
+        <source>Border break length:</source>
+        <translation>边界断裂长度︰</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MainWindow</name>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="273"/>
+        <source>&amp;New</source>
+        <translation>与新</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="275"/>
+        <source>Create a new map</source>
+        <translation>创建一个新的映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="279"/>
+        <source>&amp;Open...</source>
+        <translation>与打开......</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="281"/>
+        <source>Open an existing file</source>
+        <translation>打开现有的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="285"/>
+        <source>Open &amp;recent</source>
+        <translation>开放与最近</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="296"/>
+        <source>&amp;Save</source>
+        <translation>与保存</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="301"/>
+        <source>Save &amp;as...</source>
+        <translation>保存与作为...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="303"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl + Shift + S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="309"/>
+        <source>Settings...</source>
+        <translation>设置。。。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="314"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="107"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="316"/>
+        <source>Close this file</source>
+        <translation>关闭此文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="320"/>
+        <source>E&amp;xit</source>
+        <translation>E &amp; xit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="322"/>
+        <source>Exit the application</source>
+        <translation>退出应用程序</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="329"/>
+        <source>&amp;File</source>
+        <translation>与文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="348"/>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="363"/>
+        <source>Open &amp;Manual</source>
+        <translation>打开 &amp; 手册</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="364"/>
+        <source>Show the help file for this application</source>
+        <translation>显示此应用程序的帮助文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="368"/>
+        <source>&amp;About %1</source>
+        <translation>&amp; 大约 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="369"/>
+        <source>Show information about this application</source>
+        <translation>显示有关此应用程序的信息</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="373"/>
+        <source>About &amp;Qt</source>
+        <translation>关于与 qt 离散度</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="374"/>
+        <source>Show information about Qt</source>
+        <translation>显示有关 qt 离散度的信息</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="380"/>
+        <source>&amp;Help</source>
+        <translation>与帮助</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="564"/>
+        <source>Do you want to remove the autosaved version?</source>
+        <translation>你想要删除自动保存的版本？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="570"/>
+        <source>The file has been modified.
+Do you want to save your changes?</source>
+        <translation>该文件已被修改。
+你想要保存您的更改吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="401"/>
+        <location filename="../src/gui/main_window.cpp" line="712"/>
+        <source>Unsaved file</source>
+        <translation>未保存的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <location filename="../src/gui/main_window.cpp" line="979"/>
+        <location filename="../src/gui/widgets/home_screen_widget.cpp" line="445"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="684"/>
+        <source>The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.
+
+Do you want to scale the symbols to the selected scale?</source>
+        <translation>选定的比例尺是 1:%1，但选的符号集只有 1:%2 名义尺度。
+
+你想要缩放到选定的比例符号吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="754"/>
+        <source>Crash warning</source>
+        <translation>崩溃的警告</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="755"/>
+        <source>It seems that %1 crashed the last time this file was opened:&lt;br /&gt;&lt;tt&gt;%2&lt;/tt&gt;&lt;br /&gt;&lt;br /&gt;Really retry to open it?</source>
+        <translation>看来这 %1 坠毁最后一次打开此文件时间: &lt; br / &gt; &lt;tt&gt;%2&lt;/tt&gt; &lt; br / &gt; &lt; br / &gt; 真的重新尝试打开它吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="946"/>
+        <source>Autosaving...</source>
+        <translation>自动保存...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="956"/>
+        <source>Autosaving failed!</source>
+        <translation>自动保存失败 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1031"/>
+        <source>All maps</source>
+        <translation>所有的地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1035"/>
+        <source>All files</source>
+        <translation>所有文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="723"/>
+        <source>Open file</source>
+        <translation>打开的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
+        <source>You must close the current file before you can open another one.</source>
+        <translation>你可以打开另一个之前，必须关闭当前文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="735"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="693"/>
+        <source>Opening %1</source>
+        <translation>打开 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <location filename="../src/gui/main_window.cpp" line="1091"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="707"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="771"/>
+        <source>Cannot open file:
+%1
+
+File format not recognized.</source>
+        <translation>无法打开文件: %1 文件格式无法识别。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="848"/>
+        <source>The file has been modified.
+Do you want to discard your changes?</source>
+        <translation>该文件已被修改。
+你想要放弃您的更改吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="899"/>
+        <source>&amp;%1 %2</source>
+        <translation>与 %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="978"/>
+        <source>This map is being saved as a &quot;%1&quot; file. Information may be lost.
+
+Press Yes to save in this format.
+Press No to choose a different format.</source>
+        <translation>这张地图是被保存为&quot;%1&quot;的文件。信息可能会丢失。
+
+按是保存为此格式。
+按无选择不同的格式。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1071"/>
+        <source>Save file</source>
+        <translation>保存文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1092"/>
+        <source>File could not be saved:</source>
+        <translation>无法保存文件︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1093"/>
+        <source>There was a problem in determining the file format.</source>
+        <translation>还有一个问题中确定的文件格式。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.cpp" line="1094"/>
+        <source>Please report this as a bug.</source>
+        <translation>请当作一个 bug 报告这。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::Map</name>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <location filename="../src/core/map.cpp" line="699"/>
+        <location filename="../src/core/map.cpp" line="723"/>
+        <location filename="../src/core/map.cpp" line="800"/>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3952"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="287"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="345"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="670"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because saving as %2 (.%3) is not supported.</source>
+        <translation>不能导出该映射为&quot;%1&quot;，因为另存为 %2 (.%3) 不受支持。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="665"/>
+        <source>Cannot export the map as
+&quot;%1&quot;
+because the format is unknown.</source>
+        <translation>不能导出该映射为&quot;%1&quot;，因为该格式是未知。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="706"/>
+        <location filename="../src/core/map.cpp" line="768"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="707"/>
+        <source>The map export generated warnings.</source>
+        <translation>地图出口将生成警告。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="688"/>
+        <source>Internal error while saving:
+%1</source>
+        <translation>保存时出现内部错误: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="769"/>
+        <source>The map import generated warnings.</source>
+        <translation>导入映射生成警告。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="724"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3953"/>
+        <source>Cannot open file:
+%1
+for reading.</source>
+        <translation>无法打开文件: %1 的阅读。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="738"/>
+        <source>Invalid file type.</source>
+        <translation>无效的文件类型。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="801"/>
+        <source>Cannot open file:
+%1
+
+%2</source>
+        <translation>无法打开文件: %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="700"/>
+        <source>Cannot save file
+%1:
+%2</source>
+        <translation>无法保存文件 %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="828"/>
+        <source>Nothing to import.</source>
+        <translation>没有要导入。</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="837"/>
+        <source>Question</source>
+        <translation>问题</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="838"/>
+        <source>The scale of the imported data is 1:%1 which is different from this map&apos;s scale of 1:%2.
+
+Rescale the imported data?</source>
+        <translation>导入的数据规模 1:%1 是从 1:%2 本地图规模不同。
+
+重新缩放导入的数据吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map.cpp" line="500"/>
+        <source>default part</source>
+        <translation>默认部分</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="36"/>
+        <location filename="../src/core/map_color.cpp" line="50"/>
+        <source>New color</source>
+        <translation>新颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3959"/>
+        <source>Import...</source>
+        <translation type="unfinished">导入...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3960"/>
+        <source>Symbol replacement was canceled.
+Import the data anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapColor</name>
+    <message>
+        <location filename="../src/core/map_color.cpp" line="79"/>
+        <source>Registration black (all printed colors)</source>
+        <translation>注册黑色 （所有打印颜色）</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapCoord</name>
+    <message>
+        <location filename="../src/core/map_coord.cpp" line="182"/>
+        <source>Coordinates are out-of-bounds.</source>
+        <translation>坐标是出界。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorController</name>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo</source>
+        <translation>撤消</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="857"/>
+        <source>Undo the last step</source>
+        <translation>撤消最后一步</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo</source>
+        <translation>重做</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="858"/>
+        <source>Redo the last step</source>
+        <translation>重做的最后一步</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="859"/>
+        <source>Cu&amp;t</source>
+        <translation>Cu&amp;t</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="860"/>
+        <source>C&amp;opy</source>
+        <translation>C 与复制</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="861"/>
+        <source>&amp;Paste</source>
+        <translation>与粘贴</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="877"/>
+        <source>Zoom in</source>
+        <translation>放大</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="878"/>
+        <source>Zoom out</source>
+        <translation>缩小</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="880"/>
+        <source>Toggle fullscreen mode</source>
+        <translation>切换全屏模式</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="881"/>
+        <source>Set custom zoom factor...</source>
+        <translation>设置自定义的缩放因子......</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Symbol window</source>
+        <translation>符号窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="888"/>
+        <source>Show/Hide the symbol window</source>
+        <translation>显示/隐藏符号窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Color window</source>
+        <translation>颜色窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="889"/>
+        <source>Show/Hide the color window</source>
+        <translation>显示/隐藏颜色窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace the symbols with those from another map file</source>
+        <translation>符号替换那些来自另一个映射文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale all symbols...</source>
+        <translation>缩放所有符号...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="895"/>
+        <source>Scale the whole symbol set</source>
+        <translation>缩放整个符号集</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change map scale...</source>
+        <translation>更改地图规模......</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="897"/>
+        <source>Change the map scale and adjust map objects and symbol sizes</source>
+        <translation>改变地图规模和调整地图对象和符号尺寸</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="899"/>
+        <source>Map notes...</source>
+        <translation>注意到地图...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Template setup window</source>
+        <translation>模板安装程序窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="901"/>
+        <source>Show/Hide the template window</source>
+        <translation>显示/隐藏模板窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="904"/>
+        <source>Open template...</source>
+        <translation>打开模板...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="879"/>
+        <source>Show whole map</source>
+        <translation>显示整个地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="909"/>
+        <source>Edit objects</source>
+        <translation>编辑对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="911"/>
+        <source>Set point objects</source>
+        <translation>设置点对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="912"/>
+        <source>Draw paths</source>
+        <translation>绘制路径</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="913"/>
+        <source>Draw circles and ellipses</source>
+        <translation>绘制圆和椭圆</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="917"/>
+        <source>Write text</source>
+        <translation>写入文本</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="918"/>
+        <source>Duplicate</source>
+        <translation>重复</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="919"/>
+        <source>Switch symbol</source>
+        <translation>开关符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="920"/>
+        <source>Fill / Create border</source>
+        <translation>填充/创建边框</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="921"/>
+        <source>Switch dash direction</source>
+        <translation>破折号方向切换</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="922"/>
+        <source>Connect paths</source>
+        <translation>连接路径</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="924"/>
+        <source>Cut object</source>
+        <translation>剪切对象</translation>
+    </message>
+    <message>
+        <source>Rotate object(s)</source>
+        <translation type="vanished">旋转对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="937"/>
+        <source>Measure lengths and areas</source>
+        <translation>测量长度和面积</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="940"/>
+        <source>Cut away from area</source>
+        <translation>切离地区</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="942"/>
+        <source>Merge area holes</source>
+        <translation>合并区孔</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="954"/>
+        <source>Paint on template settings</source>
+        <translation>画上模板设置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="960"/>
+        <source>Enable touch cursor</source>
+        <translation>启用触摸光标</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="961"/>
+        <source>Enable GPS display</source>
+        <translation>启用 GPS 显示</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="963"/>
+        <source>Enable GPS distance rings</source>
+        <translation>启用 GPS 距离环</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="965"/>
+        <source>Set point object at GPS position</source>
+        <translation>在 GPS 定位设置点对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="967"/>
+        <source>Set temporary marker at GPS position</source>
+        <translation>在 GPS 定位设置临时记号笔</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="969"/>
+        <source>Create temporary path at GPS position</source>
+        <translation>在 GPS 位置创建临时路径</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="971"/>
+        <source>Clear temporary GPS markers</source>
+        <translation>清除临时 GPS 标记</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="974"/>
+        <source>Enable compass display</source>
+        <translation>启用指南针显示</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="975"/>
+        <source>Align map with north</source>
+        <translation>对齐与北地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="977"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3561"/>
+        <source>Add new part...</source>
+        <translation>添加新的部分...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="978"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3621"/>
+        <source>Rename current part...</source>
+        <translation>重命名当前部分...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="979"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3582"/>
+        <source>Remove current part</source>
+        <translation>删除当前部分</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="980"/>
+        <source>Merge all parts</source>
+        <translation>合并所有零件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="982"/>
+        <source>Import...</source>
+        <translation>导入...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1034"/>
+        <location filename="../src/gui/widgets/color_list_widget.cpp" line="113"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="241"/>
+        <source>&amp;Edit</source>
+        <translation>与编辑</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1055"/>
+        <source>&amp;View</source>
+        <translation>与视图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1084"/>
+        <source>&amp;Tools</source>
+        <translation>与工具</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1137"/>
+        <source>Sy&amp;mbols</source>
+        <translation>Sy &amp; mbols</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1119"/>
+        <source>M&amp;ap</source>
+        <translation>购 ap</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1149"/>
+        <source>&amp;Templates</source>
+        <translation>与模板</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1205"/>
+        <source>Drawing</source>
+        <translation>绘图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="949"/>
+        <source>Paint on template</source>
+        <translation>在模板上画</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>Editing in progress</source>
+        <translation>在进展中编辑</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="550"/>
+        <source>The map is currently being edited. Please finish the edit operation before saving.</source>
+        <translation>当前正在编辑的地图。请完成编辑操作然后再进行保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="555"/>
+        <source>Map saved</source>
+        <translation>保存地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="871"/>
+        <source>Show grid</source>
+        <translation>显示网格</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="872"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1180"/>
+        <source>Configure grid...</source>
+        <translation>配置网格...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="883"/>
+        <source>Hatch areas</source>
+        <translation>剖面线区域</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="884"/>
+        <source>Baseline view</source>
+        <translation>基线视图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="885"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="102"/>
+        <source>Hide all templates</source>
+        <translation>隐藏所有模板</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="891"/>
+        <source>Replace symbol set...</source>
+        <translation>替换符号集...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="896"/>
+        <source>Georeferencing...</source>
+        <translation>小基......</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate map...</source>
+        <translation>旋转地图...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="898"/>
+        <source>Rotate the whole map</source>
+        <translation>旋转整个地图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="905"/>
+        <source>Reopen template...</source>
+        <translation>重新打开模板...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Tag editor</source>
+        <translation>标签编辑器</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="907"/>
+        <source>Show/Hide the tag editor window</source>
+        <translation>显示/隐藏标记编辑器窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="914"/>
+        <source>Draw rectangles</source>
+        <translation>绘制矩形</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="915"/>
+        <source>Draw free-handedly</source>
+        <translation>单枪匹马的自由绘制</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="916"/>
+        <source>Fill bounded areas</source>
+        <translation>填充有界的区域</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="925"/>
+        <source>Cut free form hole</source>
+        <translation>挖了自由形式</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="926"/>
+        <source>Cut round hole</source>
+        <translation>切圆孔</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="927"/>
+        <source>Cut rectangular hole</source>
+        <translation>剪切矩形孔</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="935"/>
+        <source>Rotate pattern</source>
+        <translation>旋转模式</translation>
+    </message>
+    <message>
+        <source>Scale object(s)</source>
+        <translation type="vanished">规模对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="938"/>
+        <source>Unify areas</source>
+        <translation>统一的领域</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="939"/>
+        <source>Intersect areas</source>
+        <translation>相交区域</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="941"/>
+        <source>Area XOr</source>
+        <translation>异或地区</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="945"/>
+        <source>Cutout</source>
+        <translation>剪影</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="946"/>
+        <source>Cut away</source>
+        <translation>切掉了</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="947"/>
+        <source>Distribute points along path</source>
+        <translation>分发点沿路径</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="984"/>
+        <source>Map coordinates</source>
+        <translation>地图坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="986"/>
+        <source>Projected coordinates</source>
+        <translation>投影的坐标</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="988"/>
+        <source>Latitude/Longitude (Dec)</source>
+        <translation>经纬度 （12 月）</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="990"/>
+        <source>Latitude/Longitude (DMS)</source>
+        <translation>经纬度 (DMS)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1069"/>
+        <source>Display coordinates as...</source>
+        <translation>显示坐标作为...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="928"/>
+        <source>Cut hole</source>
+        <translation>挖洞</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="798"/>
+        <source>Ctrl+A</source>
+        <translation>按 Ctrl + A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="799"/>
+        <source>Ctrl+Shift+A</source>
+        <translation>Ctrl + Shift + A</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="800"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl + I</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="802"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="815"/>
+        <source>E</source>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="816"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="817"/>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="818"/>
+        <source>P</source>
+        <translation>P</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="819"/>
+        <source>O</source>
+        <translation>O</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="820"/>
+        <source>Ctrl+R</source>
+        <translation>Ctrl + R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="821"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="822"/>
+        <source>T</source>
+        <translation>T</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="824"/>
+        <source>D</source>
+        <translation>D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="825"/>
+        <source>Ctrl+G</source>
+        <translation>Ctrl + G</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="826"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl + F</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="827"/>
+        <source>Ctrl+D</source>
+        <translation>按 Ctrl + D</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="828"/>
+        <source>C</source>
+        <translation>C</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="829"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="830"/>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="831"/>
+        <source>K</source>
+        <translation>K</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="832"/>
+        <source>H</source>
+        <translation>H</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="833"/>
+        <source>M</source>
+        <translation>M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="834"/>
+        <source>U</source>
+        <translation>U</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="835"/>
+        <source>N</source>
+        <translation>N</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="836"/>
+        <source>Ctrl+M</source>
+        <translation>Ctrl + M</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="863"/>
+        <source>Select all</source>
+        <translation>选择所有</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="864"/>
+        <source>Select nothing</source>
+        <translation>不选择任何内容</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="865"/>
+        <source>Invert selection</source>
+        <translation>反向选择</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Symbol set ID...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="890"/>
+        <source>Edit the symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Load CRT file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="892"/>
+        <source>Assign new symbols by cross-reference table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tag Selection</source>
+        <translation type="vanished">标记选择</translation>
+    </message>
+    <message>
+        <source>Show/Hide the tag selection window</source>
+        <translation type="vanished">显示/隐藏标记选择窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position</source>
+        <translation>副本位置</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1002"/>
+        <source>Copy position to clipboard.</source>
+        <translation>将位置复制到剪贴板。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1173"/>
+        <source>View</source>
+        <translation>视图</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1191"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1196"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1328"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3496"/>
+        <source>Map parts</source>
+        <translation>地图部分</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1223"/>
+        <source>Select template...</source>
+        <translation>选择模板...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1229"/>
+        <source>Editing</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1254"/>
+        <source>Advanced editing</source>
+        <translation>高级编辑</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1281"/>
+        <source>Select symbol</source>
+        <translation>选择符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1321"/>
+        <source>Hide top bar</source>
+        <translation>隐藏顶栏</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1324"/>
+        <source>Show top bar</source>
+        <translation>显示顶部栏</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1589"/>
+        <source>Print / Export is not available in this program version!</source>
+        <translation>打印 / 导出此程序版本中不可用 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1609"/>
+        <source>No undo steps available.</source>
+        <translation>没有可用的撤消步骤。</translation>
+    </message>
+    <message>
+        <source>Cut %1 object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation type="vanished">切断 %1 对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1666"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1699"/>
+        <source>An internal error occurred, sorry!</source>
+        <translation>发生内部错误，抱歉 ！</translation>
+    </message>
+    <message>
+        <source>Copied %1 object(s)</source>
+        <translation type="vanished">复制 %1 对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1686"/>
+        <source>There are no objects in clipboard which could be pasted!</source>
+        <translation>可以粘贴的剪贴板中没有对象 ！</translation>
+    </message>
+    <message>
+        <source>Pasted %1 object(s)</source>
+        <translation type="vanished">粘贴的 %1 对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Set custom zoom factor</source>
+        <translation>设置自定义的缩放因子</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1774"/>
+        <source>Zoom factor:</source>
+        <translation>缩放因子︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1848"/>
+        <source>Symbols</source>
+        <translation>符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1862"/>
+        <source>Colors</source>
+        <translation>颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1883"/>
+        <source>Symbol set ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1884"/>
+        <source>Edit the symbol set ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale all symbols</source>
+        <translation>缩放所有符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1911"/>
+        <source>Scale to percentage:</source>
+        <translation>按百分比缩放︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1935"/>
+        <source>Map notes</source>
+        <translation>地图说明</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1940"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="363"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1941"/>
+        <source>OK</source>
+        <translation>还行</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1981"/>
+        <source>Templates</source>
+        <translation>模板</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2043"/>
+        <source>Tag Editor</source>
+        <translation>标签编辑器</translation>
+    </message>
+    <message>
+        <source>Tag Selector</source>
+        <translation type="vanished">标签选择器</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2106"/>
+        <source>No
+symbol
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation>没有选定的符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2107"/>
+        <source>Multiple
+symbols
+selected</source>
+        <comment>Keep it short. Should not be much longer per line than the longest word in the original.</comment>
+        <translation>选定的多个符号</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Place point objects on the map.</source>
+        <translation>在地图上放置点对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2195"/>
+        <source>Select a point symbol to be able to use this tool.</source>
+        <translation>选择一个点符号，以便能够使用此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <source>Draw polygonal and curved lines.</source>
+        <translation>绘制多边形和曲线。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2197"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Select a line, area or combined symbol to be able to use this tool.</source>
+        <translation>选择线条、 地区或联合的象征，必须能够使用此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2199"/>
+        <source>Draw circles and ellipses.</source>
+        <translation>绘制圆和椭圆。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2203"/>
+        <source>Draw paths free-handedly.</source>
+        <translation>绘制路径免费单枪匹马。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2205"/>
+        <source>Fill bounded areas.</source>
+        <translation>填充有界的区域。</translation>
+    </message>
+    <message>
+        <source>Deletes the selected object(s).</source>
+        <translation type="vanished">删除所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Set the direction of area fill patterns or point objects.</source>
+        <translation>设置区域的方向填充图案或点对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2310"/>
+        <source>Select an area object with rotatable fill pattern or a rotatable point object to activate this tool.</source>
+        <translation>选择区域对象与旋转填充图案或要激活此工具可旋转点对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2340"/>
+        <source>Resulting symbol: %1 %2.</source>
+        <translation>生成的符号: %1 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2341"/>
+        <source>Select at least two area or path objects activate this tool.</source>
+        <translation>选择至少两个区域或路径对象激活此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2343"/>
+        <source>Unify overlapping objects.</source>
+        <translation>统一重叠对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2345"/>
+        <source>Remove all parts which are not overlaps with the first selected object.</source>
+        <translation>删除不是重叠与第一个选定对象的所有部分。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2347"/>
+        <source>Remove overlapped parts of the first selected object.</source>
+        <translation>删除第一个选定对象的重叠的部分。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2349"/>
+        <source>Remove all parts which overlap the first selected object.</source>
+        <translation>删除重叠的第一个选定的对象的所有部分。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Merge area holes together, or merge holes with the object boundary to cut out this part.</source>
+        <translation>将地区孔合并在一起，或合并对象边界裁剪这一部分孔。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2353"/>
+        <source>Select one area object with holes to activate this tool.</source>
+        <translation>选择一个区域对象与孔来激活此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <source>Create a cutout of some objects or the whole map.</source>
+        <translation>创建某些对象或整个地图的一个保险开关。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2358"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Select a closed path object as cutout shape to activate this tool.</source>
+        <translation>作为抠出形状来激活此工具选择一个封闭的路径对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2360"/>
+        <source>Cut away some objects or everything in a limited area.</source>
+        <translation>砍掉某些对象或一个有限的区域中的所有内容。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Places evenly spaced point objects along an existing path object</source>
+        <translation>点对象沿现有路径对象间隔均匀的地方</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2379"/>
+        <source>Select at least one path object and a single point symbol to activate this tool.</source>
+        <translation>选择至少一个路径对象和一个单点符号来激活此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3104"/>
+        <source>Merging holes failed.</source>
+        <translation>合并孔失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Clear temporary markers</source>
+        <translation>清除临时标记</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3388"/>
+        <source>Are you sure you want to delete all temporary GPS markers? This cannot be undone.</source>
+        <translation>你确定你想要删除所有临时 GPS 标记？这不能撤消。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3502"/>
+        <source>Merge this part with</source>
+        <translation>合并与这部分</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3508"/>
+        <source>Move selected objects to</source>
+        <translation>移动到所选的对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3562"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3622"/>
+        <source>Enter the name of the map part:</source>
+        <translation>输入地图部分的名称︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3638"/>
+        <source>Switched to map part &apos;%1&apos;.</source>
+        <translation>切换到地图部分 &apos;%1&apos;。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3660"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="3692"/>
+        <source>Merge map parts</source>
+        <translation>合并地图部分</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3661"/>
+        <source>Do you want to move all objects from map part &quot;%1&quot; to &quot;%2&quot;, and to remove &quot;%1&quot;?</source>
+        <translation>你想要将所有对象从地图部分&quot;%1&quot;都移动到&quot;%2&quot;，并删除&quot;%1&quot;吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3693"/>
+        <source>Do you want to move all objects to map part &quot;%1&quot;, and to remove all other map parts?</source>
+        <translation>你想要移动所有对象映射部分&quot;%1&quot;，并删除所有其他地图部分吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3918"/>
+        <source>Cannot import the selected map file because it could not be loaded.</source>
+        <translation>无法导入所选的映射文件，因为它不能被加载。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2201"/>
+        <source>Draw rectangles.</source>
+        <translation>绘制矩形。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="845"/>
+        <source>Print...</source>
+        <translation>打印......</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="847"/>
+        <source>&amp;Image</source>
+        <translation>与图像</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="849"/>
+        <source>&amp;PDF</source>
+        <translation>&amp; PDF</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear undo / redo history</source>
+        <translation>清除撤消/重做历史</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="869"/>
+        <source>Clear the undo / redo history to reduce map file size.</source>
+        <translation>清楚的撤消/重做历史记录为了减少地图文件大小。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="876"/>
+        <source>Pan</source>
+        <translation>潘</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="886"/>
+        <source>Overprinting simulation</source>
+        <translation>叠印模拟</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="910"/>
+        <source>Edit lines</source>
+        <translation>编辑行</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="943"/>
+        <source>Convert to curves</source>
+        <translation>转换为曲线</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="944"/>
+        <source>Simplify path</source>
+        <translation>简化路径</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="1026"/>
+        <source>&amp;Export as...</source>
+        <translation>与作为出口...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Write text on the map.</source>
+        <translation>在地图上写的文本。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2207"/>
+        <source>Select a text symbol to be able to use this tool.</source>
+        <translation>选择一个文本符号，以便能够使用此工具。</translation>
+    </message>
+    <message>
+        <source>Duplicate the selected object(s).</source>
+        <translation type="vanished">复制所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Select at least one object to activate this tool.</source>
+        <translation>选择至少一个对象来激活此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <source>Switch the direction of symbols on line objects.</source>
+        <translation>切换行对象的符号的方向。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2314"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Select at least one line object to activate this tool.</source>
+        <translation>选择至少一个要激活此工具的线对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2316"/>
+        <source>Connect endpoints of paths which are close together.</source>
+        <translation>将终结点的路径，都是紧密连接。</translation>
+    </message>
+    <message>
+        <source>Cut the selected object(s) into smaller parts.</source>
+        <translation type="vanished">剪切所选的对象分成较小部分。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Select at least one line or area object to activate this tool.</source>
+        <translation>选择至少一个线或区域的对象来激活此工具。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Cut a hole into the selected area object.</source>
+        <translation>剪一个洞到选定的区域的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2329"/>
+        <source>Select a single area object to activate this tool.</source>
+        <translation>选择要激活此工具的单个区域对象。</translation>
+    </message>
+    <message>
+        <source>Rotate the selected object(s).</source>
+        <translation type="vanished">旋转所选的对象。</translation>
+    </message>
+    <message>
+        <source>Scale the selected object(s).</source>
+        <translation type="vanished">缩放所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <source>Turn paths made of straight segments into smooth bezier splines.</source>
+        <translation>轮到路径的直线段做成光滑贝塞尔样条。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2322"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Select a path object to activate this tool.</source>
+        <translation>选择要激活此工具的路径对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2324"/>
+        <source>Reduce the number of points in path objects while trying to retain their shape.</source>
+        <translation>减少路径对象的点的数量，同时设法留住他们的形状。</translation>
+    </message>
+    <message>
+        <source>Switches the symbol of the selected object(s) to the selected symbol.</source>
+        <translation type="vanished">将所选对象的符号切换到所选符号。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Select at least one object and a fitting, different symbol to activate this tool.</source>
+        <translation>选择至少一个对象和一个拟合、 不同的符号来激活此工具。</translation>
+    </message>
+    <message>
+        <source>Fill the selected line(s) or create a border for the selected area(s).</source>
+        <translation type="vanished">填充选定的线路或创建选取区域的边框。</translation>
+    </message>
+    <message>
+        <source>%1 object(s) duplicated</source>
+        <translation type="vanished">%1 对象复制</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>Object selection</source>
+        <translation>选取对象</translation>
+    </message>
+    <message>
+        <source>No objects were selected because there are no objects with the selected symbol(s).</source>
+        <translation type="vanished">因为没有与所选符号的对象选择的对象没有。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3063"/>
+        <source>Measure</source>
+        <translation>措施</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3077"/>
+        <source>Unification failed.</source>
+        <translation>失败的统一。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3083"/>
+        <source>Intersection failed.</source>
+        <translation>失败的十字路口。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3089"/>
+        <source>Difference failed.</source>
+        <translation>失败的差异。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3095"/>
+        <source>XOr failed.</source>
+        <translation>异或失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3583"/>
+        <source>Do you want to remove map part &quot;%1&quot; and all its objects?</source>
+        <translation>你想要删除地图部分&quot;%1&quot;及其所有对象吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3747"/>
+        <source>Paint free-handedly on a template</source>
+        <translation>自由-单枪匹马在模板上画</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3749"/>
+        <source>Paint free-handedly on a template. Create or load a template which can be drawn onto to activate this button</source>
+        <translation>自由-单枪匹马在模板上油漆。创建或加载一个模板，可以上绘制以激活此按钮</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3878"/>
+        <source>Import %1, GPX, OSM or DXF file</source>
+        <translation>%1，GPX，OSM 或 DXF 文件导入</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>Importable files</source>
+        <translation>可导入文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3882"/>
+        <source>All files</source>
+        <translation>所有文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="3911"/>
+        <source>Cannot import the selected file because its file format is not supported.</source>
+        <translation>无法导入所选的文件，因为其文件格式不受支持。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="934"/>
+        <source>Rotate objects</source>
+        <translation>旋转对象</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="936"/>
+        <source>Scale objects</source>
+        <translation>缩放对象</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1623"/>
+        <source>Cut %n object(s)</source>
+        <extracomment>Past tense. Displayed when an Edit &gt; Cut operation is completed.</extracomment>
+        <translation>
+            <numerusform>切 %n 对象</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1676"/>
+        <source>Copied %n object(s)</source>
+        <translation>
+            <numerusform>%N 复制的对象</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="1716"/>
+        <source>Pasted %n object(s)</source>
+        <translation>
+            <numerusform>%N 粘贴的对象</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2299"/>
+        <source>Deletes the selected objects.</source>
+        <translation>删除所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2301"/>
+        <source>Duplicate the selected objects.</source>
+        <translation>复制选定的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2303"/>
+        <source>Rotate the selected objects.</source>
+        <translation>旋转所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2305"/>
+        <source>Scale the selected objects.</source>
+        <translation>缩放所选的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2320"/>
+        <source>Cut the selected objects into smaller parts.</source>
+        <translation>切成更小的部分选定的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2374"/>
+        <source>Switches the symbol of the selected objects to the selected symbol.</source>
+        <translation>切换到所选符号的所选对象的符号。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2376"/>
+        <source>Fill the selected lines or create a border for the selected areas.</source>
+        <translation>创建所选区域的边框或填充选定的行。</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/map/map_editor.cpp" line="2495"/>
+        <source>Duplicated %n object(s)</source>
+        <translation>
+            <numerusform>%N 重复的对象</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_editor.cpp" line="2705"/>
+        <source>No objects were selected because there are no objects with the selected symbols.</source>
+        <translation>未选中对象因为没有对象与选定的符号。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapEditorTool</name>
+    <message>
+        <location filename="../src/templates/template_adjust.cpp" line="619"/>
+        <location filename="../src/tools/cutout_tool.cpp" line="156"/>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1226"/>
+        <location filename="../src/tools/draw_circle_tool.cpp" line="317"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="767"/>
+        <location filename="../src/tools/draw_freehand_tool.cpp" line="290"/>
+        <source>&lt;b&gt;%1&lt;/b&gt;: Abort. </source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;︰ 中止。 </translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1245"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="720"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="721"/>
+        <location filename="../src/tools/edit_point_tool.cpp" line="765"/>
+        <source>More: %1, %2</source>
+        <translation>更多: %1、 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1242"/>
+        <location filename="../src/tools/edit_line_tool.cpp" line="536"/>
+        <source>More: %1</source>
+        <translation>更多: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/draw_path_tool.cpp" line="1248"/>
+        <location filename="../src/tools/draw_rectangle_tool.cpp" line="719"/>
+        <source>More: %1, %2, %3</source>
+        <translation>更多: %1、 %2 和 %3</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapFindFeature</name>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="55"/>
+        <source>&amp;Find...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="62"/>
+        <source>Find &amp;next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="92"/>
+        <source>Find objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="99"/>
+        <source>&amp;Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="102"/>
+        <source>Find &amp;all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="105"/>
+        <source>Query editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapPrinter</name>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="490"/>
+        <source>- Map -</source>
+        <translation>-地图-</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1241"/>
+        <source>Processing separations of page %1...</source>
+        <translation>分色处理的页 %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1242"/>
+        <source>Processing page %1...</source>
+        <translation>处理页 %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1292"/>
+        <source>Canceled</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1296"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/core/map_printer.cpp" line="1301"/>
+        <source>Finished</source>
+        <translation>完成</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapSymbolTranslation</name>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="275"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <source>Text source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="325"/>
+        <source>Map (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="518"/>
+        <location filename="../src/gui/color_dialog.cpp" line="533"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="326"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="339"/>
+        <source>undefined language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="536"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="342"/>
+        <source>Translation (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="588"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="216"/>
+        <source>Before editing, the stored text will be replaced with the current translation. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/color_dialog.cpp" line="595"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="223"/>
+        <source>After modifying the stored text, the translation may no longer be found. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MapWidget</name>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="580"/>
+        <source>%1x</source>
+        <comment>Zoom factor</comment>
+        <translation>%1 x</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="602"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="618"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="655"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="837"/>
+        <source>Empty map!
+
+Start by defining some colors:
+Select Symbols -&gt; Color window to
+open the color dialog and
+define the colors there.</source>
+        <translation>空的地图 ！
+
+首先定义一些颜色︰ 选择符号-&gt; 颜色窗口打开颜色对话框并定义那里的颜色。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="839"/>
+        <source>No symbols!
+
+Now define some symbols:
+Right-click in the symbol bar
+and select &quot;New symbol&quot;
+to create one.</source>
+        <translation>没有符号 ！
+
+现在定义一些符号︰ 符号栏中用鼠标右键单击并选择&quot;新符号&quot;来创建一个。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Ready to draw!
+
+Start drawing or load a base map.
+To load a base map, click
+Templates -&gt; Open template...</source>
+        <translation>准备好画 ！
+
+开始绘制或加载底图。
+若要加载底图，单击模板-&gt; 打开模板...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/map_widget.cpp" line="841"/>
+        <source>Hint: Hold the middle mouse button to drag the map,
+zoom using the mouse wheel, if available.</source>
+        <translation>提示︰ 按住鼠标按钮拖动地图，使用鼠标滚轮缩放如果可用。</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::MeasureWidget</name>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="98"/>
+        <source>Boundary length:</source>
+        <translation>边界长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="136"/>
+        <source>Length:</source>
+        <translation>长度︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="114"/>
+        <source>Area:</source>
+        <translation>区域︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="61"/>
+        <source>No object selected.</source>
+        <translation>没有选定的对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="65"/>
+        <source>%1 objects selected.</source>
+        <translation>选择 %1 对象。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="75"/>
+        <source>The selected object is not a path.</source>
+        <translation>所选的对象不是一个路径。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="99"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="137"/>
+        <source>mm</source>
+        <comment>millimeters</comment>
+        <translation>毫米</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="100"/>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="138"/>
+        <source>m</source>
+        <comment>meters</comment>
+        <translation>m</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="115"/>
+        <source>mm²</source>
+        <comment>square millimeters</comment>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="116"/>
+        <source>m²</source>
+        <comment>square meters</comment>
+        <translation>m ²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="128"/>
+        <source>This object is too small.</source>
+        <translation>此对象是太小了。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>The minimimum area is %1 %2.</source>
+        <translation>管网地区是 %1 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="129"/>
+        <source>mm²</source>
+        <translation>mm²</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="132"/>
+        <source>Note: Boundary length and area are correct only if there are no self-intersections and holes are used as such.</source>
+        <translation>注︰ 边界长度和面积是正确的才有没有自交和孔同样地使用。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="150"/>
+        <source>This line is too short.</source>
+        <translation>这条线是太短。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>The minimum length is %1 %2.</source>
+        <translation>最小长度是 %1 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/widgets/measure_widget.cpp" line="151"/>
+        <source>mm</source>
+        <translation>毫米</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::NewMapDialog</name>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="66"/>
+        <source>Create new map</source>
+        <translation>创建新的映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="70"/>
+        <source>Choose the scale and symbol set for the new map.</source>
+        <translation>选择的规模和符号集的新地图。</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="77"/>
+        <source>Scale:  1 : </source>
+        <translation>规模︰ 1: </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="82"/>
+        <source>Symbol sets:</source>
+        <translation>符号集︰</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="87"/>
+        <source>Only show symbol sets matching the selected scale</source>
+        <translation>只显示符号集的选定的规模相匹配</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">取消</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="95"/>
+        <source>Create</source>
+        <translation>创建</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="171"/>
+        <source>Empty symbol set</source>
+        <translation>空符号集</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="209"/>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="264"/>
+        <source>Load symbol set from a file...</source>
+        <translation>从文件中加载符号集...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="260"/>
+        <source>All symbol set files</source>
+        <translation>所有符号设置的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/map/new_map_dialog.cpp" line="262"/>
+        <source>All files</source>
+        <translation>所有文件</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileExport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1559"/>
+        <source>The map contains more than 256 colors which is not supported by ocd version 8.</source>
+        <translation>映射包含 256 种以上颜色的强迫症版本 8 中找不到支持。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1563"/>
+        <source>libocad returned %1</source>
+        <translation>libocad 返回 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1608"/>
+        <source>Registration black is exported as a regular color.</source>
+        <translation>注册黑色导出为定期的颜色。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1716"/>
+        <source>Unable to export fill pattern shift for an area object</source>
+        <translation>无法导出区域对象的填充模式转变</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1866"/>
+        <source>Unable to export template: file type of &quot;%1&quot; is not supported yet</source>
+        <translation>无法导出模板:&quot;%1&quot;的文件类型尚不支持</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1889"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1900"/>
+        <source>Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1911"/>
+        <source>Some coordinates remain outside of the OCAD 8 drawing area. They might be unreachable in OCAD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2182"/>
+        <source>In line symbol &quot;%1&quot;, cannot represent cap/join combination.</source>
+        <translation>在行的符号&quot;%1&quot;，不能代表帽/联接组合。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2206"/>
+        <source>In line symbol &quot;%1&quot;, neglecting the dash grouping.</source>
+        <translation>行中的符号&quot;%1&quot;，忽视了短跑分组。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2217"/>
+        <source>In line symbol &quot;%1&quot;, the number of dashes in a group has been reduced to 2.</source>
+        <translation>线符号&quot;%1&quot;，在有了破折号在一群数目减少到 2。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2273"/>
+        <source>In line symbol &quot;%1&quot;, cannot export the borders correctly.</source>
+        <translation>在行的符号&quot;%1&quot;，不能正确导出边界。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2332"/>
+        <source>In area symbol &quot;%1&quot;, skipping a fill pattern.</source>
+        <translation>在地区的符号&quot;%1&quot;，跳过填充图案。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2379"/>
+        <source>In area symbol &quot;%1&quot;, assuming a &quot;shifted rows&quot; point pattern. This might be correct as well as incorrect.</source>
+        <translation>在地区的符号&quot;%1&quot;，假设&quot;转移的行&quot;点模式。这可能是正确的以及不正确。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2418"/>
+        <source>In text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation>在文本中的符号 %1︰ 设置自定义字符间距，其执行尚未不符遗漏的行为</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2425"/>
+        <source>In text symbol %1: ignoring underlining</source>
+        <translation>在文本中的符号 %1︰ 忽略下划线</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2427"/>
+        <source>In text symbol %1: ignoring kerning</source>
+        <translation>在文本中的符号 %1︰ 忽略字偶间距调整</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="2851"/>
+        <source>String truncated (truncation marked with three &apos;|&apos;): %1</source>
+        <translation>字符串被截断 (截断标记三个 &apos; |&apos;): %1</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OCAD8FileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="118"/>
+        <source>Could not allocate buffer.</source>
+        <translation>无法分配缓冲区。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="122"/>
+        <source>libocad returned %1</source>
+        <translation>libocad 返回 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="125"/>
+        <source>OCAD files of version %1 are not supported!</source>
+        <translation>不支持 OCAD 文件的版本是 %1 ！</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="149"/>
+        <source>%n color separation(s) were skipped, reason: Import disabled.</source>
+        <translation>
+            <numerusform>%n 颜色 separation(s) 被跳过，原因︰ 导入已禁用。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="154"/>
+        <source>Could not load the spot color definitions, error: %1</source>
+        <translation>不能加载专色定义，错误: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="215"/>
+        <source>Color &quot;Registration black&quot; is imported as a special color.</source>
+        <translation>作为特殊的颜色，导入颜色&quot;注册黑&quot;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="279"/>
+        <source>Unable to import symbol &quot;%3&quot; (%1.%2)</source>
+        <translation>无法导入符号&quot;%3&quot;(%1.%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="292"/>
+        <source>OCAD import layer</source>
+        <translation>OCAD 导入图层</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="432"/>
+        <source>In dashed line symbol %1, pointed cap lengths for begin and end are different (%2 and %3). Using %4.</source>
+        <translation>在虚线符号 %1，尖尖的帽长度为开始和结束都不同 （%2 和 %3）。使用 %4。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="449"/>
+        <source>In dashed line symbol %1, the end length cannot be imported correctly.</source>
+        <translation>在虚线符号 %1，末端长度不能正确导入。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="451"/>
+        <source>In dashed line symbol %1, the end gap cannot be imported correctly.</source>
+        <translation>在虚线符号 %1，结束差距无法正确导入。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="460"/>
+        <source>In dashed line symbol %1, main and end length are different (%2 and %3). Using %4.</source>
+        <translation>在虚线符号 %1，主要和结束长度是不同 （%2 和 %3）。使用 %4。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="470"/>
+        <source>In dashed line symbol %1, gaps D and E are different (%2 and %3). Using %4.</source>
+        <translation>在虚线符号 %1，D 和 E 的差距是不同 （%2 和 %3）。使用 %4。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="620"/>
+        <source>Line symbol %1: suppressing dash symbol at line ends.</source>
+        <translation>线符号 %1︰ 抑制线两端破折号。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="758"/>
+        <source>During import of text symbol %1: ignoring justified alignment</source>
+        <translation>文本导入过程中符号 %1︰ 忽略两端的对齐</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="764"/>
+        <source>During import of text symbol %1: ignoring custom weight (%2)</source>
+        <translation>文本导入过程中符号 %1︰ 忽略自定义权重 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="769"/>
+        <source>During import of text symbol %1: custom character spacing is set, its implementation does not match OCAD&apos;s behavior yet</source>
+        <translation>文本导入过程中符号 %1︰ 设置自定义字符间距，其执行尚未不符遗漏的行为</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="774"/>
+        <source>During import of text symbol %1: ignoring custom word spacing (%2%)</source>
+        <translation>文本导入过程中符号 %1︰ 忽略自定义单词间距 （%2%)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="779"/>
+        <source>During import of text symbol %1: ignoring custom indents (%2/%3)</source>
+        <translation>文本导入过程中符号 %1︰ 忽略自定义缩进 (%2 / 3%)</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="800"/>
+        <source>During import of text symbol %1: ignoring text framing (mode %2)</source>
+        <translation>文本导入过程中符号 %1︰ 忽略文本框架 （模式 %2）</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="954"/>
+        <source>Unable to load object</source>
+        <translation>无法加载对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="961"/>
+        <source>Unable to import rectangle object</source>
+        <translation>无法导入矩形对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1008"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation>不导入文本符号，找不出路径 &apos; (npts = %1): %2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1200"/>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1307"/>
+        <source>Unable to import template: background &quot;%1&quot; doesn&apos;t seem to be a raster image</source>
+        <translation>无法导入模板︰ 背景&quot;%1&quot;似乎不是一个光栅图像</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1412"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation>尝试导入具有未知坐标格式的文本对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocad8_file_format.cpp" line="1523"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation>找不到的颜色 id: %1，无视这种颜色</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::ObjectQuery</name>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="295"/>
+        <source>is</source>
+        <extracomment>Very short label</extracomment>
+        <translation>是</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="298"/>
+        <source>is not</source>
+        <extracomment>Very short label</extracomment>
+        <translation>不是</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="301"/>
+        <source>contains</source>
+        <extracomment>Very short label</extracomment>
+        <translation>包含</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="304"/>
+        <source>Search</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="307"/>
+        <source>Text</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished">文本</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="311"/>
+        <source>and</source>
+        <extracomment>Very short label</extracomment>
+        <translation>和</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="314"/>
+        <source>or</source>
+        <extracomment>Very short label</extracomment>
+        <translation>或</translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="318"/>
+        <source>Symbol</source>
+        <extracomment>Very short label</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/objects/object_query.cpp" line="322"/>
+        <source>invalid</source>
+        <extracomment>Very short label</extracomment>
+        <translation>无效</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OcdFileImport</name>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="148"/>
+        <source>In line symbol %1 &apos;%2&apos;: %3</source>
+        <translation>线符号 %1 &apos;%2&apos; 中: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="154"/>
+        <source>In text symbol %1 &apos;%2&apos;: %3</source>
+        <translation>在文本符号 %1 &apos;%2&apos;: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="412"/>
+        <source>Could not load the coordinate reference system &apos;%1&apos;.</source>
+        <translation>无法加载坐标参照系统 &apos;%1&apos;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="446"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="453"/>
+        <source>Spot color information was ignored.</source>
+        <translation>专色信息被忽略了。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="581"/>
+        <source>Unable to import symbol %1.%2 &quot;%3&quot;: %4</source>
+        <translation>无法导入符号 %1.%2&quot;%3&quot;: %4</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="585"/>
+        <source>Unsupported type &quot;%1&quot;.</source>
+        <translation>不支持的类型&quot;%1&quot;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="678"/>
+        <source>Unable to import template: &quot;%1&quot; is not a supported template type.</source>
+        <translation>无法导入模板:&quot;%1&quot;不是一种支持的模板类型。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="926"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="988"/>
+        <source>Unsupported line style &apos;%1&apos;.</source>
+        <translation>不受支持的线条样式 &apos;%1&apos;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1025"/>
+        <source>Different lengths for pointed caps at begin (%1 mm) and end (%2 mm) are not supported. Using %3 mm.</source>
+        <translation>不支持不同长度的尖帽 （%1 毫米） 开始和结尾 （%2 毫米）。使用 %3 毫米。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1041"/>
+        <source>The dash pattern cannot be imported correctly.</source>
+        <translation>短划线图案无法正确导入。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1056"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1088"/>
+        <source>The dash pattern&apos;s end length (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation>短划线图案末端长度 （%1 毫米） 无法正确导入。使用 %2 毫米。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1063"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1103"/>
+        <source>The dash pattern&apos;s end gap (%1 mm) cannot be imported correctly. Using %2 mm.</source>
+        <translation>短划线图案结束间隙 （%1 毫米） 无法正确导入。使用 %2 毫米。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1145"/>
+        <source>Unsupported framing line style &apos;%1&apos;.</source>
+        <translation>不支持的帧线条样式 &apos;%1&apos;。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1217"/>
+        <source>Skipped secondary point symbol.</source>
+        <translation>跳过二次点符号。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1253"/>
+        <source>Suppressing dash symbol at line ends.</source>
+        <translation>抑制破折号在行结束。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="969"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1322"/>
+        <source>This symbol cannot be saved as a proper OCD symbol again.</source>
+        <translation>这个符号不能再保存为相应的强迫症符号。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1977"/>
+        <source>Justified alignment is not supported.</source>
+        <translation>不支持两端的对齐。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1992"/>
+        <source>Vertical alignment &apos;%1&apos; is not supported.</source>
+        <translation>垂直对齐方式 &apos;%1&apos; 不受支持。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1964"/>
+        <source>Ignoring custom weight (%1).</source>
+        <translation>忽略自定义权重 (%1)。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2001"/>
+        <source>Custom character spacing may be incorrect.</source>
+        <translation>自定义字符间距可能不正确。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2006"/>
+        <source>Ignoring custom word spacing (%1 %).</source>
+        <translation>忽略自定义单词间距 （%1%）。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2030"/>
+        <source>Ignoring custom indents (%1/%2).</source>
+        <translation>忽略自定义缩进 (%1 / %2)。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2052"/>
+        <source>Ignoring text framing (mode %1).</source>
+        <translation>忽略文本框架 （模式 %1）。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1411"/>
+        <source>Line text symbols are not yet supported. Marking the symbol as hidden.</source>
+        <translation>尚不支持行文本符号。标记为隐藏的符号。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="105"/>
+        <source>Encoding &apos;%1&apos; is not available. Check the settings.</source>
+        <translation>编码 &apos;%1&apos; 不是可用的。请检查设置。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="142"/>
+        <source>In area symbol %1 &apos;%2&apos;: %3</source>
+        <translation>在地区符号 %1 &apos;%2&apos;: %3</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1588"/>
+        <source>Unable to load object</source>
+        <translation>无法加载对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1598"/>
+        <source>Unable to import rectangle object</source>
+        <translation>无法导入矩形对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1639"/>
+        <source>Not importing text symbol, couldn&apos;t figure out path&apos; (npts=%1): %2</source>
+        <translation>不导入文本符号，找不出路径 &apos; (npts = %1): %2</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="1939"/>
+        <source>Trying to import a text object with unknown coordinate format</source>
+        <translation>尝试导入具有未知坐标格式的文本对象</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2069"/>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2073"/>
+        <source>Invalid data.</source>
+        <translation>无效的数据。</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.cpp" line="2104"/>
+        <source>OCD files of version %1 are not supported!</source>
+        <translation>不支持的版本 %1 的强迫症文件 ！</translation>
+    </message>
+    <message>
+        <location filename="../src/fileformats/ocd_file_import.h" line="455"/>
+        <source>Color id not found: %1, ignoring this color</source>
+        <translation>找不到的颜色 id: %1，无视这种颜色</translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::OgrFileImport</name>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="392"/>
+        <source>Unable to setup &quot;%1&quot; SRS for GDAL: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="326"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="339"/>
+        <source>Point</source>
+        <translation type="unfinished">点</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="346"/>
+        <source>Line</source>
+        <translation type="unfinished">线</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="355"/>
+        <source>Area</source>
+        <translation type="unfinished">地区</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="361"/>
+        <source>Text</source>
+        <translation type="unfinished">文本</translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="452"/>
+        <source>Unable to load layer %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gdal/ogr_file_format.cpp" line="500"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="505"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="510"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="515"/>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="520"/>
+        <source>Unable to load %n objects, reason: %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="501"/>
+        <source>Empty geometry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="506"/>
+        <source>Can&apos;t determine the coordinate transformation: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="511"/>
+        <source>Failed to transform the coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="516"/>
+        <source>Unknown or unsupported geometry type.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="521"/>
+        <source>Not enough coordinates.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="564"/>
+        <source>Cannot use this spatial reference:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gdal/ogr_file_format.cpp" line="623"/>
+        <source>The geospatial data has no suitable spatial reference.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenOrienteering::PaintOnTemplateSelectDialog</name>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="350"/>
+        <source>Select template to draw onto</source>
+        <translation>选择要绘图模板</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="364"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../src/templates/template_tool_paint.cpp" line="365"/>
         <source>Draw</source>
         <translation>绘制</translation>
     </message>
 </context>
 <context>
-    <name>PaintOnTemplateTool</name>
+    <name>OpenOrienteering::PaintOnTemplateTool</name>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="72"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="74"/>
         <source>&lt;b&gt;Click and drag&lt;/b&gt;: Paint. &lt;b&gt;Right click and drag&lt;/b&gt;: Erase. </source>
         <translation>&lt;b&gt;单击并拖动&lt;/b&gt;︰ 油漆。&lt;b&gt;右键单击并拖动&lt;/b&gt;︰ 擦除。 </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_tool_paint.cpp" line="75"/>
+        <location filename="../src/templates/template_tool_paint.cpp" line="77"/>
         <source>Color selection</source>
         <translation>颜色选择</translation>
     </message>
 </context>
 <context>
-    <name>PanTool</name>
+    <name>OpenOrienteering::PanTool</name>
     <message>
-        <location filename="../src/tools/pan_tool.cpp" line="78"/>
+        <location filename="../src/tools/pan_tool.cpp" line="80"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动地图。 </translation>
     </message>
 </context>
 <context>
-    <name>PercentageDelegate</name>
+    <name>OpenOrienteering::PercentageDelegate</name>
     <message>
-        <location filename="../src/util/item_delegates.cpp" line="153"/>
-        <location filename="../src/util/item_delegates.cpp" line="160"/>
+        <location filename="../src/util/item_delegates.cpp" line="155"/>
+        <location filename="../src/util/item_delegates.cpp" line="162"/>
         <source>%</source>
         <translation>%</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorTool</name>
+    <name>OpenOrienteering::PointSymbolEditorTool</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="985"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="987"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Add a coordinate. &lt;b&gt;%1+Click&lt;/b&gt;: Change the selected coordinate. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 添加坐标。&lt;b&gt;%1 + 点击&lt;/b&gt;︰ 更改选定的坐标。 </translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolEditorWidget</name>
+    <name>OpenOrienteering::PointSymbolEditorWidget</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="103"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="105"/>
         <source>Always oriented to north (not rotatable)</source>
         <translation>总是面向北 （不旋转）</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="106"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="108"/>
         <source>Elements</source>
         <translation>元素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="118"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="944"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
         <source>Point</source>
         <translation>点</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="119"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="946"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="121"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
         <source>Line</source>
         <translation>线</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="120"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="948"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="122"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="950"/>
         <source>Area</source>
         <translation>地区</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="123"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
         <source>Center all elements</source>
         <translation>中心的所有元素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="125"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="127"/>
         <source>Current element</source>
         <translation>当前元素</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="131"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="133"/>
         <source>Diameter &lt;b&gt;a&lt;/b&gt;:</source>
         <translation>直径 &lt;b&gt;&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="132"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="138"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="166"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
         <source>mm</source>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="134"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="136"/>
         <source>Inner color:</source>
         <translation>内部颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="137"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="139"/>
         <source>Outer width &lt;b&gt;b&lt;/b&gt;:</source>
         <translation>外宽 &lt;b&gt;b&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="140"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="142"/>
         <source>Outer color:</source>
         <translation>外部颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="165"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="167"/>
         <source>Line width:</source>
         <translation>线宽︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="168"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="170"/>
         <source>Line color:</source>
         <translation>线条颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="171"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
         <source>Line cap:</source>
         <translation>线帽︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="173"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
         <source>flat</source>
         <translation>平</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="174"/>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="181"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="176"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="183"/>
         <source>round</source>
         <translation>一轮</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="175"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="177"/>
         <source>square</source>
         <translation>广场</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="178"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
         <source>Line join:</source>
         <translation>线条联接︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="180"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
         <source>miter</source>
         <translation>船闸人字</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="182"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
         <source>bevel</source>
         <translation>斜角</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="184"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="186"/>
         <source>Line closed</source>
         <translation>封闭的线</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="204"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="206"/>
         <source>Area color:</source>
         <translation>区域颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="217"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="219"/>
         <source>Coordinates:</source>
         <translation>坐标︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="222"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="224"/>
         <source>Curve start</source>
         <translation>曲线开始</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="233"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="235"/>
         <source>Center by coordinate average</source>
         <translation>中心由坐标平均</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="417"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="419"/>
         <source>[Midpoint]</source>
         <translation>[中点]</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="951"/>
+        <location filename="../src/gui/symbols/point_symbol_editor_widget.cpp" line="953"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
 </context>
 <context>
-    <name>PointSymbolSettings</name>
+    <name>OpenOrienteering::PointSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="58"/>
+        <location filename="../src/gui/symbols/point_symbol_settings.cpp" line="60"/>
         <source>Point symbol</source>
         <translation>点符号</translation>
     </message>
 </context>
 <context>
-    <name>PrintProgressDialog</name>
+    <name>OpenOrienteering::PrintProgressDialog</name>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="56"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="58"/>
         <source>Printing</source>
         <comment>PrintWidget</comment>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_progress_dialog.cpp" line="57"/>
+        <location filename="../src/gui/print_progress_dialog.cpp" line="59"/>
         <source>An error occurred during processing.</source>
         <comment>PrintWidget</comment>
         <translation>在处理过程中出现错误。</translation>
     </message>
 </context>
 <context>
-    <name>PrintTool</name>
+    <name>OpenOrienteering::PrintTool</name>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="57"/>
-        <location filename="../src/gui/print_tool.cpp" line="369"/>
+        <location filename="../src/gui/print_tool.cpp" line="59"/>
+        <location filename="../src/gui/print_tool.cpp" line="371"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map, the print area or the area&apos;s borders. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动地图、 打印区域或地区的边界。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="341"/>
+        <location filename="../src/gui/print_tool.cpp" line="343"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动打印区域。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="345"/>
+        <location filename="../src/gui/print_tool.cpp" line="347"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the map. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动地图。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="350"/>
-        <location filename="../src/gui/print_tool.cpp" line="355"/>
+        <location filename="../src/gui/print_tool.cpp" line="352"/>
+        <location filename="../src/gui/print_tool.cpp" line="357"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s border. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动打印区域边界。 </translation>
     </message>
     <message>
-        <location filename="../src/gui/print_tool.cpp" line="360"/>
-        <location filename="../src/gui/print_tool.cpp" line="365"/>
+        <location filename="../src/gui/print_tool.cpp" line="362"/>
+        <location filename="../src/gui/print_tool.cpp" line="367"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move the print area&apos;s borders. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动打印区域的边界。 </translation>
     </message>
 </context>
 <context>
-    <name>PrintWidget</name>
+    <name>OpenOrienteering::PrintWidget</name>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="246"/>
+        <location filename="../src/gui/print_widget.cpp" line="251"/>
         <source>Show templates</source>
         <translation>显示模板</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="257"/>
+        <location filename="../src/gui/print_widget.cpp" line="262"/>
         <source>Show grid</source>
         <translation>显示网格</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="170"/>
+        <location filename="../src/gui/print_widget.cpp" line="175"/>
         <source>Page orientation:</source>
         <translation>页面方向︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="130"/>
+        <location filename="../src/gui/print_widget.cpp" line="135"/>
         <source>Printer:</source>
         <translation>打印机︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="163"/>
+        <location filename="../src/gui/print_widget.cpp" line="168"/>
         <source>Portrait</source>
         <translation>肖像</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="165"/>
+        <location filename="../src/gui/print_widget.cpp" line="170"/>
         <source>Landscape</source>
         <translation>景观</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="144"/>
+        <location filename="../src/gui/print_widget.cpp" line="149"/>
         <source>Page format:</source>
         <translation>页面格式︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="173"/>
+        <location filename="../src/gui/print_widget.cpp" line="178"/>
         <source>Copies:</source>
         <translation>副本︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="186"/>
+        <location filename="../src/gui/print_widget.cpp" line="191"/>
         <source>Left:</source>
         <translation>左︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="189"/>
+        <location filename="../src/gui/print_widget.cpp" line="194"/>
         <source>Top:</source>
         <translation>返回页首：</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="192"/>
+        <location filename="../src/gui/print_widget.cpp" line="197"/>
         <source>Width:</source>
         <translation>宽度：</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="195"/>
+        <location filename="../src/gui/print_widget.cpp" line="200"/>
         <source>Height:</source>
         <translation>高度︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="289"/>
+        <location filename="../src/gui/print_widget.cpp" line="294"/>
         <source>Preview...</source>
         <translation>预览。。。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="178"/>
+        <location filename="../src/gui/print_widget.cpp" line="183"/>
         <source>Single page</source>
         <translation>单个页面</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="179"/>
+        <location filename="../src/gui/print_widget.cpp" line="184"/>
         <source>Custom area</source>
         <translation>自定义区域</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="180"/>
+        <location filename="../src/gui/print_widget.cpp" line="185"/>
         <source>Map area:</source>
         <translation>地图区域︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="182"/>
+        <location filename="../src/gui/print_widget.cpp" line="187"/>
         <source>Center print area</source>
         <translation>中心打印区域</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="150"/>
-        <location filename="../src/gui/print_widget.cpp" line="154"/>
-        <location filename="../src/gui/print_widget.cpp" line="185"/>
-        <location filename="../src/gui/print_widget.cpp" line="188"/>
-        <location filename="../src/gui/print_widget.cpp" line="191"/>
-        <location filename="../src/gui/print_widget.cpp" line="194"/>
-        <location filename="../src/gui/print_widget.cpp" line="197"/>
+        <location filename="../src/gui/print_widget.cpp" line="155"/>
+        <location filename="../src/gui/print_widget.cpp" line="159"/>
+        <location filename="../src/gui/print_widget.cpp" line="190"/>
+        <location filename="../src/gui/print_widget.cpp" line="193"/>
+        <location filename="../src/gui/print_widget.cpp" line="196"/>
+        <location filename="../src/gui/print_widget.cpp" line="199"/>
+        <location filename="../src/gui/print_widget.cpp" line="202"/>
         <source>mm</source>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="135"/>
+        <location filename="../src/gui/print_widget.cpp" line="140"/>
         <source>Properties</source>
         <translation>属性</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="198"/>
+        <location filename="../src/gui/print_widget.cpp" line="203"/>
         <source>Page overlap:</source>
         <translation>页面重叠︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="202"/>
+        <location filename="../src/gui/print_widget.cpp" line="207"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="230"/>
+        <location filename="../src/gui/print_widget.cpp" line="235"/>
         <source>Resolution:</source>
         <translation>分辨率︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="232"/>
+        <location filename="../src/gui/print_widget.cpp" line="237"/>
         <source>Print in different scale:</source>
         <translation>打印在不同的尺度︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="253"/>
+        <location filename="../src/gui/print_widget.cpp" line="258"/>
         <source>Template appearance may differ.</source>
         <translation>模板的外观可能会有所不同。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="260"/>
+        <location filename="../src/gui/print_widget.cpp" line="265"/>
         <source>Simulate overprinting</source>
         <translation>模拟叠印</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="265"/>
+        <location filename="../src/gui/print_widget.cpp" line="270"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="266"/>
+        <location filename="../src/gui/print_widget.cpp" line="271"/>
         <source>Device CMYK (experimental)</source>
         <translation>设备 CMYK （实验）</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="267"/>
+        <location filename="../src/gui/print_widget.cpp" line="272"/>
         <source>Color mode:</source>
         <translation>颜色模式︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="291"/>
-        <location filename="../src/gui/print_widget.cpp" line="397"/>
+        <location filename="../src/gui/print_widget.cpp" line="296"/>
+        <location filename="../src/gui/print_widget.cpp" line="402"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="295"/>
+        <location filename="../src/gui/print_widget.cpp" line="300"/>
         <source>Export...</source>
         <translation>出口...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="402"/>
+        <location filename="../src/gui/print_widget.cpp" line="407"/>
         <source>PDF export</source>
         <translation>PDF 导出</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="413"/>
+        <location filename="../src/gui/print_widget.cpp" line="418"/>
         <source>Image export</source>
         <translation>图像导出</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="519"/>
+        <location filename="../src/gui/print_widget.cpp" line="524"/>
         <source>Save to PDF</source>
         <translation>将保存到 PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="228"/>
-        <location filename="../src/gui/print_widget.cpp" line="923"/>
-        <location filename="../src/gui/print_widget.cpp" line="964"/>
+        <location filename="../src/gui/print_widget.cpp" line="233"/>
+        <location filename="../src/gui/print_widget.cpp" line="928"/>
+        <location filename="../src/gui/print_widget.cpp" line="969"/>
         <source>dpi</source>
         <translation>新闻部</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
         <source>Not supported on Android.</source>
         <translation>不支持在 Android 上。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
         <source>Failed to prepare the preview.</source>
         <translation>未能准备预览。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1113"/>
+        <location filename="../src/gui/print_widget.cpp" line="1118"/>
         <source>Print Preview Progress</source>
         <translation>打印预览进展</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1130"/>
+        <location filename="../src/gui/print_widget.cpp" line="1135"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1131"/>
+        <location filename="../src/gui/print_widget.cpp" line="1136"/>
         <source>A non-standard view mode is activated. Are you sure to print / export the map like this?</source>
         <translation>非标准视图模式被激活。是否确实要打印 / 导出映射像这样？</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1148"/>
+        <location filename="../src/gui/print_widget.cpp" line="1153"/>
         <source>PNG</source>
         <translation>PNG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1149"/>
+        <location filename="../src/gui/print_widget.cpp" line="1154"/>
         <source>BMP</source>
         <translation>骨形态发生蛋白</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1150"/>
+        <location filename="../src/gui/print_widget.cpp" line="1155"/>
         <source>TIFF</source>
         <translation>TIFF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1151"/>
+        <location filename="../src/gui/print_widget.cpp" line="1156"/>
         <source>JPEG</source>
         <translation>JPEG</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
         <source>Failed to prepare the PDF export.</source>
         <translation>准备 PDF 导出失败。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1215"/>
+        <location filename="../src/gui/print_widget.cpp" line="1220"/>
         <source>PDF</source>
         <translation>PDF</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
         <source>An error occurred during printing.</source>
         <translation>在打印过程中出现错误。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1153"/>
-        <location filename="../src/gui/print_widget.cpp" line="1181"/>
-        <location filename="../src/gui/print_widget.cpp" line="1217"/>
-        <location filename="../src/gui/print_widget.cpp" line="1229"/>
+        <location filename="../src/gui/print_widget.cpp" line="1158"/>
+        <location filename="../src/gui/print_widget.cpp" line="1186"/>
+        <location filename="../src/gui/print_widget.cpp" line="1222"/>
+        <location filename="../src/gui/print_widget.cpp" line="1234"/>
         <source>Export map ...</source>
         <translation>导出映射...</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1152"/>
-        <location filename="../src/gui/print_widget.cpp" line="1216"/>
+        <location filename="../src/gui/print_widget.cpp" line="1157"/>
+        <location filename="../src/gui/print_widget.cpp" line="1221"/>
         <source>All files (*.*)</source>
         <translation>所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
         <source>Failed to prepare the printing.</source>
         <translation>准备打印失败。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1263"/>
+        <location filename="../src/gui/print_widget.cpp" line="1268"/>
         <source>Printing Progress</source>
         <translation>打印进度</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1094"/>
-        <location filename="../src/gui/print_widget.cpp" line="1102"/>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
-        <location filename="../src/gui/print_widget.cpp" line="1205"/>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
-        <location filename="../src/gui/print_widget.cpp" line="1254"/>
-        <location filename="../src/gui/print_widget.cpp" line="1268"/>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1099"/>
+        <location filename="../src/gui/print_widget.cpp" line="1107"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
+        <location filename="../src/gui/print_widget.cpp" line="1210"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
+        <location filename="../src/gui/print_widget.cpp" line="1259"/>
+        <location filename="../src/gui/print_widget.cpp" line="1273"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="209"/>
+        <location filename="../src/gui/print_widget.cpp" line="214"/>
         <source>Vector
 graphics</source>
         <translation>矢量图形</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="210"/>
+        <location filename="../src/gui/print_widget.cpp" line="215"/>
         <source>Raster
 graphics</source>
         <translation>光栅图形</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="211"/>
+        <location filename="../src/gui/print_widget.cpp" line="216"/>
         <source>Color
 separations</source>
         <translation>分色</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="224"/>
+        <location filename="../src/gui/print_widget.cpp" line="229"/>
         <source>Mode:</source>
         <translation>模式︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1171"/>
+        <location filename="../src/gui/print_widget.cpp" line="1176"/>
         <source>Failed to prepare the image. Not enough memory.</source>
         <translation>未能准备映像。没有足够的内存。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1190"/>
+        <location filename="../src/gui/print_widget.cpp" line="1195"/>
         <source>Failed to save the image. Does the path exist? Do you have sufficient rights?</source>
         <translation>未能保存图像。路径存在吗？你有足够的权利吗？</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1194"/>
-        <location filename="../src/gui/print_widget.cpp" line="1239"/>
+        <location filename="../src/gui/print_widget.cpp" line="1199"/>
+        <location filename="../src/gui/print_widget.cpp" line="1244"/>
         <source>Exported successfully to %1</source>
         <translation>成功导出到 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1235"/>
+        <location filename="../src/gui/print_widget.cpp" line="1240"/>
         <source>Failed to finish the PDF export.</source>
         <translation>未能完成 PDF 导出。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1245"/>
-        <location filename="../src/gui/print_widget.cpp" line="1277"/>
+        <location filename="../src/gui/print_widget.cpp" line="1250"/>
+        <location filename="../src/gui/print_widget.cpp" line="1282"/>
         <source>Canceled.</source>
         <translation>取消了。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1281"/>
+        <location filename="../src/gui/print_widget.cpp" line="1286"/>
         <source>The print job could not be stopped.</source>
         <translation>不能停止打印作业。</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1272"/>
+        <location filename="../src/gui/print_widget.cpp" line="1277"/>
         <source>Successfully created print job</source>
         <translation>成功创建打印作业</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1329"/>
-        <location filename="../src/gui/print_widget.cpp" line="1337"/>
+        <location filename="../src/gui/print_widget.cpp" line="1334"/>
+        <location filename="../src/gui/print_widget.cpp" line="1342"/>
         <source>Unknown</source>
         <comment>Paper size</comment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/gui/print_widget.cpp" line="1345"/>
+        <location filename="../src/gui/print_widget.cpp" line="1350"/>
         <source>The map area is empty. Output canceled.</source>
         <translation>映射区为空。取消的输出。</translation>
     </message>
 </context>
 <context>
-    <name>ReopenTemplateDialog</name>
+    <name>OpenOrienteering::ReopenTemplateDialog</name>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="38"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="41"/>
         <source>Reopen template</source>
         <translation>重新打开模板</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="40"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="43"/>
         <source>Drag items from the left list to the desired spot in the right list to reload them.</source>
         <translation>将从左侧的列表中的项目拖到所需的点，在右侧的列表，以便重新加载它们。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="42"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
         <source>Closed templates:</source>
         <translation>封闭的模板︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="45"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
         <source>Clear list</source>
         <translation>清除列表</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="48"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="51"/>
         <source>Active templates:</source>
         <translation>活动模板︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_dialog_reopen.cpp" line="57"/>
+        <location filename="../src/templates/template_dialog_reopen.cpp" line="60"/>
         <source>- Map -</source>
         <translation>-地图-</translation>
     </message>
 </context>
 <context>
-    <name>ReplaceSymbolSetDialog</name>
+    <name>OpenOrienteering::ReplaceSymbolSetDialog</name>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
         <source>Replace symbol set</source>
         <translation>替换符号集</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="106"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="108"/>
         <source>Configure how the symbols should be replaced, and which.</source>
         <translation>配置如何应该替换符号，和其中。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="109"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="111"/>
         <source>Import all new symbols, even if not used as replacement</source>
         <translation>导入所有的新符号，即使不使用作为替换</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="115"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="117"/>
         <source>Delete original symbols which are unused after the replacement</source>
         <translation>删除原始符号未使用更换后</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="118"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="120"/>
         <source>Delete unused colors after the replacement</source>
         <translation>更换后删除未使用的颜色</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="164"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="166"/>
         <source>Symbol mapping:</source>
         <translation>符号映射︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="112"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="114"/>
         <source>Keep the symbols&apos; hidden / protected states of the old symbol set</source>
         <translation>保持旧的符号集的符号隐藏 / 保护状态</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
         <source>Match replacement symbols by symbol number</source>
         <translation>比赛替换符号的符号数</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
         <source>Original</source>
         <translation>源语言</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="130"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="132"/>
         <source>Edit the symbol set ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="133"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="135"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Replacement</source>
         <translation>更换</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="137"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="139"/>
         <source>Match by symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="142"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="144"/>
         <source>Assign new symbols</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="143"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="145"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="155"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="157"/>
         <source>Clear replacements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="158"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="234"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="236"/>
         <source>Open CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="160"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="330"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="162"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="332"/>
         <source>Save CRT file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="165"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="167"/>
         <source>Symbol mapping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="233"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="329"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="235"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="331"/>
         <source>CRT file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="283"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="285"/>
         <source>There are multiple replacements for symbol %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="286"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="288"/>
         <source>Cannot open file:
 %1
 
@@ -5950,7 +5951,7 @@ separations</source>
         <translation type="unfinished">无法打开文件: %1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="344"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="346"/>
         <source>Cannot save file:
 %1
 
@@ -5958,467 +5959,467 @@ separations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="360"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="362"/>
         <source>The cross reference table has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="517"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="519"/>
         <source>- None -</source>
         <translation>-无-</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="562"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="564"/>
         <source>Choose map file to load symbols from</source>
         <translation>选择要加载的符号的地图文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="570"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="572"/>
         <source>Cannot load map file, aborting.</source>
         <translation>无法加载地图文件，中止。</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="576"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="578"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="577"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="579"/>
         <source>The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?</source>
         <translation>空房的符号集具有规模的 1:%1，1:%2 地图规模时。你真的想要选择这一套？</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="655"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="657"/>
         <source>Cannot load CRT file, aborting.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RotateMapDialog</name>
+    <name>OpenOrienteering::RotateMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="44"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="46"/>
         <source>Rotate map</source>
         <translation>旋转地图</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
         <source>Angle (counter-clockwise):</source>
         <translation>角度 （逆时针）︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="52"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="50"/>
         <source>Rotation parameters</source>
         <translation>旋转参数</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
         <source>Rotate around:</source>
         <translation>旋转︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="56"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="58"/>
         <source>Map coordinate system origin</source>
         <comment>Rotation center point</comment>
         <translation>地图坐标系的原点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="60"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="62"/>
         <source>Georeferencing reference point</source>
         <comment>Rotation center point</comment>
         <translation>加注地理数据的参考点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="65"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
         <source>Other point,</source>
         <comment>Rotation center point</comment>
         <translation>另一点，</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="66"/>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="67"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="68"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="69"/>
         <source>mm</source>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="70"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="72"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="74"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="78"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="82"/>
         <source>Adjust georeferencing reference point</source>
         <translation>调整加注地理数据的参考点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="89"/>
         <source>Adjust georeferencing declination</source>
         <translation>调整小基赤纬</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_rotate.cpp" line="96"/>
         <source>Rotate non-georeferenced templates</source>
         <translation>旋转的非地理参考模板</translation>
     </message>
 </context>
 <context>
-    <name>RotatePatternTool</name>
+    <name>OpenOrienteering::RotatePatternTool</name>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="80"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="82"/>
         <source>&lt;b&gt;Angle:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;角︰&lt;/b&gt; %1 ° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="90"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="92"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_pattern_tool.cpp" line="84"/>
+        <location filename="../src/tools/rotate_pattern_tool.cpp" line="86"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Set the direction of area fill patterns or point objects. </source>
         <translation>&lt;b&gt;拖动&lt;/b&gt;︰ 点对象或设置区域的方向填充图案。 </translation>
     </message>
 </context>
 <context>
-    <name>RotateTool</name>
+    <name>OpenOrienteering::RotateTool</name>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="203"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="205"/>
         <source>&lt;b&gt;Rotation:&lt;/b&gt; %1° </source>
         <translation>&lt;b&gt;旋转︰&lt;/b&gt; %1 ° </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="215"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="217"/>
         <source>&lt;b&gt;%1&lt;/b&gt;: Fixed angles. </source>
         <translation>&lt;b&gt;%1&lt;/b&gt;︰ 固定的角度。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="209"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="211"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the center of rotation. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置的旋转中心。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/rotate_tool.cpp" line="210"/>
+        <location filename="../src/tools/rotate_tool.cpp" line="212"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Rotate the selected objects. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 旋转所选的对象。 </translation>
     </message>
 </context>
 <context>
-    <name>ScaleMapDialog</name>
+    <name>OpenOrienteering::ScaleMapDialog</name>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="38"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="41"/>
         <source>Change map scale</source>
         <translation>更改地图规模</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="42"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="45"/>
         <source>Scaling parameters</source>
         <translation>标度参数</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="46"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="49"/>
         <source>New scale:  1 :</source>
         <translation>新规模︰ 1:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="48"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="51"/>
         <source>Scaling center:</source>
         <translation>缩放的中心︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="50"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="53"/>
         <source>Map coordinate system origin</source>
         <comment>Scaling center point</comment>
         <translation>地图坐标系的原点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="54"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="57"/>
         <source>Georeferencing reference point</source>
         <comment>Scaling center point</comment>
         <translation>加注地理数据的参考点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="59"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="62"/>
         <source>Other point,</source>
         <comment>Scaling center point</comment>
         <translation>另一点，</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="60"/>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="61"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="63"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
         <source>mm</source>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="64"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="67"/>
         <source>X:</source>
         <comment>x coordinate</comment>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="66"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="69"/>
         <source>Y:</source>
         <comment>y coordinate</comment>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="71"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="74"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="73"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="76"/>
         <source>Scale symbol sizes</source>
         <translation>缩放符号尺寸</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="80"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="83"/>
         <source>Scale map object positions</source>
         <translation>规模地图对象位置</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="87"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="90"/>
         <source>Adjust georeferencing reference point</source>
         <translation>调整加注地理数据的参考点</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_dialog_scale.cpp" line="94"/>
+        <location filename="../src/gui/map/map_dialog_scale.cpp" line="97"/>
         <source>Scale non-georeferenced templates</source>
         <translation>规模非地理参考模板</translation>
     </message>
 </context>
 <context>
-    <name>ScaleTool</name>
+    <name>OpenOrienteering::ScaleTool</name>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="66"/>
+        <location filename="../src/tools/scale_tool.cpp" line="68"/>
         <source>&lt;b&gt;Scaling:&lt;/b&gt; %1%</source>
         <translation>&lt;b&gt;缩放比例︰&lt;/b&gt; %1%</translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="68"/>
+        <location filename="../src/tools/scale_tool.cpp" line="70"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the scaling center. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置缩放中心。 </translation>
     </message>
     <message>
-        <location filename="../src/tools/scale_tool.cpp" line="69"/>
+        <location filename="../src/tools/scale_tool.cpp" line="71"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Scale the selected objects. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 缩放所选的对象。 </translation>
     </message>
 </context>
 <context>
-    <name>SelectCRSDialog</name>
+    <name>OpenOrienteering::SelectCRSDialog</name>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="58"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="63"/>
         <source>Select coordinate reference system</source>
         <translation>选择坐标参照系统</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="66"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="71"/>
         <source>Same as map</source>
         <translation>同样作为地图</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="72"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
         <source>Local</source>
         <translation>本地</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="77"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="82"/>
         <source>Geographic coordinates (WGS84)</source>
         <translation>地理坐标 (WGS84)</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="89"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="94"/>
         <source>Status:</source>
         <translation>状态︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/select_crs_dialog.cpp" line="134"/>
+        <location filename="../src/gui/select_crs_dialog.cpp" line="139"/>
         <source>valid</source>
         <translation>有效</translation>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>OpenOrienteering::SettingsDialog</name>
     <message>
-        <location filename="../src/gui/settings_dialog.cpp" line="60"/>
+        <location filename="../src/gui/settings_dialog.cpp" line="62"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
 </context>
 <context>
-    <name>StorageLocation</name>
+    <name>OpenOrienteering::StorageLocation</name>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="282"/>
+        <location filename="../src/core/storage_location.cpp" line="288"/>
         <source>&apos;%1&apos; is stored in a regular location.</source>
         <translation>&apos;%1&apos; 存储在一个常规的位置。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="285"/>
+        <location filename="../src/core/storage_location.cpp" line="291"/>
         <source>&apos;%1&apos; is located in app storage. The files will be removed when uninstalling the app.</source>
         <translation>&apos;%1&apos; 位于应用程序存储。在卸载应用程序时，文件将被删除。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="288"/>
+        <location filename="../src/core/storage_location.cpp" line="294"/>
         <source>&apos;%1&apos; is not writable. Changes cannot be saved.</source>
         <translation>&apos;%1&apos; 不是可写的。不能保存更改。</translation>
     </message>
     <message>
-        <location filename="../src/core/storage_location.cpp" line="291"/>
+        <location filename="../src/core/storage_location.cpp" line="297"/>
         <source>&apos;%1&apos; is not a valid storage location.</source>
         <translation>&apos;%1&apos; 不是有效的存储位置。</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDown</name>
+    <name>OpenOrienteering::SymbolDropDown</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="52"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="56"/>
         <source>- none -</source>
         <translation>-无-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolDropDownDelegate</name>
+    <name>OpenOrienteering::SymbolDropDownDelegate</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="166"/>
+        <location filename="../src/gui/widgets/symbol_dropdown.cpp" line="170"/>
         <source>- None -</source>
         <translation>-无-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolPropertiesWidget</name>
+    <name>OpenOrienteering::SymbolPropertiesWidget</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="72"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="74"/>
         <source>Number:</source>
         <translation>编号︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="83"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="85"/>
         <source>Edit</source>
         <translation type="unfinished">编辑</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="84"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
         <source>Name:</source>
         <translation>名称︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="86"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
         <source>Description:</source>
         <translation>描述︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="88"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="90"/>
         <source>Helper symbol (not shown in finished map)</source>
         <translation>辅助符号 （成品图中未显示）</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="135"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="137"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="226"/>
+        <location filename="../src/gui/symbols/symbol_properties_widget.cpp" line="228"/>
         <source>Warning</source>
         <translation type="unfinished">警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1282"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1286"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SymbolRenderWidget</name>
+    <name>OpenOrienteering::SymbolRenderWidget</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="245"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
         <source>For symbols with description, press F1 while the tooltip is visible to show it</source>
         <translation>与描述符号，请按 f1 键工具提示可见显示它时</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="249"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
         <source>New symbol</source>
         <translation>新符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="438"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="251"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="440"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
         <source>Point</source>
         <translation>点</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="433"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="252"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="435"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="256"/>
         <source>Line</source>
         <translation>线</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="423"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="253"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="425"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="257"/>
         <source>Area</source>
         <translation>地区</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="443"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="254"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="445"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
         <source>Text</source>
         <translation>文本</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="428"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="255"/>
+        <location filename="../src/gui/symbols/replace_symbol_set_dialog.cpp" line="430"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
         <source>Combined</source>
         <translation>联合</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="258"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="262"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="259"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
         <source>Duplicate</source>
         <translation>重复</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="260"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="261"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="265"/>
         <source>Scale...</source>
         <translation>规模......</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="263"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
         <source>Copy</source>
         <translation>副本</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="264"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="268"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
@@ -6431,12 +6432,12 @@ Do you want to save your changes?</source>
         <translation type="vanished">填充/创建所选对象的边框</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="279"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
         <source>Select symbols</source>
         <translation>选择符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="294"/>
         <source>Enable drag and drop</source>
         <translation>启用拖和放</translation>
     </message>
@@ -6445,197 +6446,197 @@ Do you want to save your changes?</source>
         <translation type="vanished">规模代号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1017"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1045"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1021"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1049"/>
         <source>An internal error occurred, sorry!</source>
         <translation>发生内部错误，抱歉 ！</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1032"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1036"/>
         <source>There are no symbols in clipboard which could be pasted!</source>
         <translation>可以粘贴的剪贴板中没有符号 ！</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1202"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
         <source>Select all objects with this symbol</source>
         <translation>选择此符号的所有对象</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1203"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1207"/>
         <source>Add all objects with this symbol to selection</source>
         <translation>将所有对象与此符号都添加到选择</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1204"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1208"/>
         <source>Remove all objects with this symbol from selection</source>
         <translation>从选择中删除与该符号的所有对象</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1295"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1205"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1299"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1209"/>
         <source>Hide objects with this symbol</source>
         <translation>隐藏对象与此符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="1306"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1206"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="1310"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
         <source>Protect objects with this symbol</source>
         <translation>保护对象与此符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1211"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1215"/>
         <source>Add all objects with selected symbols to selection</source>
         <translation>将所有对象与选定的符号都添加到选择</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1212"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1216"/>
         <source>Remove all objects with selected symbols from selection</source>
         <translation>从选择中删除选定的符号的所有对象</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1213"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1217"/>
         <source>Hide objects with selected symbols</source>
         <translation>隐藏选定的符号与对象</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1218"/>
         <source>Protect objects with selected symbols</source>
         <translation>保护对象与选定的符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="283"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
         <source>Invert selection</source>
         <translation>反向选择</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="240"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="244"/>
         <source>F1</source>
         <comment>Shortcut for displaying the symbol&apos;s description</comment>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="280"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="284"/>
         <source>Select all</source>
         <translation>选择所有</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="281"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="285"/>
         <source>Select unused</source>
         <translation>选择未使用</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="286"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="290"/>
         <source>Sort symbols</source>
         <translation>排序符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="287"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="291"/>
         <source>Sort by number</source>
         <translation>按数字排序</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="288"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="292"/>
         <source>Sort by primary color</source>
         <translation>按主颜色排序</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="289"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="293"/>
         <source>Sort by primary color priority</source>
         <translation>按原色优先级排序</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale to percentage:</source>
         <translation>按百分比缩放︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>Confirmation</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="979"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="983"/>
         <source>The map contains objects with the symbol &quot;%1&quot;. Deleting it will delete those objects and clear the undo history! Do you really want to do that?</source>
         <translation>映射包含带有符号&quot;%1&quot;的对象。删除它将删除这些对象并清除撤消历史记录 ！你真的想要这样做？</translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_editor.cpp" line="862"/>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1210"/>
+        <location filename="../src/gui/map/map_editor.cpp" line="866"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="1214"/>
         <source>Select all objects with selected symbols</source>
         <translation>选择与所选符号的所有对象</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="266"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="270"/>
         <source>Switch symbol of selected objects</source>
         <translation>所选对象的开关符号</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="267"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="271"/>
         <source>Fill / Create border for selected objects</source>
         <translation>填充/创建所选对象的边框</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="949"/>
+        <location filename="../src/gui/widgets/symbol_render_widget.cpp" line="953"/>
         <source>Scale symbols</source>
         <translation>规模符号</translation>
     </message>
 </context>
 <context>
-    <name>SymbolSettingDialog</name>
+    <name>OpenOrienteering::SymbolSettingDialog</name>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="60"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="62"/>
         <source>Symbol settings</source>
         <translation>符号设置</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="102"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
         <source>Template:</source>
         <translation>模板︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="103"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
         <source>&lt;b&gt;Template:&lt;/b&gt; </source>
         <translation>&lt;b&gt;模板︰&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="104"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="106"/>
         <source>(none)</source>
         <translation>（无）</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="105"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="107"/>
         <source>Open...</source>
         <translation>打开...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="108"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="110"/>
         <source>Center template...</source>
         <translation>中心模板...</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="113"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="115"/>
         <source>bounding box on origin</source>
         <translation>在起源上定界框</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="114"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="116"/>
         <source>center of gravity on origin</source>
         <translation>重心的起源</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="232"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="234"/>
         <source>Select background color</source>
         <translation>选择背景颜色</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="418"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="420"/>
         <source>The quick brown fox
 takes the routechoice
 to jump over the lazy dog
@@ -6643,58 +6644,58 @@ to jump over the lazy dog
         <translation>那只敏捷的棕色狐狸花 routechoice 跳过那只懒狗 1234567890</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="493"/>
+        <location filename="../src/gui/symbols/symbol_setting_dialog.cpp" line="495"/>
         <source>- unnamed -</source>
         <translation>-未命名-</translation>
     </message>
 </context>
 <context>
-    <name>SymbolToolTip</name>
+    <name>OpenOrienteering::SymbolToolTip</name>
     <message>
-        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="200"/>
+        <location filename="../src/gui/widgets/symbol_tooltip.cpp" line="202"/>
         <source>No description!</source>
         <translation>没有描述 ！</translation>
     </message>
 </context>
 <context>
-    <name>TagSelectWidget</name>
+    <name>OpenOrienteering::TagSelectWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Relation</source>
         <translation>关系</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Key</source>
         <translation>关键</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Comparison</source>
         <translation>比较</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="62"/>
         <source>Value</source>
         <translation>价值</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="88"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="90"/>
         <source>Add Row</source>
         <translation>添加行</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="89"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="91"/>
         <source>Remove Row</source>
         <translation>删除行</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="95"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
         <source>Move Up</source>
         <translation>向上移动</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="97"/>
+        <location filename="../src/gui/widgets/tag_select_widget.cpp" line="99"/>
         <source>Move Down</source>
         <translation>向下移动</translation>
     </message>
@@ -6707,210 +6708,210 @@ to jump over the lazy dog
         <translation type="vanished">帮助</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/gui/map/map_find_feature.cpp" line="229"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="231"/>
         <source>%n object(s) selected</source>
         <translation>
             <numerusform>%n 个对象</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="175"/>
-        <location filename="../src/gui/map/map_find_feature.cpp" line="221"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="177"/>
+        <location filename="../src/gui/map/map_find_feature.cpp" line="223"/>
         <source>Invalid query</source>
         <translation>无效的查询</translation>
     </message>
 </context>
 <context>
-    <name>TagsWidget</name>
+    <name>OpenOrienteering::TagsWidget</name>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Key</source>
         <translation>关键</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="55"/>
         <source>Value</source>
         <translation>价值</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="63"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="65"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="231"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="233"/>
         <source>Key exists</source>
         <translation>存在的键</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/tags_widget.cpp" line="232"/>
+        <location filename="../src/gui/widgets/tags_widget.cpp" line="234"/>
         <source>The key &quot;%1&quot; already exists and must not be used twice.</source>
         <translation>键&quot;%1&quot;已经存在，并且不能用两次。</translation>
     </message>
 </context>
 <context>
-    <name>Template</name>
+    <name>OpenOrienteering::Template</name>
     <message>
-        <location filename="../src/templates/template.cpp" line="476"/>
+        <location filename="../src/templates/template.cpp" line="478"/>
         <source>Find the moved template file</source>
         <translation>找到移动的模板文件</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="478"/>
+        <location filename="../src/templates/template.cpp" line="480"/>
         <source>All files (*.*)</source>
         <translation>所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="493"/>
+        <location filename="../src/templates/template.cpp" line="495"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="576"/>
-        <location filename="../src/templates/template.cpp" line="605"/>
+        <location filename="../src/templates/template.cpp" line="578"/>
+        <location filename="../src/templates/template.cpp" line="607"/>
         <source>No such file.</source>
         <translation>没有这样的文件。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="619"/>
+        <location filename="../src/templates/template.cpp" line="621"/>
         <source>Is the format of the file correct for this template type?</source>
         <translation>文件的格式是正确的这种模板类型的吗？</translation>
     </message>
     <message>
-        <location filename="../src/templates/template.cpp" line="626"/>
+        <location filename="../src/templates/template.cpp" line="628"/>
         <source>Not enough free memory.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustActivity</name>
+    <name>OpenOrienteering::TemplateAdjustActivity</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="67"/>
+        <location filename="../src/templates/template_adjust.cpp" line="69"/>
         <source>Template adjustment</source>
         <translation>模板调整</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="145"/>
+        <location filename="../src/templates/template_adjust.cpp" line="147"/>
         <source>Failed to calculate adjustment!</source>
         <translation>无法计算调整 ！</translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustAddTool</name>
+    <name>OpenOrienteering::TemplateAdjustAddTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="591"/>
+        <location filename="../src/templates/template_adjust.cpp" line="593"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the template position of the pass point. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置通点的模板位置。 </translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="616"/>
+        <location filename="../src/templates/template_adjust.cpp" line="618"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Set the map position of the pass point. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 设置通点的地图位置。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustDeleteTool</name>
+    <name>OpenOrienteering::TemplateAdjustDeleteTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="832"/>
+        <location filename="../src/templates/template_adjust.cpp" line="834"/>
         <source>&lt;b&gt;Click&lt;/b&gt;: Delete pass points. </source>
         <translation>&lt;b&gt;单击&lt;/b&gt;︰ 删除及格分。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustMoveTool</name>
+    <name>OpenOrienteering::TemplateAdjustMoveTool</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="703"/>
+        <location filename="../src/templates/template_adjust.cpp" line="705"/>
         <source>&lt;b&gt;Drag&lt;/b&gt;: Move pass points. </source>
         <translation>&lt;b&gt;拖&lt;/b&gt;︰ 移动及格分。 </translation>
     </message>
 </context>
 <context>
-    <name>TemplateAdjustWidget</name>
+    <name>OpenOrienteering::TemplateAdjustWidget</name>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="201"/>
+        <location filename="../src/templates/template_adjust.cpp" line="203"/>
         <source>Pass points:</source>
         <translation>及格分︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="203"/>
+        <location filename="../src/templates/template_adjust.cpp" line="205"/>
         <source>New</source>
         <translation>新增功能</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="207"/>
+        <location filename="../src/templates/template_adjust.cpp" line="209"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="211"/>
+        <location filename="../src/templates/template_adjust.cpp" line="213"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template X</source>
         <translation>模板 X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Template Y</source>
         <translation>模板 Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map X</source>
         <translation>地图 X</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Map Y</source>
         <translation>地图 Y</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="218"/>
+        <location filename="../src/templates/template_adjust.cpp" line="220"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="229"/>
+        <location filename="../src/templates/template_adjust.cpp" line="231"/>
         <source>Apply pass points</source>
         <translation>应用通点</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="231"/>
+        <location filename="../src/templates/template_adjust.cpp" line="233"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="232"/>
+        <location filename="../src/templates/template_adjust.cpp" line="234"/>
         <source>Apply &amp;&amp; clear all</source>
         <translation>应用 &amp; &amp; 清除所有</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_adjust.cpp" line="233"/>
+        <location filename="../src/templates/template_adjust.cpp" line="235"/>
         <source>Clear all</source>
         <translation>全部清除</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImage</name>
+    <name>OpenOrienteering::TemplateImage</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="160"/>
+        <location filename="../src/templates/template_image.cpp" line="162"/>
         <source>Not enough free memory (image size: %1x%2 pixels)</source>
         <translation>没有足够的可用内存 (图像大小: %1 %2 像素 x)</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="200"/>
+        <location filename="../src/templates/template_image.cpp" line="202"/>
         <source>Loading a GIF image template.
 Saving GIF files is not supported. This means that drawings on this template won&apos;t be saved!
 If you do not intend to draw on this template however, that is no problem.</source>
@@ -6919,472 +6920,472 @@ If you do not intend to draw on this template however, that is no problem.</sour
 如果你不打算然而在此模板上画画，那是没有问题。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="242"/>
+        <location filename="../src/templates/template_image.cpp" line="244"/>
         <source>Select the coordinate reference system of the coordinates in the world file</source>
         <translation>在世界文件中选择坐标系的坐标</translation>
     </message>
 </context>
 <context>
-    <name>TemplateImageOpenDialog</name>
+    <name>OpenOrienteering::TemplateImageOpenDialog</name>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="565"/>
+        <location filename="../src/templates/template_image.cpp" line="567"/>
         <source>Opening %1</source>
         <translation>打开 %1</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="567"/>
+        <location filename="../src/templates/template_image.cpp" line="569"/>
         <source>Image size:</source>
         <translation>图像大小︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="570"/>
+        <location filename="../src/templates/template_image.cpp" line="572"/>
         <source>Specify how to position or scale the image:</source>
         <translation>指定如何定位或缩放图像︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="580"/>
+        <location filename="../src/templates/template_image.cpp" line="582"/>
         <source>World file</source>
         <translation>世界文件</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="582"/>
+        <location filename="../src/templates/template_image.cpp" line="584"/>
         <source>GeoTiff</source>
         <translation>GeoTiff</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="584"/>
+        <location filename="../src/templates/template_image.cpp" line="586"/>
         <source>no georeferencing information</source>
         <translation>没有地理参考信息</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="586"/>
+        <location filename="../src/templates/template_image.cpp" line="588"/>
         <source>Georeferenced</source>
         <translation>地理</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="590"/>
+        <location filename="../src/templates/template_image.cpp" line="592"/>
         <source>Meters per pixel:</source>
         <translation>米 / 像素︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="594"/>
+        <location filename="../src/templates/template_image.cpp" line="596"/>
         <source>Scanned with</source>
         <translation>用扫描</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="597"/>
+        <location filename="../src/templates/template_image.cpp" line="599"/>
         <source>dpi</source>
         <translation>新闻部</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="599"/>
+        <location filename="../src/templates/template_image.cpp" line="601"/>
         <source>Template scale:  1 :</source>
         <translation>模板规模︰ 1:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="625"/>
+        <location filename="../src/templates/template_image.cpp" line="627"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_image.cpp" line="626"/>
+        <location filename="../src/templates/template_image.cpp" line="628"/>
         <source>Open</source>
         <translation>开放</translation>
     </message>
 </context>
 <context>
-    <name>TemplateListWidget</name>
+    <name>OpenOrienteering::TemplateListWidget</name>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="146"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="148"/>
         <source>Show</source>
         <translation>显示</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Group</source>
         <translation>集团</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="145"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="147"/>
         <source>Filename</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="464"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="471"/>
         <source>Sketch</source>
         <translation>素描</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="197"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="468"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="199"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="475"/>
         <source>GPS</source>
         <translation>全球定位系统</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="190"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="192"/>
         <source>Open...</source>
         <translation>打开...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="221"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="223"/>
         <source>Georeferenced: %1</source>
         <translation>地理: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="193"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="195"/>
         <source>Duplicate</source>
         <translation>重复</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="201"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="203"/>
         <source>Add template...</source>
         <translation>添加模板...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="205"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="207"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="211"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
         <source>Move Up</source>
         <translation>向上移动</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="213"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="215"/>
         <source>Move Down</source>
         <translation>向下移动</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="238"/>
         <source>Import and remove</source>
         <translation>导入和删除</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="268"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="271"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="226"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="228"/>
         <source>Move by hand</source>
         <translation>用手移动</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="374"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
         <source>Open image, GPS track or DXF file</source>
         <translation>打开图像、 GPS 跟踪或 DXF 文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="234"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="236"/>
         <source>Positioning...</source>
         <translation>定位...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>Template files</source>
         <translation>模板文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="377"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="380"/>
         <source>All files</source>
         <translation>所有文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="230"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="232"/>
         <source>Adjust...</source>
         <translation>调整...</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="401"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="408"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="737"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="745"/>
         <source>Please enter a valid integer number to set a group or leave the field empty to ungroup the template!</source>
         <translation>请输入一个有效的整数数字来设置一组或将字段留空以取消组合模板 ！</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="990"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="998"/>
         <source>Don&apos;t scale</source>
         <translation>不能扩展</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="985"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
         <source>Scale by nominal map scale ratio (%1 %)</source>
         <translation>规模由名义地图规模比 （%1%）</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="386"/>
-        <location filename="../src/templates/template.cpp" line="489"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="393"/>
+        <location filename="../src/templates/template.cpp" line="491"/>
         <source>Cannot open template
 %1:
 %2</source>
         <translation>无法打开模板 %1: %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="390"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="397"/>
         <source>File format not recognized.</source>
         <translation>文件格式无法识别。</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="400"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="407"/>
         <source>Failed to load template. Does the file exist and is it valid?</source>
         <translation>加载模板失败。此文件存在，并且有效吗？</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="987"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="995"/>
         <source>Scale by current template scaling (%1 %)</source>
         <translation>缩放当前模板缩放 （%1%）</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="992"/>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1024"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1000"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1032"/>
         <source>Template import</source>
         <translation>导入模板</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="993"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1001"/>
         <source>How shall the symbols of the imported template map be scaled?</source>
         <translation>应如何缩放的导入的模板地图符号？</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1025"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1033"/>
         <source>The template will be invisible in the overprinting simulation. Switch to normal view?</source>
         <translation>该模板将叠印模拟中不可见。切换到普通视图吗？</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1158"/>
+        <location filename="../src/gui/widgets/template_list_widget.cpp" line="1166"/>
         <source>- Map -</source>
         <translation>-地图-</translation>
     </message>
 </context>
 <context>
-    <name>TemplateMoveTool</name>
+    <name>OpenOrienteering::TemplateMoveTool</name>
     <message>
-        <location filename="../src/templates/template_tool_move.cpp" line="45"/>
+        <location filename="../src/templates/template_tool_move.cpp" line="48"/>
         <source>&lt;b&gt;Drag&lt;/b&gt; to move the current template</source>
         <translation>&lt;b&gt;拖动&lt;/b&gt; 来移动当前模板</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositionDockWidget</name>
+    <name>OpenOrienteering::TemplatePositionDockWidget</name>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="36"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="39"/>
         <source>Positioning</source>
         <translation>定位</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="40"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="43"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="46"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
         <source>X-Scale:</source>
         <translation>X-规模︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="49"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
         <source>Y-Scale:</source>
         <translation>Y-规模︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_position_dock_widget.cpp" line="52"/>
+        <location filename="../src/templates/template_position_dock_widget.cpp" line="55"/>
         <source>Rotation:</source>
         <translation>旋转︰</translation>
     </message>
 </context>
 <context>
-    <name>TemplatePositioningDialog</name>
+    <name>OpenOrienteering::TemplatePositioningDialog</name>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="40"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="42"/>
         <source>Track scaling and positioning</source>
         <translation>跟踪缩放和定位</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="45"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
         <source>Coordinate system</source>
         <translation>坐标系统</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="46"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="48"/>
         <source>Real</source>
         <translation>真正</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="47"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="49"/>
         <source>Map</source>
         <translation>地图</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="50"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="52"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="53"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
         <source>One coordinate unit equals:</source>
         <translation>一个坐标单位等于︰</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="55"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="57"/>
         <source>Position track at given coordinates</source>
         <translation>位置跟踪在给定坐标</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_positioning_dialog.cpp" line="59"/>
+        <location filename="../src/templates/template_positioning_dialog.cpp" line="61"/>
         <source>Position track at view center</source>
         <translation>在查看中心位置跟踪</translation>
     </message>
 </context>
 <context>
-    <name>TemplateTrack</name>
+    <name>OpenOrienteering::TemplateTrack</name>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="138"/>
+        <location filename="../src/templates/template_track.cpp" line="141"/>
         <source>This template must be loaded with GDAL/OGR.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="187"/>
+        <location filename="../src/templates/template_track.cpp" line="190"/>
         <source>Select the coordinate reference system of the track coordinates</source>
         <translation>选择轨道坐标的坐标参考系统</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="205"/>
+        <location filename="../src/templates/template_track.cpp" line="208"/>
         <source>Opening track ...</source>
         <translation>开场曲目......</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="206"/>
+        <location filename="../src/templates/template_track.cpp" line="209"/>
         <source>Load the track in georeferenced or non-georeferenced mode?</source>
         <translation>加载在地理或非地理模式跟踪记录吗？</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="208"/>
+        <location filename="../src/templates/template_track.cpp" line="211"/>
         <source>Positions the track according to the map&apos;s georeferencing settings.</source>
         <translation>根据地图的地理参考坐标系设置轨道的位置。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="210"/>
+        <location filename="../src/templates/template_track.cpp" line="213"/>
         <source>These are not configured yet, so they will be shown as the next step.</source>
         <translation>这些是尚未配置，所以他们将显示为下一步。</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="211"/>
+        <location filename="../src/templates/template_track.cpp" line="214"/>
         <source>Georeferenced</source>
         <translation>地理</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Non-georeferenced</source>
         <translation>非地理</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="212"/>
+        <location filename="../src/templates/template_track.cpp" line="215"/>
         <source>Projects the track using an orthographic projection with center at the track&apos;s coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position.</source>
         <translation>项目跟踪与中心轨迹的坐标平均使用正交投影。允许调整转型和设置地图小基使用调整后的轨道位置。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
-        <location filename="../src/sensors/gps_track.cpp" line="504"/>
-        <location filename="../src/sensors/gps_track.cpp" line="511"/>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
+        <location filename="../src/sensors/gps_track.cpp" line="506"/>
+        <location filename="../src/sensors/gps_track.cpp" line="513"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="447"/>
+        <location filename="../src/templates/template_track.cpp" line="450"/>
         <source>The path is empty, there is nothing to import!</source>
         <translation>路径是空的没什么可导入 ！</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Question</source>
         <translation>问题</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="461"/>
+        <location filename="../src/templates/template_track.cpp" line="464"/>
         <source>Should the waypoints be imported as a line going through all points?</source>
         <translation>应作为经历的所有点线导入路点吗？</translation>
     </message>
     <message>
-        <location filename="../src/templates/template_track.cpp" line="528"/>
+        <location filename="../src/templates/template_track.cpp" line="531"/>
         <source>Import problems</source>
         <translation>导入问题</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/templates/template_track.cpp" line="529"/>
+        <location filename="../src/templates/template_track.cpp" line="532"/>
         <source>%n path object(s) could not be imported (reason: missing coordinates).</source>
         <translation>
             <numerusform>%n 路径对象可能不会导入 (原因︰ 缺少坐标)。</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>Error reading</source>
         <translation>读取错误</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="417"/>
+        <location filename="../src/sensors/gps_track.cpp" line="419"/>
         <source>There was an error reading the DXF file %1:
 
 %2</source>
         <translation>读取 DXF 文件 %1 时出错: %2</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="495"/>
+        <location filename="../src/sensors/gps_track.cpp" line="497"/>
         <source>%1:
 Not an OSM file.</source>
         <translation>%1︰ 不 OSM 文件。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="505"/>
+        <location filename="../src/sensors/gps_track.cpp" line="507"/>
         <source>The OSM file has version %1.
 The minimum supported version is %2.</source>
         <translation>OSM 文件的版本 %1。
 最低支持的版本是 %2。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="512"/>
+        <location filename="../src/sensors/gps_track.cpp" line="514"/>
         <source>The OSM file has version %1.
 The maximum supported version is %2.</source>
         <translation>OSM 文件的版本 %1。
 最大支持的版本是 %2。</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>Problems</source>
         <translation>问题</translation>
     </message>
     <message>
-        <location filename="../src/sensors/gps_track.cpp" line="612"/>
+        <location filename="../src/sensors/gps_track.cpp" line="614"/>
         <source>%1 nodes could not be processed correctly.</source>
         <translation>节点 %1 不能正确处理。</translation>
     </message>
 </context>
 <context>
-    <name>TextBrowserDialog</name>
+    <name>OpenOrienteering::TextBrowserDialog</name>
     <message>
         <source>External link: %1</source>
         <translation type="vanished">外部链接: %1</translation>
@@ -7395,395 +7396,395 @@ The maximum supported version is %2.</source>
     </message>
 </context>
 <context>
-    <name>TextObjectAlignmentDockWidget</name>
+    <name>OpenOrienteering::TextObjectAlignmentDockWidget</name>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="60"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="62"/>
         <source>Alignment</source>
         <translation>对齐方式</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="44"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="45"/>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
         <source>Center</source>
         <translation>中心</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="46"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="47"/>
         <source>Right</source>
         <translation>权利</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="50"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="51"/>
         <source>Top</source>
         <translation>返回页首</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="52"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
         <source>Baseline</source>
         <translation>基线</translation>
     </message>
     <message>
-        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="53"/>
+        <location filename="../src/gui/widgets/text_alignment_widget.cpp" line="54"/>
         <source>Bottom</source>
         <translation>底部</translation>
     </message>
 </context>
 <context>
-    <name>TextSymbolSettings</name>
+    <name>OpenOrienteering::TextSymbolSettings</name>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="92"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="94"/>
         <source>Text settings</source>
         <translation>文本设置</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="98"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="100"/>
         <source>Font family:</source>
         <translation>字体︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="102"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="104"/>
         <source>Font size:</source>
         <translation>字体大小︰</translation>
     </message>
     <message>
-        <location filename="../src/core/symbols/text_symbol.cpp" line="553"/>
+        <location filename="../src/core/symbols/text_symbol.cpp" line="555"/>
         <source>A</source>
         <comment>First capital letter of the local alphabet</comment>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="116"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="201"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="492"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="585"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="118"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="143"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="203"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="209"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="494"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="587"/>
         <source>mm</source>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="101"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="103"/>
         <source>pt</source>
         <translation>pt</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="124"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="126"/>
         <source>Text color:</source>
         <translation>文本颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="127"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
         <source>bold</source>
         <translation>大胆</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="129"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
         <source>italic</source>
         <translation>斜体</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="131"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="133"/>
         <source>underlined</source>
         <translation>强调</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="134"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="136"/>
         <source>Text style:</source>
         <translation>文本样式︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="138"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="140"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="146"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="139"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="141"/>
         <source>Line spacing:</source>
         <translation>行间距︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="142"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="144"/>
         <source>Paragraph spacing:</source>
         <translation>段落间距︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="145"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
         <source>Character spacing:</source>
         <translation>字符间距︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="147"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="149"/>
         <source>Kerning</source>
         <translation>字偶间距调整</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="154"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="156"/>
         <source>Symbol icon text:</source>
         <translation>符号图标文本︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="158"/>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="166"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="160"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="168"/>
         <source>Framing</source>
         <translation>框架</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="161"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="163"/>
         <source>OCAD compatibility settings</source>
         <translation>遗漏的兼容性设置</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="172"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
         <source>Framing color:</source>
         <translation>框架颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="174"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="176"/>
         <source>Line framing</source>
         <translation>线框架</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="178"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
         <source>Width:</source>
         <translation>宽度：</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="180"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="182"/>
         <source>Shadow framing</source>
         <translation>阴影框架</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="184"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="186"/>
         <source>Left/Right Offset:</source>
         <translation>左/右偏移量︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="187"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="189"/>
         <source>Top/Down Offset:</source>
         <translation>自上而下的偏移量︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="191"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="193"/>
         <source>OCAD compatibility</source>
         <translation>遗漏的兼容性</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="200"/>
         <source>enabled</source>
         <translation>启用</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="202"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="204"/>
         <source>Line width:</source>
         <translation>线宽︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="205"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="207"/>
         <source>Line color:</source>
         <translation>线条颜色︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="474"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="476"/>
         <source>Position:</source>
         <translation>位置︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="196"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="198"/>
         <source>Line below paragraphs</source>
         <translation>以下段落线</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="208"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="210"/>
         <source>Distance from baseline:</source>
         <translation>基线的距离︰</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="212"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="214"/>
         <source>Custom tabulator positions</source>
         <translation>自定义制表位置</translation>
     </message>
     <message>
-        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="473"/>
+        <location filename="../src/gui/symbols/text_symbol_settings.cpp" line="475"/>
         <source>Add custom tabulator</source>
         <translation>添加自定义制表机</translation>
     </message>
 </context>
 <context>
-    <name>UTMZoneEdit</name>
+    <name>OpenOrienteering::UTMZoneEdit</name>
     <message>
-        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="65"/>
+        <location filename="../src/gui/widgets/crs_param_widgets.cpp" line="67"/>
         <source>Calculate</source>
         <translation>计算</translation>
     </message>
 </context>
 <context>
-    <name>UndoManager</name>
+    <name>OpenOrienteering::UndoManager</name>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="146"/>
+        <location filename="../src/undo/undo_manager.cpp" line="148"/>
         <source>Cannot undo because the last undo step became invalid. This can for example happen if you change the symbol of an object to another and then delete the old symbol.</source>
         <translation>不能撤消，因为最后撤消一步变得无效。如果你的对象将符号更改到另一个，然后删除旧的符号，例如可以发生这种情况。</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Confirmation</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="153"/>
+        <location filename="../src/undo/undo_manager.cpp" line="155"/>
         <source>Undoing this step will go beyond the point where the file was loaded. Are you sure?</source>
         <translation>解开这一步将超越的点被加载的文件。是否确定？</translation>
     </message>
     <message>
-        <location filename="../src/undo/undo_manager.cpp" line="191"/>
+        <location filename="../src/undo/undo_manager.cpp" line="193"/>
         <source>Cannot redo because the first redo step became invalid. This can for example happen if you delete the symbol of an object you have drawn.</source>
         <translation>不能重做因为重做的第一步变得无效。如果你删除了你画的是一个对象的符号，例如可以发生这种情况。</translation>
     </message>
 </context>
 <context>
-    <name>UnitOfMeasurement</name>
+    <name>OpenOrienteering::UnitOfMeasurement</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="209"/>
+        <location filename="../src/gui/util_gui.cpp" line="211"/>
         <source>mm</source>
         <comment>millimeters</comment>
         <translation>毫米</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="214"/>
+        <location filename="../src/gui/util_gui.cpp" line="216"/>
         <source>m</source>
         <comment>meters</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="620"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="622"/>
         <source>%1°</source>
         <comment>degree</comment>
         <translation type="unfinished">%1 x {1°?}</translation>
     </message>
     <message>
-        <location filename="../src/tools/tool_helpers.cpp" line="621"/>
+        <location filename="../src/tools/tool_helpers.cpp" line="623"/>
         <source>%1 m</source>
         <comment>meter</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>Util</name>
+    <name>OpenOrienteering::Util</name>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
-        <location filename="../src/gui/util_gui.cpp" line="183"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
+        <location filename="../src/gui/util_gui.cpp" line="185"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="135"/>
+        <location filename="../src/gui/util_gui.cpp" line="137"/>
         <source>Failed to locate the help files.</source>
         <translation>未能找到帮助文件。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="149"/>
+        <location filename="../src/gui/util_gui.cpp" line="151"/>
         <source>Failed to locate the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>无法找到帮助浏览器（“Qt的助手”）。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="184"/>
+        <location filename="../src/gui/util_gui.cpp" line="186"/>
         <source>Failed to launch the help browser (&quot;Qt Assistant&quot;).</source>
         <translation>无法启动帮助浏览器（“Qt的助手”）。</translation>
     </message>
     <message>
-        <location filename="../src/gui/util_gui.cpp" line="202"/>
+        <location filename="../src/gui/util_gui.cpp" line="204"/>
         <source>See more...</source>
         <extracomment>This &quot;See more&quot; is displayed as a link to the manual in What&apos;s-this tooltips.</extracomment>
         <translation>查看更多...</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileExporter</name>
+    <name>OpenOrienteering::XMLFileExporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="189"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="208"/>
         <source>Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts.</source>
         <translation>映射器的旧版本不支持多个地图部分。若要保存在兼容模式下的地图，必须首先将所有地图部分都合并。</translation>
     </message>
 </context>
 <context>
-    <name>XMLFileImporter</name>
+    <name>OpenOrienteering::XMLFileImporter</name>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="473"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="492"/>
         <source>Unsupported element: %1 (line %2 column %3)</source>
         <translation>不支持的元素: %1 （%2 线列 %3）</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="504"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="523"/>
         <source>Some coordinates were out of bounds for printing. Map content was adjusted.</source>
         <translation>一些坐标已超出界限印刷。映射内容作了调整。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="554"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="573"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="555"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="574"/>
         <source>Parts of this file cannot be read by this version of Mapper. Minimum required version: %1</source>
         <translation>此版本的映射器无法读取这个文件的部分。所需的最低版本: %1</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="589"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="608"/>
         <source>Error at line %1 column %2: %3</source>
         <translation>在列行 %1 %2 的错误: %3</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="601"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="858"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="877"/>
         <source>Some invalid characters had to be removed.</source>
         <translation>一些无效的字符必须被去除。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="619"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="638"/>
         <source>Unknown error</source>
         <translation>未知的错误</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="620"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="639"/>
         <source>Unsupported or invalid georeferencing specification &apos;%1&apos;: %2</source>
         <translation>不支持或无效的地理参考规范“％1”：％2</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="751"/>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="804"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="770"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="823"/>
         <source>Could not set knockout property of color &apos;%1&apos;.</source>
         <translation>无法设置颜色“％1”的淘汰赛财产。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="764"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="783"/>
         <source>Expected %1 colors, found %2.</source>
         <translation>预期找到 %2 的 %1 颜色。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="780"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="799"/>
         <source>Spot color %1 not found while processing %2 (%3).</source>
         <translation>专色处理 %(%3) 2 时找不到 %1。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="836"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="855"/>
         <source>Expected %1 symbols, found %2.</source>
         <translation>预计1％的符号，找到％2。</translation>
     </message>
     <message>
-        <location filename="../src/fileformats/xml_file_format.cpp" line="875"/>
+        <location filename="../src/fileformats/xml_file_format.cpp" line="894"/>
         <source>Expected %1 map parts, found %2.</source>
         <translation>预计1％的部分地图，找到％2。</translation>
     </message>


### PR DESCRIPTION
The identifier `Object` is very generic. Other software may use the same
identifier for different structures, leading to ODR violations which may
result in any form of undefined behaviour. In particular, poppler (used
by gdal) is known to use this identifier (#1030).